### PR TITLE
Implement StubCommand dynamic behaviour

### DIFF
--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -69,11 +69,11 @@
 
 ## **IV. Command Double Implementations**
 
-- [ ] **StubCommand**
+- [x] **StubCommand**
 
-  - [ ] `.returns()` and `.runs()` (static/dynamic behaviour)
+  - [x] `.returns()` and `.runs()` (static/dynamic behaviour)
 
-  - [ ] No verification/required calls
+  - [x] No verification/required calls
 
 - [ ] **MockCommand**
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -605,12 +605,14 @@ the following process:
 5. **Execution:** The shim receives this payload, prints "match" to its
    `stdout`, and exits with status 0.
 
-6. **Verification:** During `mox.verify()`, stubs are not checked. If the `grep`
-   command is never called, the test still passes. This "fire-and-forget"
-   nature is the defining characteristic of a stub.
+6. **Verification:** During `mox.verify()`, stubs are not checked. If the
+   `grep` command is never called, the test still passes. This
+   "fire-and-forget" nature is the defining characteristic of a stub.
 
-Implementation-wise, the controller marks only mocks as "expected". Unused
-stubs therefore never raise `UnfulfilledExpectationError` during verification.
+   Implementation-wise, the controller marks only mocks as "expected". Unused
+   stubs therefore never raise `UnfulfilledExpectationError` during
+   verification. Stub invocations still appear in the global journal for later
+   inspection.
 
 ### 4.2 Advanced Stubs: Callable Handlers
 
@@ -983,11 +985,13 @@ management and a minimal stub facility. The controller wraps
 ``EnvironmentManager`` and ``IPCServer`` to orchestrate environment setup and
 inter-process communication. Invocations from shims are appended to an internal
 journal. When a stub is registered for a command, the controller returns the
-configured :class:`Response`; otherwise it echoes the command name. During
-``verify()`` the controller asserts that every invocation corresponds to a
-registered stub and that each stub was called at least once. This simplified
-verification establishes the record → replay → verify workflow and lays the
-groundwork for upcoming expectation and spy features.
+configured :class:`Response`; otherwise it echoes the command name.
+
+During ``verify()`` the controller fails if unexpected commands were executed
+or if any registered mock command was never called. Stubs are ignored during
+this phase. This simplified verification establishes the record → replay →
+verify workflow and lays the groundwork for upcoming expectation and spy
+features.
 ```mermaid
 sequenceDiagram
     actor Tester

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -609,6 +609,9 @@ the following process:
    command is never called, the test still passes. This "fire-and-forget"
    nature is the defining characteristic of a stub.
 
+Implementation-wise, the controller marks only mocks as "expected". Unused
+stubs therefore never raise `UnfulfilledExpectationError` during verification.
+
 ### 4.2 Advanced Stubs: Callable Handlers
 
 To support dynamic or stateful behavior, `CmdMox` allows stubs to be configured

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -45,3 +45,12 @@ Feature: CmdMox basic functionality
     When I run the command "hi" using a with block
     Then the output should be "hello"
     Then the journal should contain 1 invocation of "hi"
+
+  Scenario: stub runs dynamic handler
+    Given a CmdMox controller
+    And the command "dyn" is stubbed to run a handler
+    When I replay the controller
+    And I run the command "dyn"
+    Then the output should be "handled"
+    When I verify the controller
+    Then the journal should contain 1 invocation of "dyn"


### PR DESCRIPTION
## Summary
- add dynamic handler support for CommandDouble via `runs`
- mark only mocks as required expectations
- update design notes and roadmap
- support handler-based stubs in behavioural tests
- ensure unused stubs no longer fail verification

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make markdownlint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687f3d6aa2ac83228106b8b7aa0279c7

## Summary by Sourcery

Enable dynamic behavior for stub commands via a runs handler, adjust verification to only enforce expectations for mocks, and update corresponding tests and documentation.

New Features:
- Add runs method to CommandDouble for dynamic stub responses

Bug Fixes:
- Prevent unused stubs from causing verification failures by not marking them as expected

Enhancements:
- Only mocks are now marked as expected in verification logic

Documentation:
- Update roadmap and design documentation with stub dynamic behavior and expectation changes

Tests:
- Add unit and BDD tests for handler-based stub behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic response handlers for stubbed commands, allowing stubs to generate responses based on invocation details.

* **Bug Fixes**
  * Unused stubs no longer cause verification errors, ensuring only mocks are required to be called.

* **Documentation**
  * Updated documentation to clarify stub behavior and marked related roadmap items as complete.

* **Tests**
  * Added new tests and scenarios to verify dynamic stub handler functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->