### PR TITLE
Implement pytest plugin fixture with worker-aware env

### DIFF
--- a/cmd_mox/__init__.py
+++ b/cmd_mox/__init__.py
@@ -13,6 +13,7 @@ from .errors import (
     VerificationError,
 )
 from .ipc import Invocation, IPCServer, Response
+from .pytest_plugin import cmd_mox as cmd_mox_fixture
 from .shimgen import SHIM_PATH, create_shim_symlinks
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "UnexpectedCommandError",
     "UnfulfilledExpectationError",
     "VerificationError",
+    "cmd_mox_fixture",
     "create_shim_symlinks",
 ]

--- a/cmd_mox/environment.py
+++ b/cmd_mox/environment.py
@@ -25,11 +25,12 @@ class EnvironmentManager:
     inadvertent environment leakage.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, prefix: str = "cmdmox-") -> None:
         self._orig_env: dict[str, str] | None = None
         self.shim_dir: Path | None = None
         self.socket_path: Path | None = None
         self._created_dir: Path | None = None
+        self._prefix = prefix
 
     def __enter__(self) -> EnvironmentManager:
         """Set up the temporary environment."""
@@ -39,7 +40,7 @@ class EnvironmentManager:
             raise RuntimeError(msg)
         _active_manager = self
         self._orig_env = os.environ.copy()
