### PR TITLE
Format Markdown

### DIFF
--- a/.rules/python-00.md
+++ b/.rules/python-00.md
@@ -1,38 +1,52 @@
-## Python 3.13 Code Style Guidelines (with Ruff, Pyright, and pytest)
+# Python 3.13 Code Style Guidelines (with Ruff, Pyright, and pytest)
 
-### Naming Conventions
+## Naming Conventions
 
-* **Directories:** Use *snake\_case* for top-level features or modules (e.g., `data_pipeline`, `user_auth`).
-* **Files:** Use *snake\_case.py*; name for contents (e.g., `http_client.py`, `task_queue.py`).
-* **Classes:** Use *PascalCase*.
-* **Variables & Functions:** Use *snake\_case*.
-* **Constants:** Use *UPPER\_SNAKE\_CASE* for module-level constants.
-* **Private/Internal:** Prefix with a single underscore (`_`) for non-exported helpers or internal APIs.
+- **Directories:** Use *snake_case* for top-level features or modules (e.g.,
+  `data_pipeline`, `user_auth`).
+- **Files:** Use *snake_case.py*; name for contents (e.g., `http_client.py`,
+  `task_queue.py`).
+- **Classes:** Use *PascalCase*.
+- **Variables & Functions:** Use *snake_case*.
+- **Constants:** Use *UPPER_SNAKE_CASE* for module-level constants.
+- **Private/Internal:** Prefix with a single underscore (`_`) for non-exported
+  helpers or internal APIs.
 
-### Python Typing Practices
+## Python Typing Practices
 
-* **Use typing everywhere.** Enable and maintain full static type coverage. Use Pyright for type-checking.
-* **Use `TypedDict` or `Dataclass` for structured data where appropriate.** For internal-only usage, prefer `@dataclass(slots=True)`.
-* **Avoid `Any`.** Use `Unknown`, generics, or `cast()` when necessary—always document why `Any` is acceptable if used.
-* **Be explicit with returns.** Use `-> None`, `-> str`, etc., for all public functions and class methods.
-* **Favour immutability.** Prefer tuples over lists, and `frozendict` or `types.MappingProxyType` where appropriate.
+- **Use typing everywhere.** Enable and maintain full static type coverage. Use
+  Pyright for type-checking.
+- **Use `TypedDict` or `Dataclass` for structured data where appropriate.** For
+  internal-only usage, prefer `@dataclass(slots=True)`.
+- **Avoid `Any`.** Use `Unknown`, generics, or `cast()` when necessary—always
+  document why `Any` is acceptable if used.
+- **Be explicit with returns.** Use `-> None`, `-> str`, etc., for all public
+  functions and class methods.
+- **Favour immutability.** Prefer tuples over lists, and `frozendict` or
+  `types.MappingProxyType` where appropriate.
 
-### Tooling and Runtime Practices
+## Tooling and Runtime Practices
 
-* **Enable Ruff.** Use Ruff to lint for performance, security, consistency, and style issues. Enable fixers and formatters.
-* Use `pyproject.toml` to configure tools like Ruff, Pyright,  and Pytest.
-* **Enforce `strict` in Pyright.** Treat all Pyright warnings as CI errors. Use `# pyright: ignore` sparingly and with explanation.
-* **Avoid side effects at import time.** Modules should not modify global state or perform actions on import.
-* **Use `.env` or settings modules** for environment-specific configuration. Never hardcode secrets.
+- **Enable Ruff.** Use Ruff to lint for performance, security, consistency, and
+  style issues. Enable fixers and formatters.
+- Use `pyproject.toml` to configure tools like Ruff, Pyright, and Pytest.
+- **Enforce `strict` in Pyright.** Treat all Pyright warnings as CI errors. Use
+  `# pyright: ignore` sparingly and with explanation.
+- **Avoid side effects at import time.** Modules should not modify global state
+  or perform actions on import.
+- **Use `.env` or settings modules** for environment-specific configuration.
+  Never hardcode secrets.
 
-### Linting and Formatting
+## Linting and Formatting
 
-* **Use Ruff for linting** (replacing flake8, isort, pyflakes, etc.).
-* **Use Ruff for formatting**. Let Ruff handle whitespace and formatting entirely—don't fight it.
+- **Use Ruff for linting** (replacing flake8, isort, pyflakes, etc.).
+- **Use Ruff for formatting**. Let Ruff handle whitespace and formatting
+  entirely—don't fight it.
 
-### Documentation
+## Documentation
 
-* **Use docstrings.** Document public functions, classes, and modules using NumPy format. For example:
+- **Use docstrings.** Document public functions, classes, and modules using
+  NumPy format. For example:
 
 ```python
 def scale(values: list[float], factor: float) -> list[float]:
@@ -54,14 +68,17 @@ def scale(values: list[float], factor: float) -> list[float]:
     return [v * factor for v in values]
 ```
 
-* **Explain tricky code.** Use inline comments for non-obvious logic or decisions.
-* **Colocate documentation.** Keep README.md or `docs/` near reusable packages; include usage examples.
+- **Explain tricky code.** Use inline comments for non-obvious logic or
+  decisions.
+- **Colocate documentation.** Keep README.md or `docs/` near reusable packages;
+  include usage examples.
 
-### Testing with pytest
+## Testing with pytest
 
-* **Colocate unit tests with code** using a unittests subdirectory and a `test_` prefix. This keeps logic and its tests together:
+- **Colocate unit tests with code** using a unittests subdirectory and a `test_`
+  prefix. This keeps logic and its tests together:
 
-  ```
+  ```text
   user_auth/
     models.py
     login_flow.py
@@ -70,24 +87,28 @@ def scale(values: list[float], factor: float) -> list[float]:
       test_login_flow.py
   ```
 
-* **Structure integration tests separately.** When tests span multiple components, use `tests/integration/`:
+- **Structure integration tests separately.** When tests span multiple
+  components, use `tests/integration/`:
 
-  ```
+  ```text
   tests/
     integration/
       test_login_flow.py
       test_user_onboarding.py
   ```
 
-* **Use `pytest` idioms.** Prefer fixtures over setup/teardown methods. Parametrize broadly. Avoid unnecessary mocks.
+- **Use `pytest` idioms.** Prefer fixtures over setup/teardown methods.
+  Parametrize broadly. Avoid unnecessary mocks.
 
-* **Group related tests** using `class` with method names prefixed by `test_`.
+- **Group related tests** using `class` with method names prefixed by `test_`.
 
-* **Write tests from a user's perspective.** Test public behaviour, not internals.
+- **Write tests from a user's perspective.** Test public behaviour, not
+  internals.
 
-* **Avoid mocking too much.** Prefer test doubles only for external services or non-deterministic behaviours.
+- **Avoid mocking too much.** Prefer test doubles only for external services or
+  non-deterministic behaviours.
 
-### Example:
+## Example
 
 ```python
 # login_flow.py
@@ -103,6 +124,8 @@ def test_login_failure():
     assert not login_user("alice", "wrong-password")
 ```
 
----
+______________________________________________________________________
 
-This style guide aims to foster clean, consistent, and maintainable Python 3.13 code with modern tooling. The priority is correctness, clarity, and developer empathy.
+This style guide aims to foster clean, consistent, and maintainable Python 3.13
+code with modern tooling. The priority is correctness, clarity, and developer
+empathy.

--- a/.rules/python-context-managers.md
+++ b/.rules/python-context-managers.md
@@ -1,18 +1,22 @@
-## Using Context Managers for Cleanup and Resource Management
+# Using Context Managers for Cleanup and Resource Management
 
-Use context managers to encapsulate setup and teardown logic cleanly and safely. This reduces the risk of forgetting to release resources (files, locks, connections, etc.) and simplifies error handling.
+Use context managers to encapsulate setup and teardown logic cleanly and safely.
+This reduces the risk of forgetting to release resources (files, locks,
+connections, etc.) and simplifies error handling.
 
-Context managers can be written either with `contextlib.contextmanager` (for simple procedural control flow) or by implementing `__enter__` and `__exit__` in a class (for more complex or stateful use cases).
+Context managers can be written either with `contextlib.contextmanager` (for
+simple procedural control flow) or by implementing `__enter__` and `__exit__` in
+a class (for more complex or stateful use cases).
 
-### Why Use Context Managers?
+## Why Use Context Managers?
 
-* **Safety:** Ensures cleanup occurs even if an exception is raised.
-* **Clarity:** Reduces boilerplate and visually scopes side effects.
-* **Reuse:** Common setup/teardown logic becomes reusable and composable.
+- **Safety:** Ensures cleanup occurs even if an exception is raised.
+- **Clarity:** Reduces boilerplate and visually scopes side effects.
+- **Reuse:** Common setup/teardown logic becomes reusable and composable.
 
----
+______________________________________________________________________
 
-### Example: Using `contextlib.contextmanager`
+## Example: Using `contextlib.contextmanager`
 
 Use this for straightforward procedural setup/teardown:
 
@@ -34,9 +38,9 @@ with managed_file("/tmp/data.txt", "w") as f:
 
 This avoids repeating `try/finally` in every file access.
 
----
+______________________________________________________________________
 
-### Example: Using a Class-Based Context Manager
+## Example: Using a Class-Based Context Manager
 
 Use this when state or lifecycle logic spans methods:
 
@@ -56,29 +60,31 @@ with Resource() as conn:
 
 This keeps state encapsulated and makes testing easier.
 
----
+______________________________________________________________________
 
-### When to Use Which
+## When to Use Which
 
-* Use `@contextmanager` when control flow is linear and no persistent state is required.
-* Use a class when:
+- Use `@contextmanager` when control flow is linear and no persistent state is
+  required.
 
-  * There is internal state or methods tied to the resource lifecycle.
-  * You need to support re-entry or more advanced context features.
+- Use a class when:
 
----
+  - There is internal state or methods tied to the resource lifecycle.
+  - You need to support re-entry or more advanced context features.
 
-### Common Use Cases
+______________________________________________________________________
 
-* File or network resource handling
-* Lock acquisition and release
-* Temporary changes to environment (e.g., `os.chdir`, `patch`, `tempfile`)
-* Logging scope control or tracing
-* Transaction control in databases or services
+## Common Use Cases
 
----
+- File or network resource handling
+- Lock acquisition and release
+- Temporary changes to environment (e.g., `os.chdir`, `patch`, `tempfile`)
+- Logging scope control or tracing
+- Transaction control in databases or services
 
-### Don't Do This:
+______________________________________________________________________
+
+## Don't Do This
 
 ```python
 f = open("file.txt")
@@ -88,11 +94,12 @@ finally:
     f.close()
 ```
 
-### Do This Instead:
+## Do This Instead
 
 ```python
 with open("file.txt") as f:
     process(f)
 ```
 
-Context managers make your intent and error handling explicit. Prefer them over manual `try/finally` for clearer, safer code.
+Context managers make your intent and error handling explicit. Prefer them over
+manual `try/finally` for clearer, safer code.

--- a/.rules/python-generators.md
+++ b/.rules/python-generators.md
@@ -1,16 +1,21 @@
-## Prefer Generators Over Complex Loop Logic
+# Prefer Generators Over Complex Loop Logic
 
-Using generators improves readability, composability, and memory efficiency. Functions built as generators are often simpler to test, debug, and refactor. This guidance encourages breaking apart complex `for`-loops into generator expressions or functions using `yield`.
+Using generators improves readability, composability, and memory efficiency.
+Functions built as generators are often simpler to test, debug, and refactor.
+This guidance encourages breaking apart complex `for`-loops into generator
+expressions or functions using `yield`.
 
-### Why Prefer Generators?
+## Why Prefer Generators?
 
-* **Clarity:** Isolating data flow from control flow clarifies logic.
-* **Efficiency:** Generators are lazy; they avoid building intermediate data structures unless needed.
-* **Composability:** Generators can be pipelined with other iterators using `itertools` or comprehensions.
+- **Clarity:** Isolating data flow from control flow clarifies logic.
+- **Efficiency:** Generators are lazy; they avoid building intermediate data
+  structures unless needed.
+- **Composability:** Generators can be pipelined with other iterators using
+  `itertools` or comprehensions.
 
-### Example: Filtering and Transforming
+## Example: Filtering and Transforming
 
-#### Complex Loop (harder to read/test):
+### Complex Loop (harder to read/test)
 
 ```python
 def get_names(users):
@@ -21,7 +26,7 @@ def get_names(users):
     return result
 ```
 
-#### Generator-Based Version (clearer):
+### Generator-Based Version (clearer)
 
 ```python
 def iter_user_names(users):
@@ -40,7 +45,7 @@ def get_names(users):
     return [user.name.upper() for user in users if user.active and user.name]
 ```
 
-### Example: Chaining Filters and Mappings
+## Example: Chaining Filters and Mappings
 
 ```python
 from itertools import islice
@@ -54,24 +59,25 @@ def top_active_emails(users):
     return list(islice(emails, 10))
 ```
 
-### Use Generators When:
+## Use Generators When
 
-* You're iterating and filtering/mapping data.
-* You want to make early returns or short-circuit behaviour clearer.
-* The function logically produces a sequence over time.
+- You're iterating and filtering/mapping data.
+- You want to make early returns or short-circuit behaviour clearer.
+- The function logically produces a sequence over time.
 
-### Avoid Overcomplicating:
+## Avoid Overcomplicating
 
-Don't convert everything into generators unnecessarily. Use them to simplify logic—not obscure it.
+Don't convert everything into generators unnecessarily. Use them to simplify
+logic—not obscure it.
 
-#### BAD:
+### BAD
 
 ```python
 def iter_numbers():
     yield from (x * 2 for x in range(10) if x % 2 == 0)
 ```
 
-#### BETTER:
+### BETTER
 
 ```python
 def iter_even_doubles():
@@ -80,8 +86,9 @@ def iter_even_doubles():
             yield x * 2
 ```
 
----
+______________________________________________________________________
 
-**Rule of thumb:** If your `for` loop has multiple branches, mutations, or is hard to explain in one sentence—try rewriting it as a generator.
+**Rule of thumb:** If your `for` loop has multiple branches, mutations, or is
+hard to explain in one sentence—try rewriting it as a generator.
 
 Prefer clear, linear data flows over deeply nested conditionals and loop bodies.

--- a/.rules/python-pyproject.md
+++ b/.rules/python-pyproject.md
@@ -1,23 +1,32 @@
-## 1. Overview of `uv` and `pyproject.toml`
+# 1. Overview of `uv` and `pyproject.toml`
 
-Astral's `uv` is a Rust-based project and package manager that uses `pyproject.toml` as its central configuration file. When you run commands like `uv init`, `uv sync` or `uv run`, `uv` will:
+Astral's `uv` is a Rust-based project and package manager that uses
+`pyproject.toml` as its central configuration file. When you run commands like
+`uv init`, `uv sync` or `uv run`, `uv` will:
 
-1. Look for a `pyproject.toml` in the project root and keep a lockfile (`uv.lock`) in sync with it.
+1. Look for a `pyproject.toml` in the project root and keep a lockfile
+   (`uv.lock`) in sync with it.
 2. Create a virtual environment (`.venv`) if one does not already exist.
-3. Read dependency specifications (and any build-system directives) to install or update packages accordingly. ([Astral Docs][1], [RidgeRun.ai][2])
+3. Read dependency specifications (and any build-system directives) to install
+   or update packages accordingly. ([Astral Docs][1], [RidgeRun.ai][2])
 
-In other words, your `pyproject.toml` drives everything—from metadata to dependencies to build instructions—without needing `requirements.txt` or a separate `setup.py` file. ([Level Up Coding][3], [Python Packaging][4])
+In other words, your `pyproject.toml` drives everything—from metadata to
+dependencies to build instructions—without needing `requirements.txt` or a
+separate `setup.py` file. ([Level Up Coding][3], [Python Packaging][4])
 
----
+______________________________________________________________________
 
 ## 2. The `[project]` Table (PEP 621)
 
-The `[project]` table is defined by PEP 621 and is now the canonical place to declare metadata (name, version, authors, etc.) and runtime dependencies. At minimum, PEP 621 requires:
+The `[project]` table is defined by PEP 621 and is now the canonical place to
+declare metadata (name, version, authors, etc.) and runtime dependencies. At
+minimum, PEP 621 requires:
 
-* `name`
-* `version`
+- `name`
+- `version`
 
-However, you almost always want to include at least the following additional fields for clarity and compatibility:
+However, you almost always want to include at least the following additional
+fields for clarity and compatibility:
 
 ```toml
 [project]
@@ -42,19 +51,33 @@ dependencies = [
 ]
 ```
 
