### PR TITLE
Implement SpyCommand passthrough

### DIFF
--- a/cmd_mox/command_runner.py
+++ b/cmd_mox/command_runner.py
@@ -1,0 +1,41 @@
+"""Run real commands for passthrough spies."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import typing as t
+
+from .ipc import Invocation, Response
+
+if t.TYPE_CHECKING:  # pragma: no cover - used for type hints
+    from .environment import EnvironmentManager
+
+
+class CommandRunner:
+    """Run commands using the original system environment."""
+
+    def __init__(self, env_mgr: EnvironmentManager) -> None:
+        self._env_mgr = env_mgr
+
+    def run(self, invocation: Invocation, extra_env: dict[str, str]) -> Response:
+        """Execute *invocation* in the original environment."""
+        orig_env = self._env_mgr._orig_env or {}
+        path = orig_env.get("PATH", os.environ.get("PATH", ""))
+        real = shutil.which(invocation.command, path=path)
+        if real is None:
+            return Response(stderr=f"{invocation.command}: not found", exit_code=127)
+
+        env = {**invocation.env, "PATH": path, **extra_env}
+        result = subprocess.run(  # noqa: S603 - invocation args are controlled
+            [real, *invocation.args],
+            input=invocation.stdin,
+            capture_output=True,
+            text=True,
+            env=env,
+            shell=False,
+        )
+        return Response(
+            stdout=result.stdout, stderr=result.stderr, exit_code=result.returncode
+        )

--- a/cmd_mox/command_runner.py
+++ b/cmd_mox/command_runner.py
@@ -28,6 +28,7 @@ class CommandRunner:
             return Response(stderr=f"{invocation.command}: not found", exit_code=127)
 
         env = {**invocation.env, "PATH": path, **extra_env}
+        # Explicit argument list and ``shell=False`` mitigate injection risk.
         result = subprocess.run(  # noqa: S603 - invocation args are controlled
             [real, *invocation.args],
             input=invocation.stdin,

--- a/cmd_mox/unittests/test_controller.py
+++ b/cmd_mox/unittests/test_controller.py
@@ -302,3 +302,21 @@ def test_stub_runs_handler(
     mox.verify()
 
     assert result.stdout.strip() == expected
+
+
+def test_spy_passthrough_records_real_output() -> None:
+    """Passthrough spy runs the real command and records calls."""
+    mox = CmdMox()
+    spy = mox.spy("echo").passthrough()
+    mox.__enter__()
+    mox.replay()
+
+    cmd_path = Path(mox.environment.shim_dir) / "echo"
+    result = subprocess.run(  # noqa: S603
+        [str(cmd_path), "hi"], capture_output=True, text=True, check=True
+    )
+
+    mox.verify()
+
+    assert result.stdout.strip() == "hi"
+    assert spy.call_count == 1

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -87,13 +87,13 @@
 
   - [x] Strict record-replay-verify logic
 
-- [ ] **SpyCommand**
+- [x] **SpyCommand**
 
-  - [ ] `.returns()` for canned response
+  - [x] `.returns()` for canned response
 
-  - [ ] `.passthrough()` for record/replay mode
+  - [x] `.passthrough()` for record/replay mode
 
-  - [ ] Maintain call history (`invocations`, `call_count` API)
+  - [x] Maintain call history (`invocations`, `call_count` API)
 
 ### Fluent API Enhancements
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1159,3 +1159,16 @@ The controller's `replay()` and `verify()` methods were likewise broken down
 into dedicated helper functions such as ``_check_replay_preconditions`` and
 ``_finalize_verification``. This keeps the high-level workflow clear while
 localising error handling and environment cleanup details.
+
+### 8.6 Design Decisions for ``SpyCommand``
+
+Spies now support a ``passthrough()`` mode that executes the real command
+instead of a canned response. When a passthrough spy is invoked, the controller
+locates the real executable using the original ``PATH`` preserved by the
+``EnvironmentManager``. It runs the command with the recorded environment
+(minus the shim directory) and captures its output and exit status. The results
+are stored alongside the invocation and returned to the shim so the calling
+process sees the real behaviour.
+
+Both mocks and spies maintain an ``invocations`` list. A convenience property
+``call_count`` exposes ``len(invocations)`` for assertion-style tests.

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1165,10 +1165,11 @@ localising error handling and environment cleanup details.
 Spies now support a ``passthrough()`` mode that executes the real command
 instead of a canned response. When a passthrough spy is invoked, the controller
 locates the real executable using the original ``PATH`` preserved by the
-``EnvironmentManager``. It runs the command with the recorded environment
-(minus the shim directory) and captures its output and exit status. The results
-are stored alongside the invocation and returned to the shim so the calling
-process sees the real behaviour.
+``EnvironmentManager``. A small ``CommandRunner`` helper encapsulates this
+lookup and ``subprocess.run`` call. It runs the command with the recorded
+environment (minus the shim directory) and captures its output and exit status.
+The results are stored alongside the invocation and returned to the shim so the
+calling process sees the real behaviour.
 
 Both mocks and spies maintain an ``invocations`` list. A convenience property
 ``call_count`` exposes ``len(invocations)`` for assertion-style tests.

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -82,3 +82,4 @@ Feature: CmdMox basic functionality
     Then the output should be "hello"
     When I verify the controller
     Then the spy "echo" should record 1 invocation
+    And the spy "echo" call count should be 1

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -73,3 +73,12 @@ Feature: CmdMox basic functionality
     Then the output should be "WORLD"
     When I verify the controller
     Then the journal should contain 1 invocation of "envcmd"
+
+  Scenario: passthrough spy executes real command
+    Given a CmdMox controller
+    And the command "echo" is spied to passthrough
+    When I replay the controller
+    And I run the command "echo" with arguments "hello"
+    Then the output should be "hello"
+    When I verify the controller
+    Then the spy "echo" should record 1 invocation

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -50,6 +50,12 @@ def spy_command(mox: CmdMox, cmd: str, text: str) -> None:
     mox.spy(cmd).returns(stdout=text)
 
 
+@given(parsers.cfparse('the command "{cmd}" is spied to passthrough'))
+def spy_passthrough(mox: CmdMox, cmd: str) -> None:
+    """Configure a passthrough spy."""
+    mox.spy(cmd).passthrough()
+
+
 @given(parsers.cfparse('the command "{cmd}" is stubbed to run a handler'))
 def stub_runs(mox: CmdMox, cmd: str) -> None:
     """Configure a stub with a dynamic handler."""
@@ -220,4 +226,12 @@ def test_ordered_mocks_match_arguments() -> None:
 )
 def test_environment_injection() -> None:
     """Stub applies environment variables to the shim."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"), "passthrough spy executes real command"
