### PR TITLE
Fix shim command name validation

### DIFF
--- a/cmd_mox/shimgen.py
+++ b/cmd_mox/shimgen.py
@@ -11,13 +11,13 @@ SHIM_PATH = Path(__file__).with_name("shim.py").resolve()
 
 def _validate_command_name(name: str) -> None:
     """Validate *name* is a safe command filename."""
-    if not name or name in {".", ".."}:
-        msg = f"Invalid command name: {name!r}"
-        raise ValueError(msg)
-    if any(sep in name for sep in ("/", "\\")):
-        msg = f"Invalid command name: {name!r}"
-        raise ValueError(msg)
-    if "\x00" in name:
+    invalid = (
+        not name
+        or name in {".", ".."}
+        or any(sep in name for sep in ("/", "\\"))
+        or "\x00" in name
+    )
+    if invalid:
         msg = f"Invalid command name: {name!r}"
         raise ValueError(msg)
 

--- a/cmd_mox/shimgen.py
+++ b/cmd_mox/shimgen.py
@@ -9,6 +9,19 @@ from pathlib import Path
 SHIM_PATH = Path(__file__).with_name("shim.py").resolve()
 
 
+def _validate_command_name(name: str) -> None:
+    """Validate *name* is a safe command filename."""
+    if not name or name in {".", ".."}:
+        msg = f"Invalid command name: {name!r}"
+        raise ValueError(msg)
+    if any(sep in name for sep in ("/", "\\")):
+        msg = f"Invalid command name: {name!r}"
+        raise ValueError(msg)
+    if "\x00" in name:
+        msg = f"Invalid command name: {name!r}"
+        raise ValueError(msg)
+
+
 def create_shim_symlinks(directory: Path, commands: t.Iterable[str]) -> dict[str, Path]:
     """Create symlinks for the given commands in *directory*.
 
@@ -36,6 +49,7 @@ def create_shim_symlinks(directory: Path, commands: t.Iterable[str]) -> dict[str
             raise PermissionError(msg) from exc
     mapping: dict[str, Path] = {}
     for name in commands:
+        _validate_command_name(name)
         link = directory / name
         if os.path.lexists(link):
             if not link.is_symlink():

--- a/cmd_mox/unittests/test_shim_generation.py
+++ b/cmd_mox/unittests/test_shim_generation.py
@@ -69,3 +69,12 @@ def test_create_shim_symlinks_missing_or_non_executable_shim(
         mapping = create_shim_symlinks(tempdir, ["ls"])
         assert mapping["ls"].is_symlink()
         assert os.access(shim_path, os.X_OK)
+
+
+@pytest.mark.parametrize("name", ["../evil", "bad/name", "bad\\name", "..", ""])
+def test_create_shim_symlinks_invalid_command_name(name: str) -> None:
+    """Invalid command names should raise ValueError."""
+    with EnvironmentManager() as env:
+        assert env.shim_dir is not None
+        with pytest.raises(ValueError, match="Invalid command name"):
+            create_shim_symlinks(env.shim_dir, [name])

--- a/cmd_mox/unittests/test_shim_generation.py
+++ b/cmd_mox/unittests/test_shim_generation.py
@@ -71,7 +71,9 @@ def test_create_shim_symlinks_missing_or_non_executable_shim(
         assert os.access(shim_path, os.X_OK)
 
 
-@pytest.mark.parametrize("name", ["../evil", "bad/name", "bad\\name", "..", ""])
+@pytest.mark.parametrize(
+    "name", ["../evil", "bad/name", "bad\\name", "..", "", "bad\x00name"]
+)
 def test_create_shim_symlinks_invalid_command_name(name: str) -> None:
     """Invalid command names should raise ValueError."""
     with EnvironmentManager() as env:


### PR DESCRIPTION
## Summary
- reject unsafe command names in `create_shim_symlinks`
- test invalid command name handling

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68704ac9d7a88322a4d92bf6272a10d2

## Summary by Sourcery

Validate command names when generating shim symlinks to prevent unsafe inputs and add tests for invalid names

Bug Fixes:
- Validate command names in create_shim_symlinks to reject unsafe or invalid filenames

Tests:
- Add parameterized tests to ensure invalid command names raise ValueError

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to prevent creation of symlinks with invalid command names, ensuring safer and more predictable behavior.

* **Tests**
  * Added new tests to verify that invalid command names are correctly rejected during symlink creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->