-* **`name` and `version`:** Mandatory per PEP 621. ([Python Packaging][4], [Reddit][5])
-* **`description` and `readme`:** Although not mandatory, they help with indexing and packaging tools; `readme = "README.md"` tells `uv` (and PyPI) to include your README as the long description. ([Astral Docs][1], [Python Packaging][4])
-* **`requires-python`:** Constrains which Python interpreters your package supports (e.g. `>=3.10`). ([Python Packaging][4], [Reddit][5])
-* **`license = { text = "MIT" }`:** You can specify a license either as a SPDX identifier (via `license = { text = "MIT" }`) or by pointing to a file (e.g. `license = { file = "LICENSE" }`). ([Python Packaging][4], [Reddit][5])
-* **`authors`:** A list of tables with `name` and `email`. Many registries (e.g., PyPI) pull this for display. ([Python Packaging][4], [Reddit][5])
-* **`keywords` and `classifiers`:** These help search engines and package indexes. Classifiers must follow the exact trove list defined by PyPA. ([Python Packaging][4], [Reddit][5])
-* **`dependencies`:** A list of PEP 508-style requirements (e.g., `"requests>=2.25"`). `uv sync` will install exactly those versions, updating the lockfile as needed. ([Astral Docs][1], [RidgeRun.ai][2])
+- **`name` and `version`:** Mandatory per PEP 621. ([Python Packaging][4],
+  [Reddit][5])
+- **`description` and `readme`:** Although not mandatory, they help with
+  indexing and packaging tools; `readme = "README.md"` tells `uv` (and PyPI) to
+  include your README as the long description. ([Astral Docs][1],
+  [Python Packaging][4])
+- **`requires-python`:** Constrains which Python interpreters your package
+  supports (e.g. `>=3.10`). ([Python Packaging][4], [Reddit][5])
+- **`license = { text = "MIT" }`:** You can specify a license either as a SPDX
+  identifier (via `license = { text = "MIT" }`) or by pointing to a file (e.g.
+  `license = { file = "LICENSE" }`). ([Python Packaging][4], [Reddit][5])
+- **`authors`:** A list of tables with `name` and `email`. Many registries
+  (e.g., PyPI) pull this for display. ([Python Packaging][4], [Reddit][5])
+- **`keywords` and `classifiers`:** These help search engines and package
+  indexes. Classifiers must follow the exact trove list defined by PyPA.
+  ([Python Packaging][4], [Reddit][5])
+- **`dependencies`:** A list of PEP 508-style requirements (e.g.,
+  `"requests>=2.25"`). `uv sync` will install exactly those versions, updating
+  the lockfile as needed. ([Astral Docs][1], [RidgeRun.ai][2])
 
----
+______________________________________________________________________
 
 ## 3. Optional and Development Dependencies
 
-Modern projects typically distinguish between "production" dependencies (those needed at runtime) and "development" dependencies (linters, test frameworks, etc.). In PEP 621, you use `[project.optional-dependencies]` for this:
+Modern projects typically distinguish between "production" dependencies (those
+needed at runtime) and "development" dependencies (linters, test frameworks,
+etc.). In PEP 621, you use `[project.optional-dependencies]` for this:
 
 ```toml
 [project.optional-dependencies]
@@ -69,14 +92,20 @@ docs = [
 ]
 ```
 
-* **`[project.optional-dependencies]`:** Each table key (e.g. `dev`, `docs`) defines a "dependency group." You can install a group via `uv add --group dev` or `uv sync --include dev`. ([Python Packaging][4], [DevsJC][6])
-* **Why use groups?** You keep the lockfile deterministic (via `uv.lock`) while still separating concerns (test‐only vs. production). ([Medium][7], [DevsJC][6])
+- **`[project.optional-dependencies]`:** Each table key (e.g. `dev`, `docs`)
+  defines a "dependency group." You can install a group via `uv add --group dev`
+  or `uv sync --include dev`. ([Python Packaging][4], [DevsJC][6])
+- **Why use groups?** You keep the lockfile deterministic (via `uv.lock`) while
+  still separating concerns (test‐only vs. production). ([Medium][7],
+  [DevsJC][6])
 
----
+______________________________________________________________________
 
 ## 4. Entry Points and Scripts
 
-If you want to expose command-line interfaces (CLIs) or GUIs through your package, PEP 621 provides the `[project.scripts]` and `[project.gui-scripts]` tables:
+If you want to expose command-line interfaces (CLIs) or GUIs through your
+package, PEP 621 provides the `[project.scripts]` and `[project.gui-scripts]`
+tables:
 
 ```toml
 [project.scripts]
@@ -86,15 +115,23 @@ mycli = "my_project.cli:main"
 mygui = "my_project.gui:start"
 ```
 
-* **`[project.scripts]`:** Defines console scripts. When you run `uv run mycli`, `uv` will invoke the `main` function in `my_project/cli.py`. ([Astral Docs][8])
-* **`[project.gui-scripts]`:** On Windows, `uv` will wrap these in a GUI executable; on Unix-like systems, they behave like normal console scripts. ([Astral Docs][8])
-* **Plugin Entry Points:** If your project supports plugins, use `[project.entry-points.'group.name']` to register them. ([Astral Docs][8])
+- **`[project.scripts]`:** Defines console scripts. When you run `uv run mycli`,
+  `uv` will invoke the `main` function in `my_project/cli.py`.
+  ([Astral Docs][8])
+- **`[project.gui-scripts]`:** On Windows, `uv` will wrap these in a GUI
+  executable; on Unix-like systems, they behave like normal console scripts.
+  ([Astral Docs][8])
+- **Plugin Entry Points:** If your project supports plugins, use
+  `[project.entry-points.'group.name']` to register them. ([Astral Docs][8])
 
----
+______________________________________________________________________
 
 ## 5. Declaring a Build System
 
-PEP 517/518 require a `[build-system]` table to tell tools how to build and install your project. A "modern" convention is to specify `setuptools>=61.0` (for editable installs without `setup.py`) or a lighter alternative like `flit_core`. Below is the typical setup using setuptools:
+PEP 517/518 require a `[build-system]` table to tell tools how to build and
+install your project. A "modern" convention is to specify `setuptools>=61.0`
+(for editable installs without `setup.py`) or a lighter alternative like
+`flit_core`. Below is the typical setup using setuptools:
 
 ```toml
 [build-system]
@@ -102,29 +139,43 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 ```
 
-* **`requires`:** A list of packages needed at build time. For editable installs in `uv`, you need at least `setuptools>=61.0` and `wheel`. ([Python Packaging][4], [Astral Docs][8])
-* **`build-backend`:** The entry point for your build backend. `setuptools.build_meta` is the PEP 517-compliant backend for setuptools. ([Python Packaging][4], [Astral Docs][8])
-* **Note:** If you omit `[build-system]`, `uv` will assume `setuptools.build_meta:__legacy__` and still install dependencies, but it won't editably install your own project unless you set `tool.uv.package = true` (see next section). ([Astral Docs][8])
+- **`requires`:** A list of packages needed at build time. For editable installs
+  in `uv`, you need at least `setuptools>=61.0` and `wheel`.
+  ([Python Packaging][4], [Astral Docs][8])
+- **`build-backend`:** The entry point for your build backend.
+  `setuptools.build_meta` is the PEP 517-compliant backend for setuptools.
+  ([Python Packaging][4], [Astral Docs][8])
+- **Note:** If you omit `[build-system]`, `uv` will assume
+  `setuptools.build_meta:__legacy__` and still install dependencies, but it
+  won't editably install your own project unless you set
+  `tool.uv.package = true` (see next section). ([Astral Docs][8])
 
----
+______________________________________________________________________
 
 ## 6. `uv`-Specific Configuration (`[tool.uv]`)
 
-Astral `uv` allows you to inject its own settings in `[tool.uv]`. The most common option is:
+Astral `uv` allows you to inject its own settings in `[tool.uv]`. The most
+common option is:
 
 ```toml
 [tool.uv]
 package = true
 ```
 
-* **`tool.uv.package = true`:** Forces `uv` to build and install your project into its virtual environment every time you run `uv sync` or `uv run`. Without this, `uv` only installs dependencies (not your own package) if `[build-system]` is missing. ([Astral Docs][8])
-* You may also set other `uv`-specific keys (e.g., custom indexes, resolver policies) under `[tool.uv]`, but `package` is the most common. ([Python Packaging][4], [Astral Docs][8])
+- **`tool.uv.package = true`:** Forces `uv` to build and install your project
+  into its virtual environment every time you run `uv sync` or `uv run`. Without
+  this, `uv` only installs dependencies (not your own package) if
+  `[build-system]` is missing. ([Astral Docs][8])
+- You may also set other `uv`-specific keys (e.g., custom indexes, resolver
+  policies) under `[tool.uv]`, but `package` is the most common.
+  ([Python Packaging][4], [Astral Docs][8])
 
----
+______________________________________________________________________
 
 ## 7. Putting It All Together: Example `pyproject.toml`
 
-Below is a complete example that demonstrates all sections. Adjust values as needed for your own project.
+Below is a complete example that demonstrates all sections. Adjust values as
+needed for your own project.
 
 ```toml
 [project]
@@ -174,63 +225,89 @@ package = true
 
 1. **Metadata under `[project]`:**
 
-   * `name`, `version` (mandatory per PEP 621) ([Python Packaging][4], [Reddit][5])
-   * `description`, `readme`, `requires-python`: provide clarity about the project and help tools like PyPI. ([Python Packaging][4], [Reddit][5])
-   * `license`, `authors`, `keywords`, `classifiers`: standardised metadata, which improves discoverability. ([Python Packaging][4], [Reddit][5])
-   * `dependencies`: runtime requirements, expressed in PEP 508 syntax. ([Astral Docs][1], [RidgeRun.ai][2])
+   - `name`, `version` (mandatory per PEP 621) ([Python Packaging][4],
+     [Reddit][5])
+   - `description`, `readme`, `requires-python`: provide clarity about the
+     project and help tools like PyPI. ([Python Packaging][4], [Reddit][5])
+   - `license`, `authors`, `keywords`, `classifiers`: standardised metadata,
+     which improves discoverability. ([Python Packaging][4], [Reddit][5])
+   - `dependencies`: runtime requirements, expressed in PEP 508 syntax.
+     ([Astral Docs][1], [RidgeRun.ai][2])
 
 2. **Optional Dependencies (`[project.optional-dependencies]`):**
 
-   * Grouped as `dev` (for testing + linting) and `docs` (for documentation). Installing them is as simple as `uv add --group dev` or `uv sync --include dev`. ([Python Packaging][4], [DevsJC][6])
+   - Grouped as `dev` (for testing + linting) and `docs` (for documentation).
+     Installing them is as simple as `uv add --group dev` or
+     `uv sync --include dev`. ([Python Packaging][4], [DevsJC][6])
 
 3. **Entry Points (`[project.scripts]`):**
 
-   * Defines a console command `mycli` that maps to `my_project/cli.py:main`. Invoking `uv run mycli` will run the `main()` function. ([Astral Docs][8])
+   - Defines a console command `mycli` that maps to `my_project/cli.py:main`.
+     Invoking `uv run mycli` will run the `main()` function. ([Astral Docs][8])
 
 4. **Build System:**
 
-   * `setuptools>=61.0` plus `wheel` ensures both legacy and editable installs work. ✱ Newer versions of setuptools support PEP 660 editable installs without a `setup.py` stub. ([Python Packaging][4], [Astral Docs][8])
-   * `build-backend = "setuptools.build_meta"` tells `uv` how to compile your package. ([Python Packaging][4], [Astral Docs][8])
+   - `setuptools>=61.0` plus `wheel` ensures both legacy and editable installs
+     work. ✱ Newer versions of setuptools support PEP 660 editable installs
+     without a `setup.py` stub. ([Python Packaging][4], [Astral Docs][8])
+   - `build-backend = "setuptools.build_meta"` tells `uv` how to compile your
+     package. ([Python Packaging][4], [Astral Docs][8])
 
 5. **`[tool.uv]`:**
 
-   * `package = true` ensures that `uv sync` will build and install your own project (in editable mode) every time dependencies change. Otherwise, `uv` treats your project as a collection of scripts only (no package). ([Astral Docs][8])
+   - `package = true` ensures that `uv sync` will build and install your own
+     project (in editable mode) every time dependencies change. Otherwise, `uv`
+     treats your project as a collection of scripts only (no package).
+     ([Astral Docs][8])
 
----
+______________________________________________________________________
 
 ## 8. Additional Tips & Best Practices
 
-1. **Keep `pyproject.toml` Human-Readable:**
-   Edit it by hand when possible. Modern editors (VS Code, PyCharm) offer TOML syntax highlighting and PEP 621 autocompletion. ([Python Packaging][4])
+1. **Keep `pyproject.toml` Human-Readable:** Edit it by hand when possible.
+   Modern editors (VS Code, PyCharm) offer TOML syntax highlighting and PEP 621
+   autocompletion. ([Python Packaging][4])
 
-2. **Lockfile Discipline:**
-   After modifying `dependencies` or any `[project]` fields, always run `uv sync` (or `uv lock`) to update `uv.lock`. This guarantees reproducible environments. ([Astral Docs][1])
+2. **Lockfile Discipline:** After modifying `dependencies` or any `[project]`
+   fields, always run `uv sync` (or `uv lock`) to update `uv.lock`. This
+   guarantees reproducible environments. ([Astral Docs][1])
 
-3. **Semantic Versioning:**
-   Follow [semver](https://semver.org/) for `version` values (e.g., `1.2.3`). Bump patch versions for bug fixes, minor for backward-compatible changes, and major for breaking changes. ([Python Packaging][4])
+3. **Semantic Versioning:** Follow [semver](https://semver.org/) for `version`
+   values (e.g., `1.2.3`). Bump patch versions for bug fixes, minor for
+   backward-compatible changes, and major for breaking changes.
+   ([Python Packaging][4])
 
-4. **Keep Build Constraints Minimal:**
-   If you don't need editable installs, you can omit `[build-system]` (but then `uv` won't build your package; it will only install dependencies). To override, set `tool.uv.package = true`. ([Astral Docs][8])
+4. **Keep Build Constraints Minimal:** If you don't need editable installs, you
+   can omit `[build-system]` (but then `uv` won't build your package; it will
+   only install dependencies). To override, set `tool.uv.package = true`.
+   ([Astral Docs][8])
 
-5. **Use Exact or Bounded Ranges for Dependencies:**
-   Rather than `requests`, use `requests>=2.25, <3.0` to avoid unexpected major bumps. ([DevsJC][6])
+5. **Use Exact or Bounded Ranges for Dependencies:** Rather than `requests`, use
+   `requests>=2.25, <3.0` to avoid unexpected major bumps. ([DevsJC][6])
 
-6. **Consider Dynamic Fields Sparingly:**
-   You can declare fields like `dynamic = ["version"]` if your version is computed at build time (e.g. via `setuptools_scm`). If you do so, ensure your build backend supports dynamic metadata. ([Python Packaging][4])
+6. **Consider Dynamic Fields Sparingly:** You can declare fields like
+   `dynamic = ["version"]` if your version is computed at build time (e.g. via
+   `setuptools_scm`). If you do so, ensure your build backend supports dynamic
+   metadata. ([Python Packaging][4])
 
----
+______________________________________________________________________
 
 ## 9. Summary
 
 A "modern" `pyproject.toml` for an Astral `uv` project should:
 
-* Use the PEP 621 `[project]` table for metadata and `dependencies`.
-* Distinguish optional dependencies under `[project.optional-dependencies]`.
-* Define any CLI or GUI entry points under `[project.scripts]` or `[project.gui-scripts]`.
-* Declare a PEP 517 `[build-system]` (e.g. `setuptools>=61.0`, `wheel`, `setuptools.build_meta`) to support editable installs, or omit it and rely on `tool.uv.package = true`.
-* Include a `[tool.uv]` section, at minimum `package = true` if you want `uv` to build and install your own package.
+- Use the PEP 621 `[project]` table for metadata and `dependencies`.
+- Distinguish optional dependencies under `[project.optional-dependencies]`.
+- Define any CLI or GUI entry points under `[project.scripts]` or
+  `[project.gui-scripts]`.
+- Declare a PEP 517 `[build-system]` (e.g. `setuptools>=61.0`, `wheel`,
+  `setuptools.build_meta`) to support editable installs, or omit it and rely on
+  `tool.uv.package = true`.
+- Include a `[tool.uv]` section, at minimum `package = true` if you want `uv` to
+  build and install your own package.
 
-Following these conventions ensures that your project is fully PEP-compliant, easy to maintain, and integrates seamlessly with Astral `uv`.
+Following these conventions ensures that your project is fully PEP-compliant,
+easy to maintain, and integrates seamlessly with Astral `uv`.
 
 [1]: https://docs.astral.sh/uv/guides/projects/?utm_source=chatgpt.com "Working on projects | uv - Astral Docs"
 [2]: https://www.ridgerun.ai/post/uv-tutorial-a-fast-python-package-and-project-manager?utm_source=chatgpt.com "UV Tutorial: A Fast Python Package and Project Manager"

--- a/.rules/python-return.md
+++ b/.rules/python-return.md
@@ -1,8 +1,10 @@
-## flake8-return Style Guide (Python 3.13)
+# flake8-return Style Guide (Python 3.13)
 
-The `flake8-return` rules ensure consistent and explicit return behaviour, Ensuring your functions are clear in intent and free from unnecessary control flow. Follow these rules:
+The `flake8-return` rules ensure consistent and explicit return behaviour,
+Ensuring your functions are clear in intent and free from unnecessary control
+flow. Follow these rules:
 
-### R501 — Avoid Explicit `return None` if It's the Only Return
+## R501 — Avoid Explicit `return None` if It's the Only Return
 
 ```python
 # BAD:
@@ -14,11 +16,12 @@ def func():
     return
 ```
 
-Use `return` alone instead of `return None` when the function's only result is `None`.
+Use `return` alone instead of `return None` when the function's only result is
+`None`.
 
----
+______________________________________________________________________
 
-### R502 — Avoid Implicit `None` in Functions That May Return a Value
+## R502 — Avoid Implicit `None` in Functions That May Return a Value
 
 ```python
 # BAD:
@@ -36,9 +39,9 @@ def func(x):
 
 Ensure all branches explicitly return a value if any branch does.
 
----
+______________________________________________________________________
 
-### R503 — Add an Explicit Return at the End
+## R503 — Add an Explicit Return at the End
 
 ```python
 # BAD:
@@ -56,9 +59,9 @@ def func(x):
 
 Don't rely on implicit `None`—always return something at the end.
 
----
+______________________________________________________________________
 
-### R504 — Avoid Redundant Variable Assignment Before `return`
+## R504 — Avoid Redundant Variable Assignment Before `return`
 
 ```python
 # BAD:
@@ -71,13 +74,15 @@ def func():
     return compute()
 ```
 
-Inline return expressions unless the variable is reused meaningfully before returning.
+Inline return expressions unless the variable is reused meaningfully before
+returning.
 
----
+______________________________________________________________________
 
-### R505–R508 — Eliminate Unnecessary `else` After Terminal Statements
+## R505–R508 — Eliminate Unnecessary `else` After Terminal Statements
 
-Avoid `else` after `return`, `raise`, `break`, or `continue`. These statements already exit control flow.
+Avoid `else` after `return`, `raise`, `break`, or `continue`. These statements
+already exit control flow.
 
 ```python
 # BAD:
@@ -111,6 +116,7 @@ for x in xs:
 
 These rules apply to regular and `async def` functions alike.
 
----
+______________________________________________________________________
 
-Use the `flake8-return` rules to enforce predictable and clean return logic, enhancing readability and correctness.
+Use the `flake8-return` rules to enforce predictable and clean return logic,
+enhancing readability and correctness.

--- a/.rules/python-typing.md
+++ b/.rules/python-typing.md
@@ -1,10 +1,14 @@
-### Advanced Typing and Language Features (Python 3.13)
+# Advanced Typing and Language Features (Python 3.13)
 
-> This section documents forward-looking Python 3.13 typing features and best practices to improve clarity, correctness, and tooling support. Use these features to write expressive, modern Python.
+> This section documents forward-looking Python 3.13 typing features and best
+> practices to improve clarity, correctness, and tooling support. Use these
+> features to write expressive, modern Python.
 
-#### `enum.Enum`, `enum.IntEnum`, `enum.StrEnum`
+## `enum.Enum`, `enum.IntEnum`, `enum.StrEnum`
 
-Use `Enum` for fixed sets of related constants. Use `enum.auto()` to avoid repeating values manually. Use `IntEnum` or `StrEnum` when interoperability with integers or strings is required (e.g. for database or JSON serialisation).
+Use `Enum` for fixed sets of related constants. Use `enum.auto()` to avoid
+repeating values manually. Use `IntEnum` or `StrEnum` when interoperability with
+integers or strings is required (e.g. for database or JSON serialisation).
 
 ```python
 import enum
@@ -22,11 +26,14 @@ class Role(enum.StrEnum):
     GUEST = enum.auto()
 ```
 
-Use `auto()` when exact values are unimportant and you want to avoid duplication. Avoid `auto()` in `IntEnum` where numeric meaning matters.
+Use `auto()` when exact values are unimportant and you want to avoid
+duplication. Avoid `auto()` in `IntEnum` where numeric meaning matters.
 
-#### `match` / `case` (Structural Pattern Matching)
+## `match` / `case` (Structural Pattern Matching)
 
-Use structural pattern matching for branching over structured data. This is especially useful for enums, discriminated unions, or pattern-rich data structures.
+Use structural pattern matching for branching over structured data. This is
+especially useful for enums, discriminated unions, or pattern-rich data
+structures.
 
 ```python
 def handle_status(status: Status) -> str:
@@ -37,9 +44,10 @@ def handle_status(status: Status) -> str:
             return "Done"
 ```
 
-#### Generic Class Declarations (PEP 695)
+## Generic Class Declarations (PEP 695)
 
-Use bracketed class-level type variables directly for generic class declarations.
+Use bracketed class-level type variables directly for generic class
+declarations.
 
 ```python
 class Box[T]:
@@ -49,9 +57,10 @@ class Box[T]:
 
 This is cleaner and avoids the indirection of separate `TypeVar` declarations.
 
-#### `Self` Type (PEP 673)
+## `Self` Type (PEP 673)
 
-Use `Self` in fluent interfaces and builder-style APIs to indicate the method returns the same instance.
+Use `Self` in fluent interfaces and builder-style APIs to indicate the method
+returns the same instance.
 
 ```python
 import typing
@@ -64,9 +73,10 @@ class Builder:
 
 This improves tool support and enforces correct chaining semantics.
 
-#### `@override` Decorator (PEP 698)
+## `@override` Decorator (PEP 698)
 
-Use `@override` to indicate that a method overrides one from a superclass. This enables static analysis tools to detect typos and signature mismatches.
+Use `@override` to indicate that a method overrides one from a superclass. This
+enables static analysis tools to detect typos and signature mismatches.
 
 ```python
 import typing
@@ -83,9 +93,10 @@ class Child(Base):
 
 This decorator is a no-op at runtime but improves tooling correctness.
 
-#### `TypeIs` (PEP 742)
+## `TypeIs` (PEP 742)
 
-Use `TypeIs[T]` to define custom runtime type guards that narrow types in type checkers.
+Use `TypeIs[T]` to define custom runtime type guards that narrow types in type
+checkers.
 
 ```python
 import typing
@@ -94,11 +105,13 @@ def is_str_list(val: list[object]) -> typing.TypeIs[list[str]]:
     return all(isinstance(x, str) for x in val)
 ```
 
-Unlike `isinstance`, this informs the type checker that `val` is now `list[str]`.
+Unlike `isinstance`, this informs the type checker that `val` is now
+`list[str]`.
 
-#### Defaults for TypeVars (PEP 696)
+## Defaults for TypeVars (PEP 696)
 
-Allow generic classes/functions to fall back to default types when no specific type is provided.
+Allow generic classes/functions to fall back to default types when no specific
+type is provided.
 
 ```python
 T = typing.TypeVar("T", default=int)
@@ -110,9 +123,10 @@ class Box[T]:
 
 This makes APIs more ergonomic while retaining type safety.
 
-#### Standard Library Generics (PEP 585)
+## Standard Library Generics (PEP 585)
 
-Use built-in generics from the standard library (`list`, `dict`, `tuple`, etc.) instead of `typing.List`, `typing.Dict`, etc.
+Use built-in generics from the standard library (`list`, `dict`, `tuple`, etc.)
+instead of `typing.List`, `typing.Dict`, etc.
 
 ```python
 names: list[str] = ["Alice", "Bob"]
@@ -120,7 +134,7 @@ names: list[str] = ["Alice", "Bob"]
 
 This reduces imports and reflects the modern style.
 
-#### Union Syntax and Optional (PEP 604)
+## Union Syntax and Optional (PEP 604)
 
 Use `|` to write union types, and `A | None` instead of `Optional[A]`.
 
@@ -130,24 +144,27 @@ value: int | None = None
 
 This is more concise and readable, especially for nested types.
 
-#### Type Aliases using `type`
+## Type Aliases using `type`
 
-Use the `type` keyword to create type aliases with better IDE and runtime support.
+Use the `type` keyword to create type aliases with better IDE and runtime
+support.
 
 ```python
 type StrDict = dict[str, str]
 ```
+
 This replaces `StrDict = TypeAlias = ...` and is preferred in modern Python.
 
 When compatibility with Python < 3.12 is required, keep the older
-``typing.TypeAlias`` syntax and add ``# noqa: UP040`` so ``ruff`` does not flag
-it. Place alias definitions after the import block and group shared aliases in
-``bournemouth.types`` to avoid duplication.
+`typing.TypeAlias` syntax and add `# noqa: UP040` so `ruff` does not flag it.
+Place alias definitions after the import block and group shared aliases in
+`bournemouth.types` to avoid duplication.
 
-#### `from __future__ import annotations`
+## `from __future__ import annotations`
 
-Use this import in modules with type annotations to defer evaluation of annotation expressions to runtime.
-This prevents issues with forward references and circular imports.
+Use this import in modules with type annotations to defer evaluation of
+annotation expressions to runtime. This prevents issues with forward references
+and circular imports.
 
 ```python
 from __future__ import annotations
@@ -155,7 +172,7 @@ from __future__ import annotations
 
 Recommended in all modern Python files using type hints.
 
-#### `if typing.TYPE_CHECKING`
+## `if typing.TYPE_CHECKING`
 
 Use this conditional to guard imports required only for static typing.
 
@@ -168,7 +185,7 @@ if typing.TYPE_CHECKING:
 
 This avoids runtime import costs or circular imports.
 
-#### Standard Aliases
+## Standard Aliases
 
 Use the following import aliases consistently:
 
@@ -177,8 +194,9 @@ import datetime as dt
 import collections.abc as cabc
 ```
 
-This simplifies common types such as `dt.datetime`, `cabc.Iterable`, `cabc.Callable`, and helps disambiguate usage.
+This simplifies common types such as `dt.datetime`, `cabc.Iterable`,
+`cabc.Callable`, and helps disambiguate usage.
 
----
+______________________________________________________________________
 
 These conventions promote clarity, tool compatibility, and future-ready Python.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,48 +2,71 @@
 
 ## Code Style and Structure
 
-* **Code is for humans.** Write your code with clarity and empathy—assume a tired teammate will need to debug it at 3 a.m.
-* **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs, or complexity. Don't echo the obvious.
-* **Clarity over cleverness.** Be concise, but favour explicit over terse or obscure idioms. Prefer code that's easy to follow.
-* **Use functions and composition.** Avoid repetition by extracting reusable logic. Prefer generators or comprehensions to imperative repetition when readable.
-* **Name things precisely.** Use clear, descriptive variable and function names. For booleans, prefer names with `is`, `has`, or `should`.
-* **Structure logically.** Each file should encapsulate a coherent module. Group related code (e.g., models + utilities + fixtures) close together.
-* **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers related to a domain concept rather than splitting by type.
+- **Code is for humans.** Write your code with clarity and empathy—assume a
+  tired teammate will need to debug it at 3 a.m.
+- **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs, or
+  complexity. Don't echo the obvious.
+- **Clarity over cleverness.** Be concise, but favour explicit over terse or
+  obscure idioms. Prefer code that's easy to follow.
+- **Use functions and composition.** Avoid repetition by extracting reusable
+  logic. Prefer generators or comprehensions to imperative repetition when
+  readable.
+- **Name things precisely.** Use clear, descriptive variable and function names.
+  For booleans, prefer names with `is`, `has`, or `should`.
+- **Structure logically.** Each file should encapsulate a coherent module. Group
+  related code (e.g., models + utilities + fixtures) close together.
+- **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers
+  related to a domain concept rather than splitting by type.
 
 ## Documentation Maintenance
 
-*   **Reference:** Use the markdown files within the `docs/` directory as a knowledge base and source of truth for project requirements, dependency choices, and architectural decisions.
-*   **Update:** When new decisions are made, requirements change, libraries are added/removed, or architectural patterns evolve, **proactively update** the relevant file(s) in the `docs/` directory to reflect the latest state. Ensure the documentation remains accurate and current.
+- **Reference:** Use the markdown files within the `docs/` directory as a
+  knowledge base and source of truth for project requirements, dependency
+  choices, and architectural decisions.
+- **Update:** When new decisions are made, requirements change, libraries are
+  added/removed, or architectural patterns evolve, **proactively update** the
+  relevant file(s) in the `docs/` directory to reflect the latest state. Ensure
+  the documentation remains accurate and current.
 
 ## Guidelines for Code Changes & Testing
 
 When implementing changes, adhere to the following testing procedures:
 
-* **New Functionality:**
-  * Implement unit tests covering all new code units (functions, components, classes). Implement tests **before** implementing the unit.
-  * Implement behavioral tests that verify the end-to-end behavior of the new feature from a user interaction perspective.
-  * Ensure both unit and behavioral tests pass before considering the functionality complete.
-* **Bug Fixes:**
-  * Before fixing the bug, write a new test (unit or behavioral, whichever is most appropriate) that specifically targets and reproduces the bug. This test should initially fail.
-  * Implement the bug fix.
-  * Verify that the new test now passes, along with all existing tests.
-* **Modifying Existing Functionality:**
-  * Identify the existing behavioral and unit tests relevant to the functionality being changed.
-  * **First, modify the tests** to reflect the new requirements or behavior.
-  * Run the tests; they should now fail.
-  * Implement the code changes to the functionality.
-  * Verify that the modified tests (and all other existing tests) now pass.
-* **Refactoring:**
-  * Identify or create a behavioral test that covers the functionality being refactored. Ensure this test passes **before** starting the refactor.
-  * Perform the refactoring (e.g., extracting logic into a new unit).
-  * If new units are created (e.g., a new function or component), add unit tests for these extracted units.
-  * After the refactor, ensure the original behavioral test **still passes** without modification. Also ensure any new unit tests pass.
+- **New Functionality:**
+  - Implement unit tests covering all new code units (functions, components,
+    classes). Implement tests **before** implementing the unit.
+  - Implement behavioral tests that verify the end-to-end behavior of the new
+    feature from a user interaction perspective.
+  - Ensure both unit and behavioral tests pass before considering the
+    functionality complete.
+- **Bug Fixes:**
+  - Before fixing the bug, write a new test (unit or behavioral, whichever is
+    most appropriate) that specifically targets and reproduces the bug. This
+    test should initially fail.
+  - Implement the bug fix.
+  - Verify that the new test now passes, along with all existing tests.
+- **Modifying Existing Functionality:**
+  - Identify the existing behavioral and unit tests relevant to the
+    functionality being changed.
+  - **First, modify the tests** to reflect the new requirements or behavior.
+  - Run the tests; they should now fail.
+  - Implement the code changes to the functionality.
+  - Verify that the modified tests (and all other existing tests) now pass.
+- **Refactoring:**
+  - Identify or create a behavioral test that covers the functionality being
+    refactored. Ensure this test passes **before** starting the refactor.
+  - Perform the refactoring (e.g., extracting logic into a new unit).
+  - If new units are created (e.g., a new function or component), add unit tests
+    for these extracted units.
+  - After the refactor, ensure the original behavioral test **still passes**
+    without modification. Also ensure any new unit tests pass.
 
 ## Change Quality & Committing
 
-* **Atomicity:** Aim for small, focused, atomic changes. Each change (and subsequent commit) should represent a single logical unit of work.
- **Quality Gates:** Before considering a change complete or proposing a commit,
-  ensure it meets the following criteria:
+- **Atomicity:** Aim for small, focused, atomic changes. Each change (and
+  subsequent commit) should represent a single logical unit of work. **Quality
+  Gates:** Before considering a change complete or proposing a commit, ensure it
+  meets the following criteria:
 
   - For Python files:
 
@@ -66,41 +89,67 @@ When implementing changes, adhere to the following testing procedures:
 
     - **Linting:** Passes lint checks (`make markdownlint`).
     - **Mermaid diagrams:** Passes validation using nixie (`make nixie`)