+)
+def test_passthrough_spy() -> None:
+    """Spy runs the real command while recording."""
     pass

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -161,6 +161,14 @@ def check_spy(mox: CmdMox, cmd: str, count: int) -> None:
     assert len(spy.invocations) == count
 
 
+@then(parsers.cfparse('the spy "{cmd}" call count should be {count:d}'))
+def check_spy_call_count(mox: CmdMox, cmd: str, count: int) -> None:
+    """Assert ``SpyCommand.call_count`` equals *count*."""
+    assert cmd in mox.spies, f"Spy for command '{cmd}' not found"
+    spy = mox.spies[cmd]
+    assert spy.call_count == count
+
+
 @then(parsers.cfparse('the mock "{cmd}" should record {count:d} invocation'))
 def check_mock(mox: CmdMox, cmd: str, count: int) -> None:
     """Verify the mock recorded the invocation."""


### PR DESCRIPTION
## Summary
- support passthrough mode for spies and expose call_count
- document SpyCommand behaviour and mark roadmap complete
- exercise passthrough spies via unit and BDD tests

## Testing
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68871ebd54c4832296f4ecc8c4f7a0d9

## Summary by Sourcery

Implement passthrough mode for spy commands that executes the real command while recording its output and invocation count.

New Features:
- Add passthrough() API for spies to execute the real command and capture its output
- Introduce call_count property on CommandDouble to expose the number of invocations

Enhancements:
- Extend the controller’s invocation handling to dispatch passthrough logic for spies

Documentation:
- Document SpyCommand passthrough behavior in the design doc
- Mark SpyCommand features complete in the roadmap

Tests:
- Add unit test for spy passthrough execution and call count recording
- Add BDD steps and scenario for passthrough spy behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for spy commands to execute the real underlying command (passthrough mode) while still recording invocations.
  * Introduced a property to easily view how many times a command has been invoked.

* **Tests**
  * Added unit and behavior-driven tests to verify passthrough spy functionality and ensure correct recording of real command executions.

* **Documentation**
  * Updated documentation to describe passthrough mode for spies, call history tracking, and design decisions.
  * Marked related roadmap items as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->