### PR TITLE
Simplify env merge in CommandRunner

### DIFF
--- a/cmd_mox/command_runner.py
+++ b/cmd_mox/command_runner.py
@@ -55,9 +55,7 @@ class CommandRunner:
     ) -> dict[str, str]:
         """Merge the original PATH with any supplied environment variables."""
         path = self._env_mgr.original_environment.get("PATH", "")
-        env = {"PATH": path} | extra_env
-        env |= invocation_env
-        return env
+        return {"PATH": path} | extra_env | invocation_env
 
     def _execute_command(
         self, resolved_path: Path, invocation: Invocation, env: dict[str, str]


### PR DESCRIPTION
## Summary
- avoid intermediate variable when merging env dictionaries

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688a7d3f442c8322b9df62aaa05493a6

## Summary by Sourcery

Enhancements:
- Consolidate environment dictionary merging into a one-liner in _prepare_environment