-* **Committing:**
-  * Only changes that meet all the quality gates above should be committed.
-  * Write clear, descriptive commit messages summarizing the change, following these formatting guidelines:
-    * **Imperative Mood:** Use the imperative mood in the subject line (e.g., "Fix bug", "Add feature" instead of "Fixed bug", "Added feature").
-    * **Subject Line:** The first line should be a concise summary of the change (ideally 50 characters or less).
-    * **Body:** Separate the subject from the body with a blank line. Subsequent lines should explain the *what* and *why* of the change in more detail, including rationale, goals, and scope. Wrap the body at 72 characters.
-    * **Formatting:** Use Markdown for any formatted text (like bullet points or code snippets) within the commit message body.
-  * Do not commit changes that fail any of the quality gates.
+
+- **Committing:**
+
+  - Only changes that meet all the quality gates above should be committed.
+  - Write clear, descriptive commit messages summarizing the change, following
+    these formatting guidelines:
+    - **Imperative Mood:** Use the imperative mood in the subject line (e.g.,
+      "Fix bug", "Add feature" instead of "Fixed bug", "Added feature").
+    - **Subject Line:** The first line should be a concise summary of the change
+      (ideally 50 characters or less).
+    - **Body:** Separate the subject from the body with a blank line. Subsequent
+      lines should explain the *what* and *why* of the change in more detail,
+      including rationale, goals, and scope. Wrap the body at 72 characters.
+    - **Formatting:** Use Markdown for any formatted text (like bullet points or
+      code snippets) within the commit message body.
+  - Do not commit changes that fail any of the quality gates.
 
 ## Refactoring Heuristics & Workflow
 
-* **Recognizing Refactoring Needs:** Regularly assess the codebase for potential refactoring opportunities. Consider refactoring when you observe:
-  * **Long Methods/Functions:** Functions or methods that are excessively long or try to do too many things.
-  * **Duplicated Code:** Identical or very similar code blocks appearing in multiple places.
-  * **Complex Conditionals:** Deeply nested or overly complex `if`/`else` or `switch` statements (high cyclomatic complexity).
-  * **Large Code Blocks for Single Values:** Significant chunks of logic dedicated solely to calculating or deriving a single value.
-  * **Primitive Obsession / Data Clumps:** Groups of simple variables (strings, numbers, booleans) that are frequently passed around together, often indicating a missing class or object structure.
-  * **Excessive Parameters:** Functions or methods requiring a very long list of parameters.
-  * **Feature Envy:** Methods that seem more interested in the data of another class/object than their own.
-  * **Shotgun Surgery:** A single change requiring small modifications in many different classes or functions.
-* **Post-Commit Review:** After committing a functional change or bug fix (that meets all quality gates), review the changed code and surrounding areas using the heuristics above.
-* **Separate Atomic Refactors:** If refactoring is deemed necessary:
-  * Perform the refactoring as a **separate, atomic commit** *after* the functional change commit.
-  * Ensure the refactoring adheres to the testing guidelines (behavioral tests pass before and after, unit tests added for new units).
-  * Ensure the refactoring commit itself passes all quality gates.
-
-
+- **Recognizing Refactoring Needs:** Regularly assess the codebase for potential
+  refactoring opportunities. Consider refactoring when you observe:
+  - **Long Methods/Functions:** Functions or methods that are excessively long
+    or try to do too many things.
+  - **Duplicated Code:** Identical or very similar code blocks appearing in
+    multiple places.
+  - **Complex Conditionals:** Deeply nested or overly complex `if`/`else` or
+    `switch` statements (high cyclomatic complexity).
+  - **Large Code Blocks for Single Values:** Significant chunks of logic
+    dedicated solely to calculating or deriving a single value.
+  - **Primitive Obsession / Data Clumps:** Groups of simple variables (strings,
+    numbers, booleans) that are frequently passed around together, often
+    indicating a missing class or object structure.
+  - **Excessive Parameters:** Functions or methods requiring a very long list of
+    parameters.
+  - **Feature Envy:** Methods that seem more interested in the data of another
+    class/object than their own.
+  - **Shotgun Surgery:** A single change requiring small modifications in many
+    different classes or functions.
+- **Post-Commit Review:** After committing a functional change or bug fix (that
+  meets all quality gates), review the changed code and surrounding areas using
+  the heuristics above.
+- **Separate Atomic Refactors:** If refactoring is deemed necessary:
+  - Perform the refactoring as a **separate, atomic commit** *after* the
+    functional change commit.
+  - Ensure the refactoring adheres to the testing guidelines (behavioral tests
+    pass before and after, unit tests added for new units).
+  - Ensure the refactoring commit itself passes all quality gates.
 
 ## Python Development Guidelines
 
-For Python development, refer to the detailed guidelines in the `.rules/` directory:
+For Python development, refer to the detailed guidelines in the `.rules/`
+directory:
 
-* [Python Code Style Guidelines](.rules/python-00.md) - Core Python 3.13 style conventions
-* [Python Context Managers](.rules/python-context-managers.md) - Best practices for context managers
-* [Python Generators](.rules/python-generators.md) - Generator and iterator patterns
-* [Python Project Configuration](.rules/python-pyproject.md) - pyproject.toml and packaging
-* [Python Return Patterns](.rules/python-return.md) - Function return conventions
-* [Python Typing](.rules/python-typing.md) - Type annotation best practices
+- [Python Code Style Guidelines](.rules/python-00.md) - Core Python 3.13 style
+  conventions
+- [Python Context Managers](.rules/python-context-managers.md) - Best practices
+  for context managers
+- [Python Generators](.rules/python-generators.md) - Generator and iterator
+  patterns
+- [Python Project Configuration](.rules/python-pyproject.md) - pyproject.toml
+  and packaging
+- [Python Return Patterns](.rules/python-return.md) - Function return
+  conventions
+- [Python Typing](.rules/python-typing.md) - Type annotation best practices

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
-# 🕵️‍♀️ CmdMox – Python-native command mocking so you never have to write another shell test again.
+<!-- markdownlint-disable-next-line MD013 -->
+# 🕵️‍♀️ CmdMox – Python-native command mocking so you never have to write another shell test again
 
-Replace your flaky bats tests, your brittle log-parsing hacks, and that one Bash script that only works on Tuesdays. CmdMox intercepts external commands with Python shims, speaks fluent IPC over Unix domain sockets, and enforces your expectations like a disappointed parent.
+Replace your flaky bats tests, your brittle log-parsing hacks, and that one Bash
+script that only works on Tuesdays. CmdMox intercepts external commands with
+Python shims, speaks fluent IPC over Unix domain sockets, and enforces your
+expectations like a disappointed parent.
 
 - Mocks? Verified.
 - Stubs? Quietly compliant.
 - Spies? Judging everything you do.
 
-Designed for pytest, built for people who’ve seen things—like `ksh93` unit test harnesses and AIX cronjobs running `sccs`.
+Designed for pytest, built for people who’ve seen things—like `ksh93` unit test
+harnesses and AIX cronjobs running `sccs`.
 
 If you've ever mocked `curl` with `cat`, this library is your penance.
 
 ## 🧪 Example: Testing a command-line script with CmdMox
 
