### PR TITLE
Fix default factory example

### DIFF
--- a/.rules/python-typing.md
+++ b/.rules/python-typing.md
@@ -104,8 +104,9 @@ Allow generic classes/functions to fall back to default types when no specific t
 T = typing.TypeVar("T", default=int)
 
 class Box[T]:
-    def __init__(self, value: T = T()):
-        self.value = value
+    def __init__(self, value: T | None = None):
+        # Fallback to the TypeVar default (int in this example)
+        self.value: T = value if value is not None else int()  # type: ignore[arg-type]
 ```
 
 This makes APIs more ergonomic while retaining type safety.


### PR DESCRIPTION
## Summary
- clarify TypeVar default usage in python typing guidelines

## Testing
- `make markdownlint` *(fails: MD041/first-line-heading, MD013, etc.)*
- `make nixie`

------
https://chatgpt.com/codex/tasks/task_e_686c4229785c8322b1aca415430ec1f0

## Summary by Sourcery

Clarify the default factory example in the Python typing guidelines by updating the Box class initializer to use None as a fallback and defer to the TypeVar default instead of calling T() directly.

Documentation:
- Update Box[T] __init__ example to accept None and use the TypeVar default for value fallback
- Add explanatory comment for fallback behavior and suppress type checker warning with type: ignore