### PR TITLE
Add CmdMox context manager support

### DIFF
--- a/cmd_mox/unittests/test_controller.py
+++ b/cmd_mox/unittests/test_controller.py
@@ -214,6 +214,21 @@ def test_invocation_order_multiple_calls() -> None:
     assert len(mox.spies["world"].invocations) == 1
 
 
+def test_context_manager_usage() -> None:
+    """Using ``CmdMox`` as a context manager restores the environment."""
+    original_path = os.environ["PATH"]
+    with CmdMox() as mox:
+        mox.stub("hi").returns(stdout="hello")
+        mox.replay()
+        cmd_path = Path(mox.environment.shim_dir) / "hi"
+        result = subprocess.run(  # noqa: S603
+            [str(cmd_path)], capture_output=True, text=True, check=True
+        )
+    mox.verify()
+    assert result.stdout.strip() == "hello"
+    assert os.environ["PATH"] == original_path
+
+
 def test_is_recording_property() -> None:
     """is_recording is True for mocks and spies, False for stubs."""
     mox = CmdMox()

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -63,9 +63,9 @@
 
   - [x] xdist/parallelisation awareness (worker IDs, temp dirs)
 
-- [ ] **Context Manager Interface**
+- [x] **Context Manager Interface**
 
-  - [ ] Support for explicit `with cmd_mox.CmdMox() as mox:` usage
+  - [x] Support for explicit `with cmd_mox.CmdMox() as mox:` usage
 
 ## **IV. Command Double Implementations**
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -175,7 +175,6 @@ fixture provides a fresh, properly configured `cmd_mox.CmdMox` instance for
 each test, with setup and teardown handled automatically.
 
 *Example Usage:*
-
 ```python
 # In conftest.py
 pytest_plugins = ("cmd_mox.pytest_plugin",)
@@ -205,7 +204,6 @@ that the environment is correctly set up on entry and, critically, that it is
 torn down and restored on exit, even in the case of an exception.
 
 *Example Usage:*
-
 ```python
 import cmd_mox
 import subprocess
@@ -221,6 +219,12 @@ with cmd_mox.CmdMox() as mox:
 mox.verify()
 # The PATH is automatically restored here.
 ```
+
+`__enter__` delegates to :class:`EnvironmentManager`, ensuring the PATH and IPC
+variables are set up. `__exit__` stops any running server and restores the
+original environment. Verification may occur inside the ``with`` block or after
+it has exited; if called later, ``CmdMox`` detects that cleanup already
+happened and merely performs journal checks.
 
 ### 2.3 Creating Test Doubles: `mox.mock()`, `mox.stub()`, and `mox.spy()`
 
@@ -375,9 +379,7 @@ the following steps:
 
 This symlink-based approach is highly efficient and ensures that any updates or
 bug fixes to the shim logic only need to be applied to one central template
-file.
-
-```mermaid
+```file.
 sequenceDiagram
     actor User
     participant App as Application
@@ -465,7 +467,6 @@ ensure it appears before clients connect. On the client side, `invoke_server()`
 retries connection attempts a few times and validates that the server's reply
 is valid JSON, raising a `RuntimeError` if decoding fails. These safeguards
 make the IPC bus robust on slower or heavily loaded systems.
-
 ```mermaid
 classDiagram
     class IPCServer {
@@ -505,7 +506,6 @@ classDiagram
     IPCServer --> Invocation : handles
     IPCServer --> Response : returns
 ```
-
 ```mermaid
 sequenceDiagram
     actor Shim
@@ -750,7 +750,6 @@ for this purpose:
   structured access to a single call's details.
 
 *Example Assertion-Style Verification:*
-
 ```python
 def test_downloader_uses_correct_user_agent(mox):
     spy = mox.spy('curl')
@@ -836,7 +835,6 @@ The user would test this by executing the full command line (e.g., via
 command in the pipeline:
 
 *Example Pipeline Test:*
-
 ```python
 def test_pipeline_logic(mox):
     # Mock the first command in the pipe
@@ -989,7 +987,6 @@ configured :class:`Response`; otherwise it echoes the command name. During
 registered stub and that each stub was called at least once. This simplified
 verification establishes the record → replay → verify workflow and lays the
 groundwork for upcoming expectation and spy features.
-
 ```mermaid
 sequenceDiagram
     actor Tester
@@ -1020,7 +1017,6 @@ improper use of `replay()` or `verify()`, `UnexpectedCommandError` indicates an
 invocation without a matching stub, and `UnfulfilledExpectationError` reports
 stubs that were never called. To aid debugging, these errors include the
 controller's active phase in their messages.
-
 ```mermaid
 classDiagram
     class CmdMox {
@@ -1065,7 +1061,6 @@ classDiagram
     StubCommand "1" -- "1" Response : configures
     IPCServer "1" -- "*" Invocation : handles
 ```
-
 ```mermaid
 classDiagram
     class CmdMoxError {

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -38,3 +38,10 @@ Feature: CmdMox basic functionality
     Then the journal order should be foo,bar,foo
     And the mock "foo" should record 2 invocation
     And the spy "bar" should record 1 invocation
+
+  Scenario: context manager usage
+    Given a CmdMox controller
+    And the command "hi" is stubbed to return "hello"
+    When I run the command "hi" using a with block
+    Then the output should be "hello"
+    Then the journal should contain 1 invocation of "hi"


### PR DESCRIPTION
## Summary
- verify context manager behaviour with unit and behavioural tests
- document context manager semantics
- mark roadmap entry as complete

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make markdownlint`
- `make nixie`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d94bafde08322afd1b2582c031aff