-Let’s say your script under test calls `git clone` and `curl`. You want to test it *without actually cloning anything*, because you value your bandwidth and your sanity.
+Let’s say your script under test calls `git clone` and `curl`. You want to test
+it *without actually cloning anything*, because you value your bandwidth and
+your sanity.
 
 ```python
 # test_my_script.py
@@ -40,22 +47,30 @@ def test_clone_and_fetch(mox):
 
 When it passes: your mocks were used exactly as expected.
 
-When it fails: you'll get a surgically precise diff of what was expected vs what your misbehaving code actually did.
+When it fails: you'll get a surgically precise diff of what was expected vs what
+your misbehaving code actually did.
 
-No subshells. No flaky greps. Just clean, high-fidelity, Pythonic command mocking.
+No subshells. No flaky greps. Just clean, high-fidelity, Pythonic command
+mocking.
 
 ## 🧯 Scope (and what’s gloriously *out* of it)
 
-**CmdMox** is for mocking *commands*—not re-enacting `bash(1)` interpretive dance theatre.
+**CmdMox** is for mocking *commands*—not re-enacting `bash(1)` interpretive
+dance theatre.
 
 Out of scope (for now, or forever):
 
-- 🧞 **Shell function mocking** – you want `eval`, you wait a year. Or just don’t.
+- 🧞 **Shell function mocking** – you want `eval`, you wait a year. Or just
+  don’t.
 
-- 🪟 **Windows support** – maybe one day. Until then: enjoy your `.bat` files and pray to `CreateProcess()`.
+- 🪟 **Windows support** – maybe one day. Until then: enjoy your `.bat` files and
+  pray to `CreateProcess()`.
 
-- 🦕 **Legacy UNIX support** – AIX, Solaris, IRIX? Sorry boys, the boat sailed, caught fire, and sank in 2003.
+- 🦕 **Legacy UNIX support** – AIX, Solaris, IRIX? Sorry boys, the boat sailed,
+  caught fire, and sank in 2003.
 
 - 🧩 **Builtin mocking** – `cd`, `exec`, `trap`? No. Just no.
 
-- 🧪 **Calling commands under test** – use `subprocess`, `plumbum`, or whatever black magic suits your taste. CmdMox doesn't care how you run them—as long as you run them *like you mean it*.
+- 🧪 **Calling commands under test** – use `subprocess`, `plumbum`, or whatever
+  black magic suits your taste. CmdMox doesn't care how you run them—as long as
+  you run them *like you mean it*.

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -1,12 +1,13 @@
-## CmdMox Implementation Roadmap
+# CmdMox Implementation Roadmap
 
-### **I. Project Foundation & Infrastructure**
+## **I. Project Foundation & Infrastructure**
 
 - [x] **Establish Core Repository Structure**
 
   - [x] Create project skeleton (`cmd_mox/`, `tests/`, `conftest.py`, etc.)
 
-  - [x] Set up packaging, CI, linting, type-checking (e.g., `pyproject.toml`, `pytest`, `ruff`, `mypy`)
+  - [x] Set up packaging, CI, linting, type-checking (e.g., `pyproject.toml`,
+    `pytest`, `ruff`, `mypy`)
 
 - [x] **Initial Documentation**
 
@@ -14,7 +15,7 @@
 
   - [x] Add this design spec as `docs/python-native-command-mocking-design.md`
 
-### **II. Core Components: Environment & IPC**
+## **II. Core Components: Environment & IPC**
 
 - [x] **Environment Manager**
 
@@ -30,7 +31,7 @@
 
   - [ ] Logic to create per-command symlinks in temp directory
 
-  - [ ] Symlink invokes correct behaviour based on `argv[0] `
+  - [ ] Symlink invokes correct behaviour based on `argv[0]`
 
   - [ ] Make shims executable on all supported Unix platforms
 
@@ -44,7 +45,7 @@
 
   - [ ] Timeout/error handling and robust socket cleanup
 
-### **III. Mox Controller & Public API**
+## **III. Mox Controller & Public API**
 
 - [ ] `Mox` **Controller Class**
 
@@ -66,7 +67,7 @@
 
   - [ ] Support for explicit `with cmdmox.Mox() as mox: ...` usage
 
-### **IV. Command Double Implementations**
+## **IV. Command Double Implementations**
 
 - [ ] **StubCommand**
 
@@ -94,7 +95,7 @@
 
   - [ ] Maintain call history (`invocations`, `call_count` API)
 
-### **V. Matching & Verification Engine**
+## **V. Matching & Verification Engine**
 
 - [ ] **Comparator Classes**
 
@@ -118,11 +119,11 @@
 
   - [ ] Clear diff-style error reporting (`VerificationError` etc.)
 
-### **VI. Shim Behaviour**
+## **VI. Shim Behaviour**
 
 - [ ] **Shim Startup Logic**
 
-  - [ ] Determine which command to simulate via `argv[0] `
+  - [ ] Determine which command to simulate via `argv[0]`
 
   - [ ] Connect to IPC socket
 
@@ -138,21 +139,23 @@
 
   - [ ] Shim locates real command in original `PATH`, executes, sends result
 
-### **VII. Advanced Features & Edge Cases**
+## **VII. Advanced Features & Edge Cases**
 
 - [ ] **Environment Variable Injection**
 
-  - [ ] `.with_env()` applies mock-specific env prior to executing handler or canned response
+  - [ ] `.with_env()` applies mock-specific env prior to executing handler or
+    canned response
 
 - [ ] **Concurrency Support**
 
-  - [ ] Safe parallel use: unique per-test temp dirs, socket names, no shared files
+  - [ ] Safe parallel use: unique per-test temp dirs, socket names, no shared
+    files
 
 - [ ] **Robust Cleanup**
 
   - [ ] Always restore env and remove temp dirs/sockets, even on error/interrupt
 
-### **VIII. Documentation, Examples & Usability**
+## **VIII. Documentation, Examples & Usability**
 
 - [ ] **API Reference & Tutorials**
 
@@ -162,17 +165,19 @@
 
   - [ ] Comparison/migration guide for `shellmock` users
 
-### **IX. Quality Assurance**
+## **IX. Quality Assurance**
 
 - [ ] **Unit & Integration Testing**
 
-  - [ ] Full test coverage for all core components (especially IPC and env manipulation)
+  - [ ] Full test coverage for all core components (especially IPC and env
+    manipulation)
 
   - [ ] Tests for pytest-xdist compatibility
 
-  - [ ] Regression suite for edge cases (pipelines, missing commands, complex args)
+  - [ ] Regression suite for edge cases (pipelines, missing commands, complex
+    args)
 
-### **X. Release & Post-MVP**
+## **X. Release & Post-MVP**
 
 - [ ] **First Public Release (1.0.0)**
 
@@ -180,7 +185,7 @@
 
   - [ ] Announce project, collect early user feedback
 
-### **XI. Future/Epic: Windows and Record Mode**
+## **XI. Future/Epic: Windows and Record Mode**
 
 - [ ] **Windows Support**
 
@@ -188,12 +193,15 @@
 
 - [ ] **Test Generation Utility**
 
-  - [ ] Prototype tool for automatic pytest test file generation from passthrough spy recordings
+  - [ ] Prototype tool for automatic pytest test file generation from
+    passthrough spy recordings
 
   - [ ] Export/serialise real command interactions to reusable mocks
 
 **Legend:**
 
-- Each `[ ] ` is an implementable, trackable unit (suitable for tickets/epics in e.g. GitHub Projects, Jira, etc.)
+- Each `[ ]` is an implementable, trackable unit (suitable for tickets/epics in
+  e.g. GitHub Projects, Jira, etc.)
 
-- [ ] All MVP checkboxes above this point should be completed before first public release.
+- [ ] All MVP checkboxes above this point should be completed before first
+  public release.

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1,75 +1,178 @@
-
 # `CmdMox`: A Technical Design Specification for Python-Native Command Mocking
 
 ## I. Conceptual Framework: Unifying PyMox and Shell Command Mocking
 
-This document presents the technical design for `CmdMox`, a Python library for stubbing, mocking, and spying on external commands in Unix-like environments. The primary objective is to provide a robust, ergonomic, and Python-native alternative to shell-based testing frameworks like BATS and `shellmock`. The design prioritizes a fluent API modeled on the PyMox framework, combined with a powerful and reliable command interception mechanism. This section establishes the core principles and architectural philosophy that underpin the library's design.
+This document presents the technical design for `CmdMox`, a Python library for
+stubbing, mocking, and spying on external commands in Unix-like environments.
+The primary objective is to provide a robust, ergonomic, and Python-native
+alternative to shell-based testing frameworks like BATS and `shellmock`. The
+design prioritizes a fluent API modeled on the PyMox framework, combined with a
+powerful and reliable command interception mechanism. This section establishes
+the core principles and architectural philosophy that underpin the library's
+design.
 
 ### 1.1 The "Record-Replay-Verify" Paradigm for External Processes
 
-The foundational testing paradigm adopted by `CmdMox` is "Record-Replay-Verify," a disciplined workflow popularized by the EasyMock framework for Java and its Python counterpart, PyMox. This paradigm structures tests into three distinct, sequential phases, enforcing clarity and explicitness about a system's interactions with its dependencies.
+The foundational testing paradigm adopted by `CmdMox` is "Record-Replay-Verify,"
+a disciplined workflow popularized by the EasyMock framework for Java and its
+Python counterpart, PyMox. This paradigm structures tests into three distinct,
+sequential phases, enforcing clarity and explicitness about a system's
+interactions with its dependencies.
 
-1. **Record Phase:** In this initial phase, the developer uses the `CmdMox` API to declaratively define a set of expectations. An expectation is a precise description of a single external command invocation, including the command name, its arguments, expected standard input, and the behavior it should exhibit (e.g., its `stdout`, `stderr`, and exit code). This is the setup portion of the test, where the "script" for the test doubles is written.
+1. **Record Phase:** In this initial phase, the developer uses the `CmdMox` API
+   to declaratively define a set of expectations. An expectation is a precise
+   description of a single external command invocation, including the command
+   name, its arguments, expected standard input, and the behavior it should
+   exhibit (e.g., its `stdout`, `stderr`, and exit code). This is the setup
+   portion of the test, where the "script" for the test doubles is written.
 
-2. **Replay Phase:** Once all expectations are recorded, the test transitions the framework into the replay phase. During this phase, the system or component under test is executed. Any attempt to invoke an external command is intercepted by `CmdMox`. The framework consults the recorded expectations to find one that matches the actual invocation. If a match is found, `CmdMox` provides the specified behavior. If no match is found, it is treated as an unexpected interaction, which will cause the test to fail during the final phase.
+2. **Replay Phase:** Once all expectations are recorded, the test transitions
+   the framework into the replay phase. During this phase, the system or
+   component under test is executed. Any attempt to invoke an external command
+   is intercepted by `CmdMox`. The framework consults the recorded expectations
+   to find one that matches the actual invocation. If a match is found, `CmdMox`
+   provides the specified behavior. If no match is found, it is treated as an
+   unexpected interaction, which will cause the test to fail during the final
+   phase.
 
-3. **Verify Phase:** After the code under test has completed its execution, the test enters the final verification phase. In this phase, `CmdMox` checks whether the actual invocations that occurred during the replay phase perfectly match the expectations set during the record phase. The test succeeds only if every recorded expectation was met exactly as specified (including call counts and ordering) and no unexpected command calls occurred. Any deviation results in a `VerificationError` with a detailed report of the discrepancy.
+3. **Verify Phase:** After the code under test has completed its execution, the
+   test enters the final verification phase. In this phase, `CmdMox` checks
+   whether the actual invocations that occurred during the replay phase
+   perfectly match the expectations set during the record phase. The test
+   succeeds only if every recorded expectation was met exactly as specified
+   (including call counts and ordering) and no unexpected command calls
+   occurred. Any deviation results in a `VerificationError` with a detailed
+   report of the discrepancy.
 
-Adopting this strict paradigm for command-line testing offers significant advantages. It forces developers to be deliberate about the external process dependencies of their applications. Unlike more lenient mocking styles, it prevents "dependency creep" by immediately failing a test if an unexpected command is called. The resulting tests are highly self-documenting; the record phase serves as a clear specification of the application's external interactions.
+Adopting this strict paradigm for command-line testing offers significant
+advantages. It forces developers to be deliberate about the external process
+dependencies of their applications. Unlike more lenient mocking styles, it
+prevents "dependency creep" by immediately failing a test if an unexpected
+command is called. The resulting tests are highly self-documenting; the record
+phase serves as a clear specification of the application's external
+interactions.
 
+<!-- markdownlint-disable-next-line MD013 -->
 ### 1.2 The Core Architectural Principle: Command Interception via Dynamic `PATH` Manipulation
 
-The fundamental mechanism for intercepting command invocations will be the dynamic manipulation of the `PATH` environment variable. This is a well-established and reliable technique employed by a wide array of shell-based mocking tools to redirect command calls.
+The fundamental mechanism for intercepting command invocations will be the
+dynamic manipulation of the `PATH` environment variable. This is a
+well-established and reliable technique employed by a wide array of shell-based
+mocking tools to redirect command calls.
 
 The process works as follows:
 
-- At the beginning of a test run, `CmdMox` creates a temporary, securely-named directory (e.g., within `/tmp`).
+- At the beginning of a test run, `CmdMox` creates a temporary, securely-named
+  directory (e.g., within `/tmp`).
 
-- For each command that needs to be mocked (e.g., `git`, `ls`, `curl`), the library creates a corresponding executable file, or "shim," inside this temporary directory.
+- For each command that needs to be mocked (e.g., `git`, `ls`, `curl`), the
+  library creates a corresponding executable file, or "shim," inside this
+  temporary directory.
 
-- The absolute path of this temporary directory is then prepended to the `PATH` environment variable of the test process.
+- The absolute path of this temporary directory is then prepended to the `PATH`
+  environment variable of the test process.
 
-- When the code under test attempts to execute a command like `git`, the operating system's standard library functions for finding executables (such as `execvp`) search the directories listed in `PATH` in order. The OS will find the `CmdMox`-generated shim in the temporary directory before it finds the real system command in a standard location like `/usr/bin/git`.
+- When the code under test attempts to execute a command like `git`, the
+  operating system's standard library functions for finding executables (such as
+  `execvp`) search the directories listed in `PATH` in order. The OS will find
+  the `CmdMox`-generated shim in the temporary directory before it finds the
+  real system command in a standard location like `/usr/bin/git`.
 
 - This shim then becomes the entry point for the mocked behavior.
 
-- Upon test completion (or failure), the `PATH` variable is restored to its original state, and the temporary directory and all its shims are removed, ensuring no side effects linger beyond the test's execution.
+- Upon test completion (or failure), the `PATH` variable is restored to its
+  original state, and the temporary directory and all its shims are removed,
+  ensuring no side effects linger beyond the test's execution.
 
-While the `PATH` hijacking technique is common, `CmdMox` introduces a critical architectural improvement over existing tools. Frameworks like `shellmock` and `bats-mock` generate *shell scripts* to act as shims. These shell shims are inherently limited. To communicate invocation details back to the main test runner process, they must resort to writing to temporary log files (e.g., `shellmock.out`, `*.playback.capture.tmp`). The test runner then has the brittle and inefficient task of parsing these flat text files to verify the interactions. This approach struggles with structured data, concurrency, and complex quoting or argument-passing scenarios.
+While the `PATH` hijacking technique is common, `CmdMox` introduces a critical
+architectural improvement over existing tools. Frameworks like `shellmock` and
+`bats-mock` generate *shell scripts* to act as shims. These shell shims are
+inherently limited. To communicate invocation details back to the main test
+runner process, they must resort to writing to temporary log files (e.g.,
+`shellmock.out`, `*.playback.capture.tmp`). The test runner then has the brittle
+and inefficient task of parsing these flat text files to verify the
+interactions. This approach struggles with structured data, concurrency, and
+complex quoting or argument-passing scenarios.
 
-`CmdMox` will instead generate lightweight *Python scripts* as its shims. This design choice unlocks a far more powerful and robust implementation. A Python shim can leverage the full breadth of Python's standard library for sophisticated Inter-Process Communication (IPC). Instead of writing to fragile log files, the shim can communicate with the main `CmdMox` test process over a dedicated, high-performance channel like a Unix domain socket. This allows for the bidirectional transfer of rich, structured data (e.g., JSON-serialized objects representing the command, its arguments, environment, and `stdin` content). This architectural decision elevates `CmdMox` beyond the capabilities of its shell-based predecessors, enabling more complex features, better performance, and greater reliability, as detailed in Section III.
+`CmdMox` will instead generate lightweight *Python scripts* as its shims. This
+design choice unlocks a far more powerful and robust implementation. A Python
+shim can leverage the full breadth of Python's standard library for
+sophisticated Inter-Process Communication (IPC). Instead of writing to fragile
+log files, the shim can communicate with the main `CmdMox` test process over a
+dedicated, high-performance channel like a Unix domain socket. This allows for
+the bidirectional transfer of rich, structured data (e.g., JSON-serialized
+objects representing the command, its arguments, environment, and `stdin`
+content). This architectural decision elevates `CmdMox` beyond the capabilities
+of its shell-based predecessors, enabling more complex features, better
+performance, and greater reliability, as detailed in Section III.
 
 ### 1.3 Defining the Terminology: Stubs, Mocks, and Spies
 
-To ensure clarity, `CmdMox` will adopt precise definitions for its test doubles, based on established software testing theory and adapted for the context of external commands.
+To ensure clarity, `CmdMox` will adopt precise definitions for its test doubles,
+based on established software testing theory and adapted for the context of
+external commands.
 
-- **Stub:** A stub is a simple, "fire-and-forget" replacement for a command. Its purpose is to provide a fixed, canned response to a command invocation to allow the code under test to proceed. For example, a test might stub the `git` command to always return a successful exit code. A stub does not perform any verification; if the stubbed command is never called, the test still passes. Stubs are used to satisfy a dependency, not to test an interaction.
+- **Stub:** A stub is a simple, "fire-and-forget" replacement for a command. Its
+  purpose is to provide a fixed, canned response to a command invocation to
+  allow the code under test to proceed. For example, a test might stub the `git`
+  command to always return a successful exit code. A stub does not perform any
+  verification; if the stubbed command is never called, the test still passes.
+  Stubs are used to satisfy a dependency, not to test an interaction.
 
-- **Mock:** A mock is a "verifiable" replacement for a command. Like a stub, it provides a defined behavior. However, a mock also carries a set of strict expectations about how it must be invoked. These expectations can include the exact arguments, the number of times it should be called, and the order of invocation relative to other mocks. The `verify()` phase of the test will fail if these expectations are not met precisely. Mocks are used to test that the system under test interacts with its dependencies *in a specific, correct way*. This aligns with the strict philosophy of PyMox.
+- **Mock:** A mock is a "verifiable" replacement for a command. Like a stub, it
+  provides a defined behavior. However, a mock also carries a set of strict
+  expectations about how it must be invoked. These expectations can include the
+  exact arguments, the number of times it should be called, and the order of
+  invocation relative to other mocks. The `verify()` phase of the test will fail
+  if these expectations are not met precisely. Mocks are used to test that the
+  system under test interacts with its dependencies *in a specific, correct
+  way*. This aligns with the strict philosophy of PyMox.
 
-- **Spy:** A spy is an "observational" test double. A spy wraps a command to record all invocations made to it, including arguments, `stdin`, and environment variables. A spy can either be configured with a stubbed behavior or it can "passthrough" and execute the real underlying command. After the test run, the developer can inspect the spy's recorded history to make assertions about how the command was used. This provides a more flexible, `assert`-based verification style, similar to the functionality found in tools like `bash_placebo`, and is useful when the exact sequence or number of calls is not known beforehand or is not the primary subject of the test.
+- **Spy:** A spy is an "observational" test double. A spy wraps a command to
+  record all invocations made to it, including arguments, `stdin`, and
+  environment variables. A spy can either be configured with a stubbed behavior
+  or it can "passthrough" and execute the real underlying command. After the
+  test run, the developer can inspect the spy's recorded history to make
+  assertions about how the command was used. This provides a more flexible,
+  `assert`-based verification style, similar to the functionality found in tools
+  like `bash_placebo`, and is useful when the exact sequence or number of calls
+  is not known beforehand or is not the primary subject of the test.
 
 ## II. The Public API: A `CmdMox` User's Guide
 
-The design of the `CmdMox` public API is paramount, with a primary goal of providing an ergonomic, intuitive, and "Pythonic" user experience. The API is heavily inspired by the fluent, chainable Domain-Specific Language (DSL) of the modern PyMox fork, particularly its "New Elegant Way" of integration with testing frameworks. This section serves as the definitive contract for how a developer will interact with the library.
+The design of the `CmdMox` public API is paramount, with a primary goal of
+providing an ergonomic, intuitive, and "Pythonic" user experience. The API is
+heavily inspired by the fluent, chainable Domain-Specific Language (DSL) of the
+modern PyMox fork, particularly its "New Elegant Way" of integration with
+testing frameworks. This section serves as the definitive contract for how a
+developer will interact with the library.
 
 ### 2.1 The `Mox` Controller: The Central Orchestrator
 
-The central class and primary user entry point for the library will be `cmdmox.Mox`. An instance of this class encapsulates the entire state for a single test case, including all recorded expectations, the invocation journal, and the environment management context. It is analogous to the `mox.Mox` class in PyMox and is responsible for orchestrating the record-replay-verify lifecycle.
+The central class and primary user entry point for the library will be
+`cmdmox.Mox`. An instance of this class encapsulates the entire state for a
+single test case, including all recorded expectations, the invocation journal,
+and the environment management context. It is analogous to the `mox.Mox` class
+in PyMox and is responsible for orchestrating the record-replay-verify
+lifecycle.
 
 ### 2.2 Ergonomic Integrations: `pytest` Fixtures and Context Managers
 
-To minimize boilerplate and promote best practices, the library will offer seamless integration with modern Python testing workflows.
+To minimize boilerplate and promote best practices, the library will offer
+seamless integration with modern Python testing workflows.
 
 **Primary Interface:** `pytest` **Fixture**
 
-The recommended and primary method for using `CmdMox` will be through a `pytest` fixture. This aligns with the "New Elegant Way" promoted by PyMox and the broader Python testing ecosystem. Users will enable the plugin, and a `mox` fixture will be automatically available to their test functions. This fixture provides a fresh, properly configured `Mox` instance for each test, with setup and teardown handled automatically.
+The recommended and primary method for using `CmdMox` will be through a `pytest`
+fixture. This aligns with the "New Elegant Way" promoted by PyMox and the
+broader Python testing ecosystem. Users will enable the plugin, and a `mox`
+fixture will be automatically available to their test functions. This fixture
+provides a fresh, properly configured `Mox` instance for each test, with setup
+and teardown handled automatically.
 
 *Example Usage:*
 
-Python
-
-```
+```python
 # In conftest.py
 pytest_plugins = ("cmdmox.pytest_plugin",)
 
@@ -87,18 +190,19 @@ def test_git_clone_functionality(mox):
     assert result is True
 
     # Verify phase:
-    mox.verify()
+mox.verify()
 ```
 
-**Alternative Interface: Context Manager**
+#### Alternative Interface: Context Manager
 
-For use cases outside of `pytest` or when more explicit control is desired, a standard Python context manager will be provided. The context manager ensures that the environment is correctly set up on entry and, critically, that it is torn down and restored on exit, even in the case of an exception.
+For use cases outside of `pytest` or when more explicit control is desired, a
+standard Python context manager will be provided. The context manager ensures
+that the environment is correctly set up on entry and, critically, that it is
+torn down and restored on exit, even in the case of an exception.
 
 *Example Usage:*
 
-Python
-
-```
+```python
 import cmdmox
 import subprocess
 
@@ -110,99 +214,202 @@ with cmdmox.Mox() as mox:
     output = subprocess.check_output(['ls', '-l'], text=True)
     assert output == 'total 0'
 
