### PR TITLE
Fix CI build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: build check-fmt test typecheck
 
 build: uv ## Build virtual-env and install deps
 	uv venv
-	uv sync --group dev --group examples
+	uv sync --group dev
 
 build-release: ## Build artefacts (sdist & wheel)
 	python -m build --sdist --wheel


### PR DESCRIPTION
## Summary
- fix `make build` to omit the nonexistent `examples` dependency group

## Testing
- `make check-fmt`
- `make lint`
- `make typecheck`
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_686c4adf07d08322af99a127ee28286a