### PR TITLE
Implement shim generation engine

### DIFF
--- a/cmd_mox/__init__.py
+++ b/cmd_mox/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from .environment import EnvironmentManager
+from .shimgen import SHIM_PATH, create_shim_symlinks
 
-__all__ = ["EnvironmentManager"]
+__all__ = ["SHIM_PATH", "EnvironmentManager", "create_shim_symlinks"]

--- a/cmd_mox/shim.py
+++ b/cmd_mox/shim.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Generic command shim for CmdMox."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Entry point for the shim."""
+    cmd_name = Path(sys.argv[0]).name
+    print(cmd_name)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entry
+    main()

--- a/cmd_mox/shimgen.py
+++ b/cmd_mox/shimgen.py
@@ -28,8 +28,12 @@ def create_shim_symlinks(directory: Path, commands: t.Iterable[str]) -> dict[str
         raise FileNotFoundError(msg)
 
     if not os.access(SHIM_PATH, os.X_OK):
-        msg = f"Shim template not executable: {SHIM_PATH}"
-        raise PermissionError(msg)
+        try:
+            mode = SHIM_PATH.stat().st_mode | 0o111
+            SHIM_PATH.chmod(mode)
+        except OSError as exc:  # pragma: no cover - OS specific
+            msg = f"Cannot make shim executable: {SHIM_PATH}"
+            raise PermissionError(msg) from exc
     mapping: dict[str, Path] = {}
     for name in commands:
         link = directory / name

--- a/cmd_mox/shimgen.py
+++ b/cmd_mox/shimgen.py
@@ -1,0 +1,33 @@
+"""Utilities for generating command shims."""
+
+from __future__ import annotations
+
+import typing as t
+from pathlib import Path
+
+SHIM_PATH = Path(__file__).with_name("shim.py").resolve()
+
+
+def create_shim_symlinks(directory: Path, commands: t.Iterable[str]) -> dict[str, Path]:
+    """Create symlinks for the given commands in *directory*.
+
+    Parameters
+    ----------
+    directory:
+        Directory where symlinks will be created. It must already exist.
+    commands:
+        Command names (e.g. "git", "curl") for which to create shims.
+    """
+    if not directory.exists():
+        msg = f"Directory {directory} does not exist"
+        raise FileNotFoundError(msg)
+
+    SHIM_PATH.chmod(0o755)
+    mapping: dict[str, Path] = {}
+    for name in commands:
+        link = directory / name
+        if link.exists():
+            link.unlink()
+        link.symlink_to(SHIM_PATH)
+        mapping[name] = link
+    return mapping

--- a/cmd_mox/unittests/test_shim_generation.py
+++ b/cmd_mox/unittests/test_shim_generation.py
@@ -38,7 +38,7 @@ def test_create_shim_symlinks_missing_target_dir() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         missing = pathlib.Path(tmpdir) / "absent"
         with pytest.raises(FileNotFoundError):
-            create_shim_symlinks(missing, ["ls"])  # type: ignore[list-item]
+            create_shim_symlinks(missing, ["ls"])
 
 
 def test_create_shim_symlinks_existing_non_symlink_file() -> None:
@@ -48,7 +48,7 @@ def test_create_shim_symlinks_existing_non_symlink_file() -> None:
         file_path = path / "ls"
         file_path.write_text("not a symlink")
         with pytest.raises(FileExistsError):
-            create_shim_symlinks(path, ["ls"])  # type: ignore[list-item]
+            create_shim_symlinks(path, ["ls"])
 
 
 def test_create_shim_symlinks_missing_or_non_executable_shim(
@@ -60,12 +60,12 @@ def test_create_shim_symlinks_missing_or_non_executable_shim(
         missing_shim = tempdir / "missing"
         monkeypatch.setattr("cmd_mox.shimgen.SHIM_PATH", missing_shim)
         with pytest.raises(FileNotFoundError):
-            create_shim_symlinks(tempdir, ["ls"])  # type: ignore[list-item]
+            create_shim_symlinks(tempdir, ["ls"])
 
         shim_path = tempdir / "fake_shim"
         shim_path.write_text("#!/bin/sh\necho fake")
         shim_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
         monkeypatch.setattr("cmd_mox.shimgen.SHIM_PATH", shim_path)
-        mapping = create_shim_symlinks(tempdir, ["ls"])  # type: ignore[list-item]
+        mapping = create_shim_symlinks(tempdir, ["ls"])
         assert mapping["ls"].is_symlink()
         assert os.access(shim_path, os.X_OK)

--- a/cmd_mox/unittests/test_shim_generation.py
+++ b/cmd_mox/unittests/test_shim_generation.py
@@ -1,0 +1,28 @@
+"""Tests for shim generation utilities."""
+
+import os
+import subprocess
+
+from cmd_mox.environment import EnvironmentManager
+from cmd_mox.shimgen import SHIM_PATH, create_shim_symlinks
+
+
+def test_create_shim_symlinks_and_execution() -> None:
+    """Symlinks execute the shim and expose the invoked name."""
+    commands = ["git", "curl"]
+    with EnvironmentManager() as env:
+        assert env.shim_dir is not None
+        mapping = create_shim_symlinks(env.shim_dir, commands)
+        assert set(mapping) == set(commands)
+        for cmd in commands:
+            link = mapping[cmd]
+            assert link.is_symlink()
+            assert link.resolve() == SHIM_PATH
+            assert os.access(link, os.X_OK)
+            result = subprocess.run(  # noqa: S603
+                [str(link)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            assert result.stdout.strip() == cmd

--- a/cmd_mox/unittests/test_shim_generation.py
+++ b/cmd_mox/unittests/test_shim_generation.py
@@ -66,5 +66,6 @@ def test_create_shim_symlinks_missing_or_non_executable_shim(
         shim_path.write_text("#!/bin/sh\necho fake")
         shim_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
         monkeypatch.setattr("cmd_mox.shimgen.SHIM_PATH", shim_path)
-        with pytest.raises(PermissionError):
-            create_shim_symlinks(tempdir, ["ls"])  # type: ignore[list-item]
+        mapping = create_shim_symlinks(tempdir, ["ls"])  # type: ignore[list-item]
+        assert mapping["ls"].is_symlink()
+        assert os.access(shim_path, os.X_OK)

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -25,15 +25,15 @@
 
   - [x] Environment variable for IPC socket path
 
-- [ ] **Shim Generation Engine**
+- [x] **Shim Generation Engine**
 
-  - [ ] Single Python `shim.py` script (template)
+  - [x] Single Python `shim.py` script (template)
 
-  - [ ] Logic to create per-command symlinks in temp directory
+  - [x] Logic to create per-command symlinks in temp directory
 
-  - [ ] Symlink invokes correct behaviour based on `argv[0]`
+  - [x] Symlink invokes correct behaviour based on `argv[0]`
 
-  - [ ] Make shims executable on all supported Unix platforms
+  - [x] Make shims executable on all supported Unix platforms
 
 - [ ] **IPC Bus (Unix Domain Sockets)**
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -360,6 +360,25 @@ This symlink-based approach is highly efficient and ensures that any updates or
 bug fixes to the shim logic only need to be applied to one central template
 file.
 
+```mermaid
+sequenceDiagram
+    actor User
+    participant App as Application
+    participant FS as FileSystem
+    User->>App: Call create_shim_symlinks(directory, commands)
+    App->>FS: Check if directory exists
+    alt Directory does not exist
+        App->>User: Raise FileNotFoundError
+    else Directory exists
+        App->>FS: Set SHIM_PATH executable
+        loop For each command
+            App->>FS: Remove existing symlink (if any)
+            App->>FS: Create symlink to SHIM_PATH
+        end
+        App->>User: Return mapping of command to symlink path
+    end
+```
+
 ### 3.2 State Management and Inter-Process Communication (IPC)
 
 The communication between the main test process (hosting the `Mox` controller)


### PR DESCRIPTION
## Summary
- create Python shim template
- generate symlinks to the shim at runtime
- expose shim helpers from package
- document completed roadmap tasks
- test shim generation behaviour

## Testing
- `make fmt && make lint && make typecheck && make test`

------
https://chatgpt.com/codex/tasks/task_e_686d893e025483228eaaa59851d5fed6

## Summary by Sourcery

Implement a shim generation engine that provides a generic Python shim template and generates per-command symlinks at runtime, expose the shim utilities in the public API, update documentation to reflect the completed shim roadmap, and add tests for shim creation and execution behavior.

New Features:
- Add generic Python shim template (shim.py) and create_shim_symlinks function to generate per-command symlinks.
- Expose SHIM_PATH and create_shim_symlinks in the package public API.

Documentation:
- Add sequence diagram to design documentation and mark shim generation roadmap tasks as completed.

Tests:
- Add unit tests covering shim creation, execution output, and error conditions for missing directory, existing non-symlink files, and non-executable shim template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a command shim system with per-command symlinks executing a generic shim script that outputs the invoked command name.
  * Added utilities to generate and manage these command shims.
  * Made new shim-related functions publicly accessible from the main package.

* **Tests**
  * Added tests to verify shim symlink creation, execution behavior, and error handling scenarios.

* **Documentation**
  * Updated the roadmap to mark shim generation engine tasks as completed.
  * Added a sequence diagram illustrating the shim symlink creation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->