-    mox.verify()
+mox.verify()
 # The PATH is automatically restored here.
 ```
 
 ### 2.3 Creating Test Doubles: `mox.mock()`, `mox.stub()`, and `mox.spy()`
 
-The `Mox` controller instance provides three distinct factory methods for creating the different types of test doubles, each returning a chainable object for further configuration.
+The `Mox` controller instance provides three distinct factory methods for
+creating the different types of test doubles, each returning a chainable object
+for further configuration.
 
-- `mox.mock(command_name: str) -> MockCommand`: Creates a strict `MockCommand` object. This is used for interactions that must be verified. The returned object is used to build up a complete expectation using the fluent API.
+- `mox.mock(command_name: str) -> MockCommand`: Creates a strict `MockCommand`
+  object. This is used for interactions that must be verified. The returned
+  object is used to build up a complete expectation using the fluent API.
 
-- `mox.stub(command_name: str) -> StubCommand`: Creates a `StubCommand` object. This is used to provide canned responses for dependencies that are not the focus of the test.
+- `mox.stub(command_name: str) -> StubCommand`: Creates a `StubCommand` object.
+  This is used to provide canned responses for dependencies that are not the
+  focus of the test.
 
-- `mox.spy(command_name: str) -> SpyCommand`: Creates a `SpyCommand` object. This is used to record invocations for later inspection without the strict upfront expectations of a mock.
+- `mox.spy(command_name: str) -> SpyCommand`: Creates a `SpyCommand` object.
+  This is used to record invocations for later inspection without the strict
+  upfront expectations of a mock.
 
 ### 2.4 The Fluent API for Defining Expectations
 
-The core of the library's ergonomic design lies in its fluent, chainable API for defining the behavior and expectations of test doubles. This DSL allows developers to write clear, readable, and expressive test setups, drawing direct inspiration from PyMox's method-chaining style.
+The core of the library's ergonomic design lies in its fluent, chainable API for
+defining the behavior and expectations of test doubles. This DSL allows
+developers to write clear, readable, and expressive test setups, drawing direct
+inspiration from PyMox's method-chaining style.
 
-- `.with_args(*args: str)`**:** Specifies the exact, ordered list of command-line arguments that are expected. The match must be precise.
+- `.with_args(*args: str)`**:** Specifies the exact, ordered list of
+  command-line arguments that are expected. The match must be precise.
 
-- `.with_matching_args(*comparators)`**:** For more flexible matching, this method accepts a sequence of `CmdMox` comparator objects (see Section V). This allows for matching based on type, regular expressions, or custom logic.
+- `.with_matching_args(*comparators)`**:** For more flexible matching, this
+  method accepts a sequence of `CmdMox` comparator objects (see Section V). This
+  allows for matching based on type, regular expressions, or custom logic.
 
-- `.with_stdin(data: Union[str, bytes, Comparator])`**:** Defines an expectation for the data that is piped to the command's standard input. This can be a literal string or bytes, or a comparator for flexible matching.
+- `.with_stdin(data: Union[str, bytes, Comparator])`**:** Defines an expectation
+  for the data that is piped to the command's standard input. This can be a
+  literal string or bytes, or a comparator for flexible matching.
 
-- `.returns(stdout: Union[str, bytes] = b'', stderr: Union[str, bytes] = b'', exit_code: int = 0)`**:** Specifies the static result of the command invocation. The mock will write the given `stdout` and `stderr` to the corresponding streams and exit with the provided `exit_code`.
+- <!-- markdownlint-disable-next-line MD013 -->
+- `.returns(stdout: Union[str, bytes] = b'', stderr: Union[str, bytes] = b'', exit_code: int = 0)`**:**
+  Specifies the static result of the command invocation. The mock will write the
+  given `stdout` and `stderr` to the corresponding streams and exit with the
+  provided `exit_code`.
 
-- `.runs(handler: Callable)`**:** Provides a powerful mechanism for dynamic behavior. The `handler` is a Python callable that will be executed by the `CmdMox` framework when the mock is invoked. The callable receives a structured `Invocation` object containing details of the call (args, `stdin`, env) and must return a tuple of `(stdout_bytes, stderr_bytes, exit_code)`. This is a significant enhancement of PyMox's callback feature, enabling stateful mocks and complex conditional logic.
+- `.runs(handler: Callable)`**:** Provides a powerful mechanism for dynamic
+  behavior. The `handler` is a Python callable that will be executed by the
+  `CmdMox` framework when the mock is invoked. The callable receives a
+  structured `Invocation` object containing details of the call (args, `stdin`,
+  env) and must return a tuple of `(stdout_bytes, stderr_bytes, exit_code)`.
+  This is a significant enhancement of PyMox's callback feature, enabling
+  stateful mocks and complex conditional logic.
 
-- `.times(count: int)`**:** Specifies the exact number of times this specific expectation is expected to be met. This is inspired by PyMox's `MultipleTimes()` modifier.
+- `.times(count: int)`**:** Specifies the exact number of times this specific
+  expectation is expected to be met. This is inspired by PyMox's
+  `MultipleTimes()` modifier.
 
-- `.in_order()`**:** Marks this expectation as part of a default, strictly ordered group. Invocations must occur in the order they were recorded. An `.any_order()` modifier can be provided for expectations where the calling order is not significant, mirroring PyMox's behavior.
+- `.in_order()`**:** Marks this expectation as part of a default, strictly
+  ordered group. Invocations must occur in the order they were recorded. An
+  `.any_order()` modifier can be provided for expectations where the calling
+  order is not significant, mirroring PyMox's behavior.
 
-To ensure `CmdMox` is a compelling replacement for `shellmock`, the following table maps the core features of `shellmock` to their more expressive `CmdMox` API equivalents, demonstrating complete functional parity.
+To ensure `CmdMox` is a compelling replacement for `shellmock`, the following
+table maps the core features of `shellmock` to their more expressive `CmdMox`
+API equivalents, demonstrating complete functional parity.
 
 **Table 1:** `shellmock` **to** `CmdMox` **Feature Mapping**
 
-<table class="not-prose border-collapse table-auto w-full" style="min-width: 50px">
-<colgroup><col style="min-width: 25px"><col style="min-width: 25px"></colgroup><tbody><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">shellmock</code> Feature (from)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Proposed <code class="code-inline">CmdMox</code> API Equivalent</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Mock an executable <code class="code-inline">cmd</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mock_cmd = mox.mock('cmd')</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Define behavior for specific args (<code class="code-inline">--match</code>)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mock_cmd.with_args('arg1', 'arg2')</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Define exit code (<code class="code-inline">--status &lt;exit_code&gt;</code>)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mock_cmd.returns(exit_code=&lt;exit_code&gt;)</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Define <code class="code-inline">stdout</code> (<code class="code-inline">--output &lt;string&gt;</code>)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mock_cmd.returns(stdout=&lt;string&gt;)</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Partial argument matching (<code class="code-inline">--type partial</code>)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mock_cmd.with_matching_args(Contains('arg'))</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Regex argument matching (<code class="code-inline">--type regex</code>)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mock_cmd.with_matching_args(Regex(r'--file=\S+'))</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Match on <code class="code-inline">stdin</code> (<code class="code-inline">--match-stdin</code>)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mock_cmd.with_stdin('some input')</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Custom behavior (<code class="code-inline">--exec &lt;command&gt;</code>)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mock_cmd.runs(lambda inv: ('output', b'', 0))</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Verify calls (<code class="code-inline">shellmock_verify</code>)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mox.verify()</code></p></td></tr></tbody>
-</table>
+| shellmock Feature (from)                    | Proposed CmdMox API Equivalent                    |
+| ------------------------------------------- | -------------------------------------------------- |
+| Mock an executable cmd                      | mock_cmd = mox.mock('cmd')                        |
+| Define behavior for specific args (--match) | mock_cmd.with_args('arg1', 'arg2')                |
+| Define exit code (--status \<exit_code\>)   | mock_cmd.returns(exit_code=\<exit_code\>)         |
+| Define stdout (--output \<string\>)         | mock_cmd.returns(stdout=\<string\>)               |
+| Partial argument matching (--type partial)  | mock_cmd.with_matching_args(Contains('arg'))      |
+| Regex argument matching (--type regex)      | mock_cmd.with_matching_args(Regex(r'--file=\S+')) |
+| Match on stdin (--match-stdin)              | mock_cmd.with_stdin('some input')                 |
+| Custom behavior (--exec \<command\>)        | mock_cmd.runs(lambda inv: ('output', b'', 0))     |
+| Verify calls (shellmock_verify)             | mox.verify()                                      |
 
 ### 2.5 The Lifecycle in Practice: `replay()` and `verify()`
 
-The `Mox` controller provides two methods that demarcate the phases of the testing lifecycle.
+The `Mox` controller provides two methods that demarcate the phases of the
+testing lifecycle.
 
-- `mox.replay()`: This method must be called after all expectations have been recorded. It signals the end of the record phase and the beginning of the replay phase. Internally, this call triggers the creation of the temporary shim directory, the generation of the shim executables, and the modification of the `PATH` environment variable. It effectively "arms" the mocking framework.
+- `mox.replay()`: This method must be called after all expectations have been
+  recorded. It signals the end of the record phase and the beginning of the
+  replay phase. Internally, this call triggers the creation of the temporary
+  shim directory, the generation of the shim executables, and the modification
+  of the `PATH` environment variable. It effectively "arms" the mocking
+  framework.
 
-- `mox.verify()`: This method must be called after the code under test has been executed. It signals the end of the replay phase. It performs the critical verification logic, comparing the journal of actual invocations against the list of recorded expectations. If any discrepancy is found—such as an unexpected call, an unfulfilled expectation, or an incorrect argument—it raises a detailed `VerificationError`. The error messages will be designed for maximum debuggability, providing a clear "diff" between the expected and actual interactions, similar to the highly-regarded error reporting of PyMox. Finally, it orchestrates the cleanup of all test artifacts, including restoring the `PATH`.
+- `mox.verify()`: This method must be called after the code under test has been
+  executed. It signals the end of the replay phase. It performs the critical
+  verification logic, comparing the journal of actual invocations against the
+  list of recorded expectations. If any discrepancy is found—such as an
+  unexpected call, an unfulfilled expectation, or an incorrect argument—it
+  raises a detailed `VerificationError`. The error messages will be designed for
+  maximum debuggability, providing a clear "diff" between the expected and
+  actual interactions, similar to the highly-regarded error reporting of PyMox.
+  Finally, it orchestrates the cleanup of all test artifacts, including
+  restoring the `PATH`.
 
 ## III. Architectural Blueprint: Inside `CmdMox`
 
-This section details the internal architecture of `CmdMox`, providing a blueprint for implementation. The design focuses on robustness, process safety, and performance, leveraging Python's strengths to overcome the limitations of existing shell-based tools.
+This section details the internal architecture of `CmdMox`, providing a
+blueprint for implementation. The design focuses on robustness, process safety,
+and performance, leveraging Python's strengths to overcome the limitations of
+existing shell-based tools.
 
 ### 3.1 The Shim Generation Engine
 
-This component is responsible for the on-the-fly creation of the executable Python shims that intercept command calls. To maximize efficiency and minimize disk I/O, the engine will not write a unique script for every mocked command.
+This component is responsible for the on-the-fly creation of the executable
+Python shims that intercept command calls. To maximize efficiency and minimize
+disk I/O, the engine will not write a unique script for every mocked command.
 
-Instead, the `CmdMox` library will contain a single, generic `shim.py` template script. When `mox.replay()` is invoked, the `Mox` controller will execute the following steps:
+Instead, the `CmdMox` library will contain a single, generic `shim.py` template
+script. When `mox.replay()` is invoked, the `Mox` controller will execute the
+following steps:
 
-1. Create a temporary directory with a unique, process-safe name (e.g., `/tmp/cmdmox-pytest-worker-1-pid-12345`).
+1. Create a temporary directory with a unique, process-safe name (e.g.,
+   `/tmp/cmdmox-pytest-worker-1-pid-12345`).
 
-2. For each unique command name being mocked (e.g., `git`, `curl`), it will create a symbolic link inside the temporary directory (e.g., `git` -&gt; `.../cmdmox/internal/shim.py`). This avoids duplicating the script's content on disk.
+2. For each unique command name being mocked (e.g., `git`, `curl`), it will
+   create a symbolic link inside the temporary directory (e.g., `git` ->
+   `.../cmdmox/internal/shim.py`). This avoids duplicating the script's content
+   on disk.
 
-3. The master `shim.py` script itself will be made executable (`chmod +x`). The operating system will follow the symlink and execute the target script.
+3. The master `shim.py` script itself will be made executable (`chmod +x`). The
+   operating system will follow the symlink and execute the target script.
 
-4. The shim script will determine which command it is impersonating by inspecting its own invocation name (`sys.argv`).
+4. The shim script will determine which command it is impersonating by
+   inspecting its own invocation name (`sys.argv`).
 
-This symlink-based approach is highly efficient and ensures that any updates or bug fixes to the shim logic only need to be applied to one central template file.
+This symlink-based approach is highly efficient and ensures that any updates or
+bug fixes to the shim logic only need to be applied to one central template
+file.
 
 ### 3.2 State Management and Inter-Process Communication (IPC)
 
-The communication between the main test process (hosting the `Mox` controller) and the numerous, short-lived shim processes is the most critical architectural element of `CmdMox`. The design moves away from the fragile, file-based communication methods used by shell-based tools in favor of a modern, robust IPC bus.
+The communication between the main test process (hosting the `Mox` controller)
+and the numerous, short-lived shim processes is the most critical architectural
+element of `CmdMox`. The design moves away from the fragile, file-based
+communication methods used by shell-based tools in favor of a modern, robust IPC
+bus.
 
-This IPC bus will be implemented using a Unix domain socket, which provides a fast and reliable stream-based communication channel between processes on the same host. The workflow is as follows:
+This IPC bus will be implemented using a Unix domain socket, which provides a
+fast and reliable stream-based communication channel between processes on the
+same host. The workflow is as follows:
 
-1. **Server Initialization:** When the `Mox` controller enters the replay phase, it starts a lightweight server thread. This thread creates a `socket.socket` listening on a unique path within the temporary shim directory (e.g., `/tmp/cmdmox.../ipc.sock`).
+1. **Server Initialization:** When the `Mox` controller enters the replay phase,
+   it starts a lightweight server thread. This thread creates a `socket.socket`
+   listening on a unique path within the temporary shim directory (e.g.,
+   `/tmp/cmdmox.../ipc.sock`).
 
-2. **Environment Setup:** The controller exports the path to this socket in an environment variable (e.g., `CMOX_IPC_SOCKET`). This variable is inherited by any child processes, including the code under test and, consequently, the shims it invokes.
+2. **Environment Setup:** The controller exports the path to this socket in an
+   environment variable (e.g., `CMOX_IPC_SOCKET`). This variable is inherited by
+   any child processes, including the code under test and, consequently, the
+   shims it invokes.
 
-3. **Shim Connection:** When a shim is executed by the OS, its first action is to read the `CMOX_IPC_SOCKET` environment variable and connect to the listening server thread in the main test process.
+3. **Shim Connection:** When a shim is executed by the OS, its first action is
+   to read the `CMOX_IPC_SOCKET` environment variable and connect to the
+   listening server thread in the main test process.
 
-4. **Invocation Reporting:** The shim gathers all relevant invocation data: the command name, the list of arguments (`sys.argv[1:]`), the complete content of its standard input, and a snapshot of its current environment variables. It serializes this data into a structured format like JSON and sends it over the socket to the server.
+4. **Invocation Reporting:** The shim gathers all relevant invocation data: the
+   command name, the list of arguments (`sys.argv[1:]`), the complete content of
+   its standard input, and a snapshot of its current environment variables. It
+   serializes this data into a structured format like JSON and sends it over the
+   socket to the server.
 
-5. **Server-Side Processing:** The server thread in the main process receives the JSON payload. It deserializes it into an `Invocation` object and records it in the in-memory Invocation Journal. It then searches its list of `Expectation` objects to find a match for this invocation.
+5. **Server-Side Processing:** The server thread in the main process receives
+   the JSON payload. It deserializes it into an `Invocation` object and records
+   it in the in-memory Invocation Journal. It then searches its list of
+   `Expectation` objects to find a match for this invocation.
 
-6. **Response Delivery:** Once a matching expectation is found, the server determines the prescribed response. If it's a static `.returns()` value, it serializes this data and sends it back to the shim. If it's a dynamic `.runs(handler)`, the server thread executes the handler function (which is in the same process and has access to all test state) and sends its result back.
+6. **Response Delivery:** Once a matching expectation is found, the server
+   determines the prescribed response. If it's a static `.returns()` value, it
+   serializes this data and sends it back to the shim. If it's a dynamic
+   `.runs(handler)`, the server thread executes the handler function (which is
+   in the same process and has access to all test state) and sends its result
+   back.
 
-7. **Shim Action:** The shim receives the response payload from the server. It writes the `stdout` and `stderr` data to its own standard streams and then terminates with the specified `exit_code`.
+7. **Shim Action:** The shim receives the response payload from the server. It
+   writes the `stdout` and `stderr` data to its own standard streams and then
+   terminates with the specified `exit_code`.
 
-This socket-based IPC architecture is the key technical differentiator for `CmdMox`. It is transactional, inherently process-safe, and allows for the exchange of rich, complex data structures, providing a foundation for advanced features that are infeasible with file-based logging.
+This socket-based IPC architecture is the key technical differentiator for
+`CmdMox`. It is transactional, inherently process-safe, and allows for the
+exchange of rich, complex data structures, providing a foundation for advanced
+features that are infeasible with file-based logging.
 
 ### 3.3 The Environment Manager
 
-This component will be implemented as a robust, exception-safe context manager that handles all modifications to the process environment.
+This component will be implemented as a robust, exception-safe context manager
+that handles all modifications to the process environment.
 
 - On `__enter__`:
 
@@ -212,128 +419,219 @@ This component will be implemented as a robust, exception-safe context manager t
 
   3. It will prepend the shim directory's path to `os.environ`.
 
-  4. It will set any other necessary environment variables for the IPC mechanism, such as `CMOX_IPC_SOCKET`.
+  4. It will set any other necessary environment variables for the IPC
+     mechanism, such as `CMOX_IPC_SOCKET`.
 
 - On `__exit__`:
 
-  1. It will execute in a `finally` block to guarantee cleanup, even if the test fails with an exception.
+  1. It will execute in a `finally` block to guarantee cleanup, even if the test
+     fails with an exception.
 
-  2. It will restore the original `PATH` and unset any `CmdMox`-specific environment variables.
+  2. It will restore the original `PATH` and unset any `CmdMox`-specific
+     environment variables.
 
-  3. It will perform a recursive deletion of the temporary shim directory and all its contents (symlinks and the IPC socket).
+  3. It will perform a recursive deletion of the temporary shim directory and
+     all its contents (symlinks and the IPC socket).
 
 The manager is not reentrant. Nested usage would overwrite the saved environment
-snapshot, so attempts to use it recursively will raise ``RuntimeError``.
-Instead of clearing ``os.environ`` on exit, the manager restores only those
-variables that changed and removes any that were added. This approach avoids
-disrupting other threads that might rely on the environment remaining mostly
-stable.
+snapshot, so attempts to use it recursively will raise `RuntimeError`. Instead
+of clearing `os.environ` on exit, the manager restores only those variables that
+changed and removes any that were added. This approach avoids disrupting other
+threads that might rely on the environment remaining mostly stable.
 
-This rigorous management ensures that each test runs in a perfectly isolated environment and leaves no artifacts behind, a critical requirement for a reliable testing framework.
+This rigorous management ensures that each test runs in a perfectly isolated
+environment and leaves no artifacts behind, a critical requirement for a
+reliable testing framework.
 
 ### 3.4 The Invocation Journal
 
-The Invocation Journal is a simple but crucial in-memory data structure within each `Mox` controller instance. It will likely be implemented as a `collections.deque` or a standard `list`. Its sole purpose is to store a chronological record of all command calls that occurred during the replay phase.
+The Invocation Journal is a simple but crucial in-memory data structure within
+each `Mox` controller instance. It will likely be implemented as a
+`collections.deque` or a standard `list`. Its sole purpose is to store a
+chronological record of all command calls that occurred during the replay phase.
 
-Each time the IPC server thread receives an invocation report from a shim, it constructs a structured `Invocation` object (e.g., a dataclass or `NamedTuple`) containing the command name, arguments, `stdin`, and environment. This object is then appended to the journal. The `verify()` method uses this journal as the definitive record of what actually happened, comparing it against the predefined expectations to detect any discrepancies.
+Each time the IPC server thread receives an invocation report from a shim, it
+constructs a structured `Invocation` object (e.g., a dataclass or `NamedTuple`)
+containing the command name, arguments, `stdin`, and environment. This object is
+then appended to the journal. The `verify()` method uses this journal as the
+definitive record of what actually happened, comparing it against the predefined
+expectations to detect any discrepancies.
 
 ## IV. Feature Deep Dive: Stubbing
 
-This section details the implementation of the simplest form of test double: the stub. Stubs are essential for satisfying dependencies of the system under test without coupling the test to the implementation details of those dependencies.
+This section details the implementation of the simplest form of test double: the
+stub. Stubs are essential for satisfying dependencies of the system under test
+without coupling the test to the implementation details of those dependencies.
 
 ### 4.1 Simple, "Fire-and-Forget" Replacements
 
-The primary use case for a stub is to provide a fixed, predictable response. An API call like `mox.stub('grep').returns(stdout='match', exit_code=0)` initiates the following process:
+The primary use case for a stub is to provide a fixed, predictable response. An
+API call like `mox.stub('grep').returns(stdout='match', exit_code=0)` initiates
+the following process:
 
-1. **Configuration:** The call creates a `Stub` configuration object within the `Mox` controller. This object stores the command name (`grep`) and the associated response data (stdout, stderr, exit code).
+1. **Configuration:** The call creates a `Stub` configuration object within the
+   `Mox` controller. This object stores the command name (`grep`) and the
+   associated response data (stdout, stderr, exit code).
 
-2. **Replay Phase:** During `mox.replay()`, this configuration is made available to the IPC server thread. It might be stored in a simple dictionary mapping command names to stub configurations.
+2. **Replay Phase:** During `mox.replay()`, this configuration is made available
+   to the IPC server thread. It might be stored in a simple dictionary mapping
+   command names to stub configurations.
 
-3. **Invocation:** When the code under test executes `grep`, the `grep` shim is invoked. The shim connects to the IPC server and reports its invocation.
+3. **Invocation:** When the code under test executes `grep`, the `grep` shim is
+   invoked. The shim connects to the IPC server and reports its invocation.
 
-4. **Response:** The IPC server looks up `grep` in its stub configurations. It finds the defined behavior and sends a JSON response like `{'stdout': 'match', 'stderr': '', 'exit_code': 0}` back to the shim.
+4. **Response:** The IPC server looks up `grep` in its stub configurations. It
+   finds the defined behavior and sends a JSON response like
+   `{'stdout': 'match', 'stderr': '', 'exit_code': 0}` back to the shim.
 
-5. **Execution:** The shim receives this payload, prints "match" to its `stdout`, and exits with status 0.
+5. **Execution:** The shim receives this payload, prints "match" to its
+   `stdout`, and exits with status 0.
 
-6. **Verification:** During `mox.verify()`, stubs are not checked. If the `grep` command is never called, the test still passes. This "fire-and-forget" nature is the defining characteristic of a stub.
+6. **Verification:** During `mox.verify()`, stubs are not checked. If the `grep`
+   command is never called, the test still passes. This "fire-and-forget" nature
+   is the defining characteristic of a stub.
 
 ### 4.2 Advanced Stubs: Callable Handlers
 
-To support dynamic or stateful behavior, `CmdMox` allows stubs to be configured with a callable handler via the `.runs()` method, for example: `mox.stub('date').runs(my_date_handler)`.
+To support dynamic or stateful behavior, `CmdMox` allows stubs to be configured
+with a callable handler via the `.runs()` method, for example:
+`mox.stub('date').runs(my_date_handler)`.
 
 The implementation of this feature leverages the IPC architecture:
 
-1. The `my_date_handler` callable itself is a Python object that exists only in the main test process. It is *not* serialized or sent to the shim process.
+1. The `my_date_handler` callable itself is a Python object that exists only in
+   the main test process. It is *not* serialized or sent to the shim process.
 
-2. When the `date` shim is invoked and reports its call to the IPC server, the server identifies that the corresponding stub is configured with a `.runs()` handler.
+2. When the `date` shim is invoked and reports its call to the IPC server, the
+   server identifies that the corresponding stub is configured with a `.runs()`
+   handler.
 
-3. The IPC server thread—which runs within the main test process and therefore has direct access to `my_date_handler`—executes the handler. It passes the structured `Invocation` object as an argument to the handler.
+3. The IPC server thread—which runs within the main test process and therefore
+   has direct access to `my_date_handler`—executes the handler. It passes the
+   structured `Invocation` object as an argument to the handler.
 
-4. The handler performs its logic (which can involve accessing or modifying state within the test function's scope) and returns a result tuple: `(stdout_bytes, stderr_bytes, exit_code)`.
+4. The handler performs its logic (which can involve accessing or modifying
+   state within the test function's scope) and returns a result tuple:
+   `(stdout_bytes, stderr_bytes, exit_code)`.
 
-5. The IPC server serializes this dynamic result and sends it back to the `date` shim, which then acts accordingly.
+5. The IPC server serializes this dynamic result and sends it back to the `date`
+   shim, which then acts accordingly.
 
-This powerful feature enables the creation of sophisticated stubs that can, for instance, return different values on subsequent calls, simulate I/O operations, or interact with other components of the test setup, far exceeding the capabilities of static mocks defined in shell scripts.
+This powerful feature enables the creation of sophisticated stubs that can, for
+instance, return different values on subsequent calls, simulate I/O operations,
+or interact with other components of the test setup, far exceeding the
+capabilities of static mocks defined in shell scripts.
 
 ## V. Feature Deep Dive: Mocking
 
-This section details the implementation of the library's core feature: strict, verifiable mocking. Mocks are the foundation of the "Record-Replay-Verify" paradigm and are used to assert that the system under test interacts with its external dependencies in a precisely defined manner.
+This section details the implementation of the library's core feature: strict,
+verifiable mocking. Mocks are the foundation of the "Record-Replay-Verify"
+paradigm and are used to assert that the system under test interacts with its
+external dependencies in a precisely defined manner.
 
 ### 5.1 The Argument Matching Engine and Comparators
 
-To provide flexibility beyond exact argument matching, `CmdMox` will include a rich set of comparator objects, directly inspired by the comparators in PyMox. These objects allow for defining expectations based on patterns and properties rather than just literal values.
+To provide flexibility beyond exact argument matching, `CmdMox` will include a
+rich set of comparator objects, directly inspired by the comparators in PyMox.
+These objects allow for defining expectations based on patterns and properties
+rather than just literal values.
 
 The library will provide a suite of built-in comparators:
 
 - `cmdmox.Any()`: Matches any single argument at a given position.
 
-- `cmdmox.IsA(type)`: Matches any argument that is an instance of the given Python type (after basic parsing).
+- `cmdmox.IsA(type)`: Matches any argument that is an instance of the given
+  Python type (after basic parsing).
 
-- `cmdmox.Regex(pattern: str)`: Matches any argument that conforms to the given regular expression.
+- `cmdmox.Regex(pattern: str)`: Matches any argument that conforms to the given
+  regular expression.
 
-- `cmdmox.Contains(substring: str)`: Matches any argument that contains the given substring.
+- `cmdmox.Contains(substring: str)`: Matches any argument that contains the
+  given substring.
 
-- `cmdmox.StartsWith(prefix: str)`: Matches any argument that starts with the given prefix.
+- `cmdmox.StartsWith(prefix: str)`: Matches any argument that starts with the
+  given prefix.
 
-- `cmdmox.Predicate(callable)`: The most flexible comparator. It accepts a callable that takes the argument as input and returns `True` for a match and `False` otherwise.
+- `cmdmox.Predicate(callable)`: The most flexible comparator. It accepts a
+  callable that takes the argument as input and returns `True` for a match and
+  `False` otherwise.
 
-When a developer defines an expectation using `with_matching_args(IsA(str), Regex(r'--file=\S+'))`, these comparator objects are stored as part of the `Expectation` configuration. During the replay phase, when the IPC server receives an invocation from a shim, it iterates through its list of recorded expectations. For each expectation, it compares the incoming arguments against the stored comparators to determine if there is a match. This engine is the key to writing flexible yet precise tests.
+When a developer defines an expectation using
+`with_matching_args(IsA(str), Regex(r'--file=\S+'))`, these comparator objects
+are stored as part of the `Expectation` configuration. During the replay phase,
+when the IPC server receives an invocation from a shim, it iterates through its
+list of recorded expectations. For each expectation, it compares the incoming
+arguments against the stored comparators to determine if there is a match. This
+engine is the key to writing flexible yet precise tests.
 
 ### 5.2 Verification Logic: The Heart of `mox.verify()`
 
-The `mox.verify()` method encapsulates the most complex logic in the library. Its purpose is to algorithmically reconcile the list of predefined `Expectation` objects with the chronological `InvocationJournal` collected during the replay phase. A mismatch of any kind constitutes a test failure.
+The `mox.verify()` method encapsulates the most complex logic in the library.
+Its purpose is to algorithmically reconcile the list of predefined `Expectation`
+objects with the chronological `InvocationJournal` collected during the replay
+phase. A mismatch of any kind constitutes a test failure.
 
 The verification algorithm will perform several critical checks:
 
-1. **Unexpected Invocations:** It iterates through the `InvocationJournal`. For each actual invocation, it checks if it matches any of the recorded expectations. If an invocation occurs that does not match *any* unfulfilled expectation, it signifies an unexpected command call. This immediately raises an `UnexpectedCommandError`, analogous to PyMox's `UnexpectedMethodCallError`. The error message will clearly state the unexpected command that was called.
+1. **Unexpected Invocations:** It iterates through the `InvocationJournal`. For
+   each actual invocation, it checks if it matches any of the recorded
+   expectations. If an invocation occurs that does not match *any* unfulfilled
+   expectation, it signifies an unexpected command call. This immediately raises
+   an `UnexpectedCommandError`, analogous to PyMox's
+   `UnexpectedMethodCallError`. The error message will clearly state the
+   unexpected command that was called.
 
-2. **Unfulfilled Expectations:** After checking all actual invocations, the algorithm checks if any `Expectation` objects remain unfulfilled. If an expectation was recorded but never matched by an actual invocation, it raises an `UnfulfilledExpectationError`. This is equivalent to PyMox's "Expected methods never called" error and is critical for ensuring that the code under test is actually exercising its dependencies as intended.
+2. **Unfulfilled Expectations:** After checking all actual invocations, the
+   algorithm checks if any `Expectation` objects remain unfulfilled. If an
+   expectation was recorded but never matched by an actual invocation, it raises
+   an `UnfulfilledExpectationError`. This is equivalent to PyMox's "Expected
+   methods never called" error and is critical for ensuring that the code under
+   test is actually exercising its dependencies as intended.
 
-3. **Incorrect Call Counts:** For expectations defined with `.times(N)`, the verifier ensures that the expectation was met exactly `N` times. If it was met more or fewer times, a `VerificationError` is raised.
+3. **Incorrect Call Counts:** For expectations defined with `.times(N)`, the
+   verifier ensures that the expectation was met exactly `N` times. If it was
+   met more or fewer times, a `VerificationError` is raised.
 
-4. **Order Violations:** For expectations marked with `.in_order()`, the verifier ensures that they were met in the same sequence in which they were recorded. It maintains a pointer to the "current" expected ordered call and advances it only when a match is found. An out-of-order call is treated as an unexpected invocation.
+4. **Order Violations:** For expectations marked with `.in_order()`, the
+   verifier ensures that they were met in the same sequence in which they were
+   recorded. It maintains a pointer to the "current" expected ordered call and
+   advances it only when a match is found. An out-of-order call is treated as an
+   unexpected invocation.
 
-The error messages generated by `verify()` are a key part of the user experience. They will be meticulously crafted to provide maximum diagnostic information, showing the expected call (including arguments and comparators) and contrasting it with the actual call that was received, or noting its absence entirely.
+The error messages generated by `verify()` are a key part of the user
+experience. They will be meticulously crafted to provide maximum diagnostic
+information, showing the expected call (including arguments and comparators) and
+contrasting it with the actual call that was received, or noting its absence
+entirely.
 
 ## VI. Feature Deep Dive: Spying
 
-Spying provides a more flexible, observational approach to testing interactions, complementing the strictness of mocks. Spies are useful for when the exact details of an interaction are not critical to the test's success, but the developer still wants to assert that a call was made.
+Spying provides a more flexible, observational approach to testing interactions,
+complementing the strictness of mocks. Spies are useful for when the exact
+details of an interaction are not critical to the test's success, but the
+developer still wants to assert that a call was made.
 
 ### 6.1 The Spy API and Invocation History
 
-Creating a spy is straightforward: `spy = mox.spy('curl')`. This registers `curl` as a spied command. By default, a spy will act like a stub that does nothing and returns a successful exit code. Its primary purpose is to record calls.
+Creating a spy is straightforward: `spy = mox.spy('curl')`. This registers
+`curl` as a spied command. By default, a spy will act like a stub that does
+nothing and returns a successful exit code. Its primary purpose is to record
+calls.
 
-After `mox.verify()` has been called (which for spies simply confirms no unexpected errors occurred and performs cleanup), the test can inspect the spy object to access its recorded history. The spy object will expose a public API for this purpose:
+After `mox.verify()` has been called (which for spies simply confirms no
+unexpected errors occurred and performs cleanup), the test can inspect the spy
+object to access its recorded history. The spy object will expose a public API
+for this purpose:
 
-- `spy.call_count`: An integer representing the total number of times the command was called.
+- `spy.call_count`: An integer representing the total number of times the
+  command was called.
 
-- `spy.invocations`: A list of `Invocation` objects, where each object provides structured access to a single call's details.
+- `spy.invocations`: A list of `Invocation` objects, where each object provides
+  structured access to a single call's details.
 
 *Example Assertion-Style Verification:*
 
-Python
-
-```
+```python
 def test_downloader_uses_correct_user_agent(mox):
     spy = mox.spy('curl')
     spy.returns(stdout='Success') # Spies can also be given behavior
@@ -349,43 +647,77 @@ def test_downloader_uses_correct_user_agent(mox):
     assert 'User-Agent: MyDownloader/1.0' in invocation.env
 ```
 
