### PR TITLE
Refactor command doubles and verification flow

### DIFF
--- a/cmd_mox/__init__.py
+++ b/cmd_mox/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .controller import CmdMox, MockCommand, SpyCommand
+from .controller import CmdMox, CommandDouble, MockCommand, SpyCommand
 from .environment import EnvironmentManager
 from .errors import (
     CmdMoxError,
@@ -19,6 +19,7 @@ __all__ = [
     "SHIM_PATH",
     "CmdMox",
     "CmdMoxError",
+    "CommandDouble",
     "EnvironmentManager",
     "IPCServer",
     "Invocation",

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -66,6 +66,11 @@ class CommandDouble:
         """Return ``True`` for stubs and mocks."""
         return self.kind in ("stub", "mock")
 
+    @property
+    def is_recording(self) -> bool:
+        """Return ``True`` for mocks and spies."""
+        return self.kind in ("mock", "spy")
+
     def __repr__(self) -> str:
         """Return debugging representation with name, kind, and response."""
         return (
@@ -280,6 +285,6 @@ class CmdMox:
         dbl = self._doubles.get(invocation.command)
         if not dbl:
             return Response(stdout=invocation.command)
-        if dbl.kind in ("mock", "spy"):
+        if dbl.is_recording:
             dbl.invocations.append(invocation)
         return dbl.response

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -45,7 +45,7 @@ class CommandDouble:
 
     T_Kind = t.Literal["stub", "mock", "spy"]
 
-    def __init__(self, name: str, controller: CmdMox, kind: T_Kind) -> None:
+    def __init__(self, name: str, controller: "CmdMox", kind: T_Kind) -> None:  # noqa: UP037
         self.name = name
         self.kind = kind
         self.controller = controller

--- a/cmd_mox/unittests/test_controller.py
+++ b/cmd_mox/unittests/test_controller.py
@@ -212,3 +212,15 @@ def test_invocation_order_multiple_calls() -> None:
     assert [inv.command for inv in mox.journal] == ["hello", "world", "hello"]
     assert len(mox.mocks["hello"].invocations) == 2
     assert len(mox.spies["world"].invocations) == 1
+
+
+def test_is_recording_property() -> None:
+    """is_recording is True for mocks and spies, False for stubs."""
+    mox = CmdMox()
+    stub = mox.stub("a")
+    mock = mox.mock("b")
+    spy = mox.spy("c")
+
+    assert not stub.is_recording
+    assert mock.is_recording
+    assert spy.is_recording

--- a/cmd_mox/unittests/test_controller.py
+++ b/cmd_mox/unittests/test_controller.py
@@ -147,6 +147,14 @@ def test_mock_idempotency() -> None:
     assert m1 is m2
 
 
+def test_stub_idempotency() -> None:
+    """Repeated calls to stub() with the same name return the same object."""
+    mox = CmdMox()
+    s1 = mox.stub("bar")
+    s2 = mox.stub("bar")
+    assert s1 is s2
+
+
 def test_spy_idempotency() -> None:
     """Repeated calls to spy() with the same name return the same object."""
     mox = CmdMox()

--- a/cmd_mox/unittests/test_controller.py
+++ b/cmd_mox/unittests/test_controller.py
@@ -163,6 +163,14 @@ def test_spy_idempotency() -> None:
     assert s1 is s2
 
 
+def test_double_kind_mismatch() -> None:
+    """Requesting a different kind for an existing double raises ``ValueError``."""
+    mox = CmdMox()
+    mox.stub("foo")
+    with pytest.raises(ValueError, match="registered as stub"):
+        mox.mock("foo")
+
+
 def test_mock_and_spy_invocations() -> None:
     """Mock and spy commands record calls and verify correctly."""
     mox = CmdMox()

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -245,7 +245,9 @@ Early iterations of the library exposed distinct ``StubCommand``,
 a single ``CommandDouble`` implementation tagged with a ``kind`` attribute. The
 factories ``mox.stub()``, ``mox.mock()`` and ``mox.spy()`` still exist for
 ergonomics but internally return ``CommandDouble`` instances. Each double
-tracks invocations so verification can assert on call counts and order.
+tracks invocations so verification can assert on call counts and order. Mocks
+and spies record calls (``double.is_recording`` is ``True``), while stubs do
+not.
 
 The ``kind`` flag determines whether a double is considered an expectation
 (stubs and mocks) or merely observational (spies). It also governs how

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -240,21 +240,16 @@ for further configuration.
   This is used to record invocations for later inspection without the strict
   upfront expectations of a mock.
 
-The initial implementation of `MockCommand` and `SpyCommand` mirrors the
-behaviour of `StubCommand`. They provide static responses and record
-invocations, laying the groundwork for the richer matching and verification
-engine described later in this document. `MockCommand` also records each
-invocation in an internal list so future verification logic can assert on call
-counts and arguments.
+Early iterations of the library exposed distinct ``StubCommand``,
+``MockCommand`` and ``SpyCommand`` classes. These have since been unified into
+a single ``CommandDouble`` implementation tagged with a ``kind`` attribute. The
+factories ``mox.stub()``, ``mox.mock()`` and ``mox.spy()`` still exist for
+ergonomics but internally return ``CommandDouble`` instances. Each double
+tracks invocations so verification can assert on call counts and order.
 
-All three command-double types derive from an internal `_CommandDouble` base
-class, which centralises the common ``name``, ``controller`` and ``response``
-attributes along with the ``returns()`` helper for specifying canned results.
-
-When a command name is registered in multiple categories, `CmdMox` resolves the
-collision deterministically. Stubs take precedence over mocks, which in turn
-take precedence over spies. Tests should avoid mixing categories for the same
-command, but this ordering ensures predictable behaviour if it occurs.
+The ``kind`` flag determines whether a double is considered an expectation
+(stubs and mocks) or merely observational (spies). It also governs how
+``CmdMox.verify()`` checks the journal for unexpected or missing commands.
 
 ### 2.4 The Fluent API for Defining Expectations
 

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -5,7 +5,8 @@ Feature: CmdMox basic functionality
     When I replay the controller
     And I run the command "hi"
     Then the output should be "hello"
-    And the journal should contain 1 invocation of "hi"
+    When I verify the controller
+    Then the journal should contain 1 invocation of "hi"
 
   Scenario: mocked command execution
     Given a CmdMox controller
@@ -13,7 +14,8 @@ Feature: CmdMox basic functionality
     When I replay the controller
     And I run the command "hi"
     Then the output should be "hello"
-    And the journal should contain 1 invocation of "hi"
+    When I verify the controller
+    Then the journal should contain 1 invocation of "hi"
 
   Scenario: spy records invocation
     Given a CmdMox controller
@@ -21,7 +23,8 @@ Feature: CmdMox basic functionality
     When I replay the controller
     And I run the command "hi"
     Then the output should be "hello"
-    And the spy "hi" should record 1 invocation
+    When I verify the controller
+    Then the spy "hi" should record 1 invocation
 
   Scenario: journal preserves invocation order
     Given a CmdMox controller
@@ -31,6 +34,7 @@ Feature: CmdMox basic functionality
     And I run the command "foo"
     And I run the command "bar"
     And I run the command "foo"
+    When I verify the controller
     Then the journal order should be foo,bar,foo
     And the mock "foo" should record 2 invocation
     And the spy "bar" should record 1 invocation


### PR DESCRIPTION
## Summary
- collapse stub/mock/spy classes into CommandDouble
- provide stub/mock/spy factories using a shared registry
- expose verify as its own step in BDD scenarios
- add idempotency test for `stub()`

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687b017d9e2c832283aad3e17bb1e140

## Summary by Sourcery

Unify stub, mock, and spy into a single CommandDouble type with a kind flag and central registry, expose verify as a standalone BDD step, and enforce idempotency and kind consistency across factories.

New Features:
- Expose CmdMox.verify() as its own step in BDD scenarios
- Add stub() idempotency test to ensure repeated calls return the same object

Enhancements:
- Collapse StubCommand, MockCommand, and SpyCommand into a single CommandDouble class tagged by kind
- Introduce a central _doubles registry in CmdMox to manage command doubles and enforce kind consistency
- Provide stub(), mock(), and spy() factories that return CommandDouble instances and raise on kind mismatches
- Add is_expected property and __repr__ to CommandDouble, and filter stubs, mocks, and spies via properties on CmdMox
- Simplify invocation handling by using the unified registry instead of separate stub/mock/spy lookups

Documentation:
- Update design documentation to describe the unified CommandDouble implementation and its kind flag
- Update BDD feature files and step definitions to include the new verify step

Tests:
- Add test for stub idempotency
- Add test to raise ValueError when requesting a different kind for an existing double

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified stub, mock, and spy command doubles into a single type for simplified management and improved consistency.
  * Updated public API to export the new unified command double class.
  * Adjusted internal logic to use a single collection for all command doubles, with properties for filtered access.
  * Enhanced command double behavior with kind-based filtering, improved invocation handling, and better debug representations.

* **Tests**
  * Added tests to ensure stub creation idempotency, enforce consistency in command double kind registration, and verify recording behavior.

* **Documentation**
  * Updated feature scenarios to explicitly verify the controller before checking invocation counts.
  * Revised design documentation to reflect the unified command double model.

* **Chores**
  * Simplified step definitions in test steps, removing redundant verification calls and unused imports.
  * Added explicit verification step for controller state validation in feature tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->