### PR TITLE
Add usage guide reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ harnesses and AIX cronjobs running `sccs`.
 
 If you've ever mocked `curl` with `cat`, this library is your penance.
 
+For detailed instructions, see [docs/usage-guide.md](docs/usage-guide.md).
+
 ## 🧪 Example: Testing a command-line script with CmdMox
 
 Let’s say your script under test calls `git clone` and `curl`. You want to test


### PR DESCRIPTION
## Summary
- mention docs/usage-guide.md in README

## Testing
- `make markdownlint`
- `make nixie` *(fails: Cannot find module '../bidi/BrowserConnector.js')*

------
https://chatgpt.com/codex/tasks/task_e_6888f8cfac7c83228c0a9279d493daf7

## Summary by Sourcery

Documentation:
- Add link to docs/usage-guide.md in the README