-This style of verification is less rigid than mocking and is preferred when the goal is simply to check that "a call happened with these properties" rather than enforcing a strict sequence of interactions.
+This style of verification is less rigid than mocking and is preferred when the
+goal is simply to check that "a call happened with these properties" rather than
+enforcing a strict sequence of interactions.
 
 ### 6.2 Passthrough Spies: The "Record Mode"
 
-A powerful extension of the spy concept is the "passthrough" spy. This feature enables a "record and replay" workflow for test generation, an incredibly useful tool for bootstrapping tests for legacy systems or complex command-line interactions, similar in spirit to the record mode of `bash_placebo`.
+A powerful extension of the spy concept is the "passthrough" spy. This feature
+enables a "record and replay" workflow for test generation, an incredibly useful
+tool for bootstrapping tests for legacy systems or complex command-line
+interactions, similar in spirit to the record mode of `bash_placebo`.
 
-A passthrough spy is created with `spy = mox.spy('aws').passthrough()`. The implementation leverages the IPC architecture in a unique way:
+A passthrough spy is created with `spy = mox.spy('aws').passthrough()`. The
+implementation leverages the IPC architecture in a unique way:
 
-1. When the `aws` shim is invoked, it reports the call to the IPC server as usual.
+1. When the `aws` shim is invoked, it reports the call to the IPC server as
+   usual.
 
