### PR TITLE
Fix CI paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
         run: |
           uv pip install slipcover pytest-forked
           uv run python -m slipcover \
-            --source=./falcon_pachinko \
+            --source=./cmd_mox \
             --omit="*/unittests/*,*/.venv/*" \
             --branch \
             --out coverage.xml \
-            -m pytest --forked -v falcon_pachinko/unittests
+            -m pytest --forked -v cmd_mox/unittests
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MDLINT ?= $(shell which markdownlint)
 NIXIE ?= $(shell which nixie)
 MDFORMAT_ALL ?= $(shell which mdformat-all)
 TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) $(NIXIE) uv
-VENV_TOOLS = pytest
+VENV_TOOLS =
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
 	markdownlint nixie test typecheck $(TOOLS) $(VENV_TOOLS)
@@ -13,7 +13,7 @@ all: build check-fmt test typecheck
 
 build: uv ## Build virtual-env and install deps
 	uv venv
-	uv sync --group dev --group examples
+	uv sync --group dev
 
 build-release: ## Build artefacts (sdist & wheel)
 	python -m build --sdist --wheel
@@ -67,7 +67,7 @@ nixie: $(NIXIE) ## Validate Mermaid diagrams
 	find . -type f -name '*.md' \
 	  -not -path './.venv/*' -print0 | xargs -0 $(NIXIE)
 
-test: build uv pytest ## Run tests
+test: build uv ## Run tests
 	uv run pytest -v
 
 help: ## Show available targets


### PR DESCRIPTION
## Summary
- fix coverage job paths for cmd_mox
- drop unused dependency group
- simplify Makefile test deps

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686c4d05db3483228658453d2794501e