-        self.shim_dir = Path(tempfile.mkdtemp(prefix="cmdmox-"))
+        self.shim_dir = Path(tempfile.mkdtemp(prefix=self._prefix))
         self._created_dir = self.shim_dir
         os.environ["PATH"] = os.pathsep.join(
             [str(self.shim_dir), self._orig_env.get("PATH", "")]

--- a/cmd_mox/pytest_plugin.py
+++ b/cmd_mox/pytest_plugin.py
@@ -1,0 +1,30 @@
+"""Pytest plugin providing the ``cmd_mox`` fixture."""
+
+from __future__ import annotations
+
+import os
+import typing as t
+
+import pytest
+
+from .controller import CmdMox
+from .environment import EnvironmentManager
+
+
+@pytest.fixture
+def cmd_mox(request: pytest.FixtureRequest) -> t.Generator[CmdMox, None, None]:
+    """Provide a :class:`CmdMox` instance with environment active."""
+    worker_id = os.getenv("PYTEST_XDIST_WORKER")
+    if worker_id is None:
+        worker_id = getattr(
+            getattr(request.config, "workerinput", None), "workerid", "main"
+        )
+    prefix = f"cmdmox-{worker_id}-{os.getpid()}-"
+
+    mox = CmdMox()
+    mox.environment = EnvironmentManager(prefix=prefix)
+    mox.__enter__()
+    try:
+        yield mox
+    finally:
+        mox.__exit__(None, None, None)

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -57,11 +57,11 @@
 
   - [x] `cmd_mox.mock(cmd)`, `cmd_mox.stub(cmd)`, `cmd_mox.spy(cmd)`
 
-- [ ] **Pytest Plugin**
+- [x] **Pytest Plugin**
 
-  - [ ] Register `cmd_mox` fixture
+  - [x] Register `cmd_mox` fixture
 
-  - [ ] xdist/parallelisation awareness (worker IDs, temp dirs)
+  - [x] xdist/parallelisation awareness (worker IDs, temp dirs)
 
 - [ ] **Context Manager Interface**
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1083,6 +1083,17 @@ classDiagram
     CmdMoxError <|-- LifecycleError
     CmdMoxError <|-- MissingEnvironmentError
     CmdMoxError <|-- VerificationError
-    VerificationError <|-- UnexpectedCommandError
-    VerificationError <|-- UnfulfilledExpectationError
+VerificationError <|-- UnexpectedCommandError
+VerificationError <|-- UnfulfilledExpectationError
 ```
+
+### 8.4 Design Decisions for the Pytest Plugin
+
+The plugin exposes a ``cmd_mox`` fixture that yields a ready-to-use
+:class:`CmdMox` instance.  The fixture enters the :class:`EnvironmentManager`
+before yielding and always exits it afterwards to guarantee environment cleanup.
+
+To support ``pytest-xdist`` each fixture instance incorporates the worker ID
+into the temporary directory prefix.  The prefix takes the form
+``cmdmox-{worker}-{pid}-`` ensuring that socket paths and shim directories are
+unique across parallel workers.

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1096,4 +1096,5 @@ before yielding and always exits it afterwards to guarantee environment cleanup.
 To support ``pytest-xdist`` each fixture instance incorporates the worker ID
 into the temporary directory prefix.  The prefix takes the form
 ``cmdmox-{worker}-{pid}-`` ensuring that socket paths and shim directories are
-unique across parallel workers.
+unique across parallel workers. When ``PYTEST_XDIST_WORKER`` is absent the
+fixture falls back to ``main`` so the prefix becomes ``cmdmox-main-{pid}-``.

--- a/features/pytest_plugin.feature
+++ b/features/pytest_plugin.feature
@@ -1,0 +1,5 @@
+Feature: Pytest plugin
+  Scenario: cmd_mox fixture basic usage
+    Given a temporary test file using the cmd_mox fixture
+    When I run pytest on the file
+    Then the run should pass

--- a/features/steps/steps_pytest_plugin.py
+++ b/features/steps/steps_pytest_plugin.py
@@ -1,0 +1,63 @@
+"""Steps for testing the pytest plugin."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import typing as t
+from pathlib import Path
+
+from behave import given, then, when  # type: ignore[attr-defined]
+
+
+class BehaveContext(t.Protocol):
+    """Behave step context for plugin tests."""
+
+    test_file: Path
+    tmpdir: Path
+    result: subprocess.CompletedProcess[str]
+
+
+@given("a temporary test file using the cmd_mox fixture")
+def step_create_test_file(context: BehaveContext) -> None:
+    """Write a pytest file that exercises the fixture."""
+    test_code = """
+import subprocess
+import pytest
+
+pytest_plugins = ("cmd_mox.pytest_plugin",)
+
+def test_example(cmd_mox):
+    cmd_mox.stub('hello').returns(stdout='hi')
+    cmd_mox.replay()
+    path = cmd_mox.environment.shim_dir / 'hello'
+    res = subprocess.run(
+        [str(path)], capture_output=True, text=True, check=True
+    )
+    assert res.stdout.strip() == 'hi'
+    cmd_mox.verify()
+"""
+    tmpdir = Path(tempfile.mkdtemp())
+    context.test_file = tmpdir / "test_example.py"
+    context.tmpdir = tmpdir
+    context.test_file.write_text(test_code)
+
+
+@when("I run pytest on the file")
+def step_run_pytest(context: BehaveContext) -> None:
+    """Execute pytest on the generated file."""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "pytest", str(context.test_file)],
+        capture_output=True,
+        text=True,
+    )
+    context.result = result
+    shutil.rmtree(context.tmpdir)
+
+
+@then("the run should pass")
+def step_check_pass(context: BehaveContext) -> None:
+    """Assert that pytest exited successfully."""
+    assert context.result.returncode == 0  # noqa: S101

--- a/features/steps/steps_pytest_plugin.py
+++ b/features/steps/steps_pytest_plugin.py
@@ -16,8 +16,10 @@ class BehaveContext(t.Protocol):
     """Behave step context for plugin tests."""
 
     test_file: Path
-    tmpdir: Path
     result: subprocess.CompletedProcess[str]
+
+    def add_cleanup(self, func: t.Callable[..., object], *args: object) -> None:
+        """Register a clean-up callback."""
 
 
 @given("a temporary test file using the cmd_mox fixture")
@@ -41,8 +43,8 @@ def test_example(cmd_mox):
 """
     tmpdir = Path(tempfile.mkdtemp())
     context.test_file = tmpdir / "test_example.py"
-    context.tmpdir = tmpdir
     context.test_file.write_text(test_code)
+    context.add_cleanup(shutil.rmtree, tmpdir)
 
 
 @when("I run pytest on the file")
@@ -54,7 +56,6 @@ def step_run_pytest(context: BehaveContext) -> None:
         text=True,
     )
     context.result = result
-    shutil.rmtree(context.tmpdir)
 
 
 @then("the run should pass")


### PR DESCRIPTION
## Summary
- implement `pytest_plugin` providing a `cmd_mox` fixture
- ensure isolation for pytest-xdist workers via prefix
- expose fixture from package and document the design
- add behavioural steps for plugin usage
- test fixture with `pytester`
- mark roadmap entry as complete

## Testing
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687bd06464a88322abdf296f13ab8e2a

## Summary by Sourcery

Implement and document a pytest plugin that provides a worker-aware cmd_mox fixture with environment setup and teardown, and add comprehensive tests and roadmap updates

New Features:
- Add a pytest plugin exposing a cmd_mox fixture that activates and cleans up an EnvironmentManager
- Incorporate pytest-xdist worker ID and process ID into temporary directory prefixes to ensure isolation across parallel workers

Enhancements:
- Export the cmd_mox fixture in the package API
- Update the project roadmap and design documentation to include and describe the pytest plugin

Documentation:
- Document the pytest plugin design and environment prefix strategy in the architecture guide

Tests:
- Add unit tests for the pytest plugin using pytester to verify fixture behavior and worker-aware prefixes
- Add BDD tests with behave steps and a feature file to validate plugin usage end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a pytest plugin providing a `cmd_mox` fixture for streamlined command mocking in tests.
  * Added support for parallel test execution by generating unique environment prefixes per worker.
  * Implemented behavior-driven development (BDD) feature tests for the pytest plugin.

* **Bug Fixes**
  * Corrected class diagram alignment in documentation.

* **Documentation**
  * Updated roadmap to reflect completion of pytest plugin features.
  * Added detailed design notes for the pytest plugin integration and parallelization.

* **Tests**
  * Added unit and BDD-style tests to verify the functionality and parallelization of the `cmd_mox` fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->