-2. The IPC server identifies the spy is in passthrough mode. Instead of returning a canned response, it instructs the shim to execute the *real* command. To do this, the server provides the shim with the path to the real executable, which it finds by searching the original `PATH` (which was saved by the Environment Manager).
+2. The IPC server identifies the spy is in passthrough mode. Instead of
+   returning a canned response, it instructs the shim to execute the *real*
+   command. To do this, the server provides the shim with the path to the real
+   executable, which it finds by searching the original `PATH` (which was saved
+   by the Environment Manager).
 
-3. The shim process uses `subprocess.run` or a similar mechanism to execute the real `aws` command with the original arguments and `stdin`. It captures the real command's `stdout`, `stderr`, and `exit_code`.
+3. The shim process uses `subprocess.run` or a similar mechanism to execute the
+   real `aws` command with the original arguments and `stdin`. It captures the
+   real command's `stdout`, `stderr`, and `exit_code`.
 
-4. The shim then sends a second message to the IPC server containing this captured output.
+4. The shim then sends a second message to the IPC server containing this
+   captured output.
 
-5. The server combines the initial invocation data (what went in) with the captured results (what came out) into a complete `Invocation` object and stores it in the spy's history. It also sends the captured results back to the shim, which then reproduces them as its own output.
+5. The server combines the initial invocation data (what went in) with the
+   captured results (what came out) into a complete `Invocation` object and
+   stores it in the spy's history. It also sends the captured results back to
+   the shim, which then reproduces them as its own output.
 
-The immediate benefit is that a test can run against a real system while `CmdMox` transparently records every interaction. The long-term implication is the potential for a powerful test generation utility. A developer could run a complex script under a `CmdMox` recorder, which would use passthrough spies to capture all external command interactions. The recorder could then automatically generate a complete, self-contained `pytest` file, with all the real interactions converted into `mox.mock(...).returns(...)` definitions. This would dramatically lower the barrier to entry for placing legacy command-line tools under test.
+The immediate benefit is that a test can run against a real system while
+`CmdMox` transparently records every interaction. The long-term implication is
+the potential for a powerful test generation utility. A developer could run a
+complex script under a `CmdMox` recorder, which would use passthrough spies to
+capture all external command interactions. The recorder could then automatically
+generate a complete, self-contained `pytest` file, with all the real
+interactions converted into `mox.mock(...).returns(...)` definitions. This would
+dramatically lower the barrier to entry for placing legacy command-line tools
+under test.
 
 ## VII. Advanced Topics and Implementation Considerations
 
-This section addresses known complexities, edge cases, and non-functional requirements that the implementation must handle to be considered a robust and professional-grade library.
+This section addresses known complexities, edge cases, and non-functional
+requirements that the implementation must handle to be considered a robust and
+professional-grade library.
 
 ### 7.1 Handling Complex Shell Interactions: Pipelines and Redirection
 
-A critical aspect to define is the library's scope regarding shell syntax. `PATH` hijacking, as a mechanism, intercepts the execution of individual commands. It does not, and cannot, intercept or interpret the functionality of the shell itself, such as pipelines (`|`), I/O redirection (`>`, `<`), or process substitution (`<()`).
+A critical aspect to define is the library's scope regarding shell syntax.
+`PATH` hijacking, as a mechanism, intercepts the execution of individual
+commands. It does not, and cannot, intercept or interpret the functionality of
+the shell itself, such as pipelines (`|`), I/O redirection (`>`, `<`), or
+process substitution (`<()`).
 
-Therefore, the design explicitly states that `CmdMox` mocks the *tools*, not the *shell* that glues them together. When a user needs to test a script that contains a command like `grep foo file.txt | sort -r`, the test is not on the pipeline itself, but on the behavior of `grep` and `sort`.
+Therefore, the design explicitly states that `CmdMox` mocks the *tools*, not the
+*shell* that glues them together. When a user needs to test a script that
+contains a command like `grep foo file.txt | sort -r`, the test is not on the
+pipeline itself, but on the behavior of `grep` and `sort`.
 
-The user would test this by executing the full command line (e.g., via `subprocess.run(..., shell=True)`) and setting up mocks for each individual command in the pipeline:
+The user would test this by executing the full command line (e.g., via
+`subprocess.run(..., shell=True)`) and setting up mocks for each individual
+command in the pipeline:
 
 *Example Pipeline Test:*
 
-Python
-
-```
+```python
 def test_pipeline_logic(mox):
     # Mock the first command in the pipe
     mox.mock('grep').with_args('foo', 'file.txt').returns(stdout='c\na\nb\n')
@@ -402,21 +734,40 @@ def test_pipeline_logic(mox):
     mox.verify()
 ```
 
-This approach correctly tests that the application invokes the constituent commands as expected. This limitation and the proper testing pattern must be clearly documented for users.
+This approach correctly tests that the application invokes the constituent
+commands as expected. This limitation and the proper testing pattern must be
+clearly documented for users.
 
 ### 7.2 Managing the Mocked Environment
 
-Applications often depend on environment variables. `CmdMox` must provide a way to control the environment in which the mocked commands execute. The fluent API will include a `.with_env(vars: dict)` method on `MockCommand`, `StubCommand`, and `SpyCommand` objects.
+Applications often depend on environment variables. `CmdMox` must provide a way
+to control the environment in which the mocked commands execute. The fluent API
+will include a `.with_env(vars: dict)` method on `MockCommand`, `StubCommand`,
+and `SpyCommand` objects.
 
-When this method is used, the provided dictionary of environment variables is stored with the expectation. This data is then passed to the shim as part of the response payload from the IPC server. Before executing its primary action (e.g., printing `stdout` or running a handler), the shim script will update its own environment using `os.environ.update(vars)`. This ensures that any further processes spawned by a `.runs()` handler, for example, will inherit the correct, mock-specific environment.
+When this method is used, the provided dictionary of environment variables is
+stored with the expectation. This data is then passed to the shim as part of the
+response payload from the IPC server. Before executing its primary action (e.g.,
+printing `stdout` or running a handler), the shim script will update its own
+environment using `os.environ.update(vars)`. This ensures that any further
+processes spawned by a `.runs()` handler, for example, will inherit the correct,
+mock-specific environment.
 
 ### 7.3 Concurrency and Parallelization (`pytest-xdist`)
 
-Modern test suites are frequently run in parallel using tools like `pytest-xdist` to reduce execution time. `CmdMox` must be designed from the ground up to be fully compatible with parallel execution, where each test worker runs in a separate process.
+Modern test suites are frequently run in parallel using tools like
+`pytest-xdist` to reduce execution time. `CmdMox` must be designed from the
+ground up to be fully compatible with parallel execution, where each test worker
+runs in a separate process.
 
-The proposed IPC-based architecture is inherently conducive to safe parallelization. The file-based communication used by shell-based mockers would require complex file locking or intricate namespacing schemes to avoid race conditions between parallel workers. `CmdMox` avoids this entirely.
+The proposed IPC-based architecture is inherently conducive to safe
+parallelization. The file-based communication used by shell-based mockers would
+require complex file locking or intricate namespacing schemes to avoid race
+conditions between parallel workers. `CmdMox` avoids this entirely.
 
-The `pytest` fixture will be designed to be "xdist-aware." It can access the worker ID provided by `pytest-xdist` (e.g., `gw0`, `gw1`). This ID will be incorporated into the names of the temporary directory and the IPC socket:
+The `pytest` fixture will be designed to be "xdist-aware." It can access the
+worker ID provided by `pytest-xdist` (e.g., `gw0`, `gw1`). This ID will be
+incorporated into the names of the temporary directory and the IPC socket:
 
 - Worker 0 Directory: `/tmp/cmdmox-gw0-pid12345/`
 
@@ -426,32 +777,79 @@ The `pytest` fixture will be designed to be "xdist-aware." It can access the wor
 
 - Worker 1 Socket: `/tmp/cmdmox-gw1-pid54321/ipc.sock`
 
-Because each worker process gets its own `Mox` instance, its own unique shim directory, and its own private IPC socket, there is no shared state between workers. Each test runs in a completely isolated `CmdMox` environment, eliminating the possibility of cross-test interference and ensuring correctness and reliability in parallel test runs.
+Because each worker process gets its own `Mox` instance, its own unique shim
+directory, and its own private IPC socket, there is no shared state between
+workers. Each test runs in a completely isolated `CmdMox` environment,
+eliminating the possibility of cross-test interference and ensuring correctness
+and reliability in parallel test runs.
 
-**Table 2: Fluent API Method Reference**
+<!-- markdownlint-disable MD013 -->
+#### Table 2: Fluent API Method Reference
 
-This table provides a quick, scannable reference for the core Domain-Specific Language (DSL) used to build expectations.
+This table provides a quick, scannable reference for the core Domain-Specific
+Language (DSL) used to build expectations.
 
-<table class="not-prose border-collapse table-auto w-full" style="min-width: 75px">
-<colgroup><col style="min-width: 25px"><col style="min-width: 25px"><col style="min-width: 25px"></colgroup><tbody><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Method</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Purpose</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Example</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.with_args(*args)</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Specifies the exact arguments the command must be called with.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.with_args('ls', '-l', '/tmp')</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.with_matching_args(*matchers)</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Specifies flexible argument matchers (e.g., comparators).</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.with_matching_args(IsA(str), Regex(r'--foo=\d+'))</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.with_stdin(data)</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Specifies expected <code class="code-inline">stdin</code> content. Can use strings or comparators.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.with_stdin(Contains('payload'))</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.with_env(vars)</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Specifies environment variables for the command's context.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.with_env({'API_KEY': 'secret'})</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.returns(stdout, stderr, exit_code)</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Defines the static output and exit code of the mocked command.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.returns(stdout=b'OK', exit_code=0)</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.runs(handler)</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Provides a callable for dynamic, stateful behavior.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.runs(my_handler_func)</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.times(count)</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Sets the expected number of times the command will be called.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.times(2)</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.in_order()</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Marks this expectation as part of an ordered sequence.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.in_order()</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">.passthrough()</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>(Spy only) Executes the real command and records the interaction.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mox.spy('ssh').passthrough()</code></p></td></tr></tbody>
-</table>
+| Method                              | Purpose                                               | Example                                            |
+| ----------------------------------- | ----------------------------------------------------- | -------------------------------------------------- |
+| .with_args(*args)                   | Specifies the exact arguments the command must be called with.    | .with_args('ls', '-l', '/tmp')                     |
+| .with_matching_args(*matchers)      | Specifies flexible argument matchers (e.g., comparators).         | .with_matching_args(IsA(str), Regex(r'--foo=\\d+')) |
+| .with_stdin(data)                   | Specifies expected stdin content. Can use strings or comparators. | .with_stdin(Contains('payload'))                   |
+| .with_env(vars)                     | Specifies environment variables for the command's context.        | .with_env({'API_KEY': 'secret'})                   |
+| .returns(stdout, stderr, exit_code) | Defines the static output and exit code of the mocked command.    | .returns(stdout=b'OK', exit_code=0)                |
+| .runs(handler)                      | Provides a callable for dynamic, stateful behavior.               | .runs(my_handler_func)                             |
+| .times(count)                       | Sets the expected number of times the command will be called.     | .times(2)                                          |
+| .in_order()                         | Marks this expectation as part of an ordered sequence.            | .in_order()                                        |
+| .passthrough()                      | (Spy only) Executes the real command and records the interaction. | mox.spy('ssh').passthrough()                       |
+<!-- markdownlint-enable MD013 -->
 
 ## VIII. Conclusion and Future Roadmap
 
 ### 8.1 Summary of the `CmdMox` Design
 
-This document outlines a comprehensive design for `CmdMox`, a Python library poised to significantly improve the testing landscape for command-line tools and scripts. By synthesizing the ergonomic, "Record-Replay-Verify" paradigm of PyMox with a robust `PATH`-hijacking mechanism, `CmdMox` offers a powerful and developer-friendly solution.
+This document outlines a comprehensive design for `CmdMox`, a Python library
+poised to significantly improve the testing landscape for command-line tools and
+scripts. By synthesizing the ergonomic, "Record-Replay-Verify" paradigm of PyMox
+with a robust `PATH`-hijacking mechanism, `CmdMox` offers a powerful and
+developer-friendly solution.
 
-The key architectural innovations—the use of Python shims over shell scripts and the implementation of a sophisticated, socket-based IPC bus—liberate the framework from the brittleness of file-based communication. This design provides a solid foundation for reliable, process-safe, and highly-featured test doubles. The fluent, chainable API ensures that tests are not only effective but also readable and maintainable. The inclusion of stubs, strict mocks, and observational spies (including a passthrough mode) provides a complete toolkit for tackling a wide range of testing scenarios.
+The key architectural innovations—the use of Python shims over shell scripts and
+the implementation of a sophisticated, socket-based IPC bus—liberate the
+framework from the brittleness of file-based communication. This design provides
+a solid foundation for reliable, process-safe, and highly-featured test doubles.
+The fluent, chainable API ensures that tests are not only effective but also
+readable and maintainable. The inclusion of stubs, strict mocks, and
+observational spies (including a passthrough mode) provides a complete toolkit
+for tackling a wide range of testing scenarios.
 
 ### 8.2 Future Roadmap
 
-While the design for version 1.0 is comprehensive for Linux, FreeBSD, and Darwin environments, several avenues for future expansion exist.
+While the design for version 1.0 is comprehensive for Linux, FreeBSD, and Darwin
+environments, several avenues for future expansion exist.
 
-- **Windows Support:** This is the most significant potential extension. It would constitute a major architectural undertaking, as the `PATH` interception mechanism is fundamentally different on Windows. It would require generating `.bat` or `.exe` shims, handling a different `PATH` separator, and likely using a different IPC mechanism (e.g., named pipes) instead of Unix domain sockets. This would be a target for a version 2.0 release.
+- **Windows Support:** This is the most significant potential extension. It
+  would constitute a major architectural undertaking, as the `PATH` interception
+  mechanism is fundamentally different on Windows. It would require generating
+  `.bat` or `.exe` shims, handling a different `PATH` separator, and likely
+  using a different IPC mechanism (e.g., named pipes) instead of Unix domain
+  sockets. This would be a target for a version 2.0 release.
 
-- **Shell Function Mocking:** The current design explicitly excludes the mocking of shell functions defined within a script, a notoriously difficult problem. Future research could explore techniques to achieve this, such as pre-processing the script under test to replace target function definitions with calls to a `cmdmox-shim` command before sourcing it. This remains a complex area with many edge cases.
+- **Shell Function Mocking:** The current design explicitly excludes the mocking
+  of shell functions defined within a script, a notoriously difficult problem.
+  Future research could explore techniques to achieve this, such as
+  pre-processing the script under test to replace target function definitions
+  with calls to a `cmdmox-shim` command before sourcing it. This remains a
+  complex area with many edge cases.
 
-- **Performance Optimizations:** For test suites with extremely high-frequency command calls, the performance of the JSON serialization and socket communication could become a factor. Future versions could investigate higher-performance IPC strategies, such as using a binary serialization format like MessagePack or exploring shared memory for certain use cases.
+- **Performance Optimizations:** For test suites with extremely high-frequency
+  command calls, the performance of the JSON serialization and socket
+  communication could become a factor. Future versions could investigate
+  higher-performance IPC strategies, such as using a binary serialization format
+  like MessagePack or exploring shared memory for certain use cases.
 
-- **Test Generation Utility:** The "passthrough spy" feature is a stepping stone to a powerful developer tool. A high-priority post-1.0 feature would be to build a standalone utility that leverages this "record mode." This tool would execute a target script, capture all its external command interactions, and automatically generate a complete `pytest` test file with all the necessary `CmdMox` mock definitions, dramatically accelerating the adoption of testing for existing, legacy codebases.
+- **Test Generation Utility:** The "passthrough spy" feature is a stepping stone
+  to a powerful developer tool. A high-priority post-1.0 feature would be to
+  build a standalone utility that leverages this "record mode." This tool would
+  execute a target script, capture all its external command interactions, and
+  automatically generate a complete `pytest` test file with all the necessary
+  `CmdMox` mock definitions, dramatically accelerating the adoption of testing
+  for existing, legacy codebases.


### PR DESCRIPTION
## Summary
- run mdformat-all
- rewrap Markdown content in docs and style guidelines
- fix heading levels and fenced block languages

## Testing
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_686c39c4a47483229be3403f604d6dfd