### PR TITLE
Improve passthrough spy error handling

### DIFF
--- a/cmd_mox/command_runner.py
+++ b/cmd_mox/command_runner.py
@@ -82,20 +82,16 @@ class CommandRunner:
             )
         except subprocess.TimeoutExpired:
             duration = int(self._timeout)
-            return Response(
-                stderr=f"{invocation.command}: timeout after {duration} seconds",
-                exit_code=124,
-            )
-        except FileNotFoundError as e:
-            return Response(stderr=f"{invocation.command}: {e}", exit_code=127)
+            return self._error(invocation, f"timeout after {duration} seconds", 124)
+        except FileNotFoundError:
+            return self._error(invocation, "not found", 127)
         except PermissionError as e:
-            return Response(stderr=f"{invocation.command}: {e}", exit_code=126)
+            return self._error(invocation, str(e), 126)
         except OSError as e:
-            return Response(
-                stderr=f"{invocation.command}: execution failed: {e}", exit_code=126
-            )
+            return self._error(invocation, f"execution failed: {e}", 126)
         except Exception as e:  # noqa: BLE001 - broad catch for safety
-            return Response(
-                stderr=f"{invocation.command}: unexpected error: {e}",
-                exit_code=126,
-            )
+            return self._error(invocation, f"unexpected error: {e}", 126)
+
+    def _error(self, invocation: Invocation, msg: str, code: int) -> Response:
+        """Return a ``Response`` containing *msg* for *invocation*."""
+        return Response(stderr=f"{invocation.command}: {msg}", exit_code=code)

--- a/cmd_mox/command_runner.py
+++ b/cmd_mox/command_runner.py
@@ -35,7 +35,9 @@ class CommandRunner:
     # ------------------------------------------------------------------
     def _resolve_and_validate_command(self, command: str) -> Path | Response:
         """Locate *command* in PATH and ensure it is safe to execute."""
-        path = self._env_mgr.original_environment.get("PATH", "")
+        path = self._env_mgr.original_environment.get(
+            "PATH", os.environ.get("PATH", "")
+        )
         real = shutil.which(command, path=path)
         if real is None:
             return Response(stderr=f"{command}: not found", exit_code=127)
@@ -84,7 +86,9 @@ class CommandRunner:
                 stderr=f"{invocation.command}: timeout after {duration} seconds",
                 exit_code=124,
             )
-        except (FileNotFoundError, PermissionError) as e:
+        except FileNotFoundError as e:
+            return Response(stderr=f"{invocation.command}: {e}", exit_code=127)
+        except PermissionError as e:
             return Response(stderr=f"{invocation.command}: {e}", exit_code=126)
         except OSError as e:
             return Response(

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -365,7 +365,8 @@ class CmdMox:
         if handler is not None:
             resp = self._call_with_env(lambda: handler(invocation), env_vars)
 
-        resp.env.update(env_vars)
+        for key, val in env_vars.items():
+            resp.env.setdefault(key, val)
         return resp
 
     def _call_with_env(

--- a/cmd_mox/unittests/test_command_runner.py
+++ b/cmd_mox/unittests/test_command_runner.py
@@ -1,0 +1,54 @@
+"""Unit tests for :mod:`cmd_mox.command_runner`."""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from cmd_mox.command_runner import CommandRunner
+from cmd_mox.environment import EnvironmentManager
+from cmd_mox.ipc import Invocation
+
+if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
+    import collections.abc as cabc
+
+
+class DummyResult:
+    """Simplified ``CompletedProcess`` replacement for assertions."""
+
+    def __init__(self, env: dict[str, str]) -> None:
+        self.stdout = ""
+        self.stderr = ""
+        self.returncode = 0
+        self.env = env
+
+
+@pytest.fixture
+def runner() -> cabc.Iterator[CommandRunner]:
+    """Return a :class:`CommandRunner` with a managed environment."""
+    env_mgr = EnvironmentManager()
+    env_mgr.__enter__()
+    runner = CommandRunner(env_mgr)
+    yield runner
+    env_mgr.__exit__(None, None, None)
+
+
+def test_invocation_env_overrides_expectation_env(
+    runner: CommandRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invocation environment should take precedence over expectation env."""
+    captured: dict[str, str] = {}
+
+    def fake_run(
+        argv: list[str], *, env: dict[str, str], **_kwargs: object
+    ) -> DummyResult:
+        nonlocal captured
+        captured = env
+        return DummyResult(env)
+
+    monkeypatch.setattr("cmd_mox.command_runner.subprocess.run", fake_run)
+
+    invocation = Invocation(command="echo", args=[], stdin="", env={"VAR": "inv"})
+    runner.run(invocation, {"VAR": "expect"})
+    assert captured["VAR"] == "inv"

--- a/cmd_mox/unittests/test_command_runner.py
+++ b/cmd_mox/unittests/test_command_runner.py
@@ -31,8 +31,7 @@ def runner() -> cabc.Iterator[CommandRunner]:
     """Return a :class:`CommandRunner` with a managed environment."""
     env_mgr = EnvironmentManager()
     env_mgr.__enter__()
-    runner = CommandRunner(env_mgr)
-    yield runner
+    yield CommandRunner(env_mgr)
     env_mgr.__exit__(None, None, None)
 
 

--- a/cmd_mox/unittests/test_controller.py
+++ b/cmd_mox/unittests/test_controller.py
@@ -388,3 +388,11 @@ def test_passthrough_handles_permission_error(
 
     assert result.returncode == 126
     assert "not executable" in result.stderr
+
+
+def test_passthrough_only_valid_for_spies() -> None:
+    """Calling passthrough() on a non-spy should raise ValueError."""
+    mox = CmdMox()
+    stub = mox.stub("foo")
+    with pytest.raises(ValueError, match="only valid for spies"):
+        stub.passthrough()

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1165,7 +1165,7 @@ localising error handling and environment cleanup details.
 Spies now support a ``passthrough()`` mode that executes the real command
 instead of a canned response. When a passthrough spy is invoked, the controller
 locates the real executable using the original ``PATH`` preserved by the
-``EnvironmentManager``. The manager now exposes this data via a new
+``EnvironmentManager``. The manager exposes this via a new
 ``original_environment`` property. A small ``CommandRunner`` helper
 encapsulates the lookup and ``subprocess.run`` call. It runs the command with
 the recorded environment (minus the shim directory) and captures its output and

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -93,3 +93,25 @@ Feature: CmdMox basic functionality
     And the stderr should contain "not found"
     When I verify the controller
     Then the spy "bogus" should record 1 invocation
+
+  Scenario: passthrough spy handles permission error
+    Given a CmdMox controller
+    And the command "dummycmd" is spied to passthrough
+    And the command "dummycmd" resolves to a non-executable file
+    When I replay the controller
+    And I run the command "dummycmd" expecting failure
+    Then the exit code should be 126
+    And the stderr should contain "not executable"
+    When I verify the controller
+    Then the spy "dummycmd" should record 1 invocation
+
+  Scenario: passthrough spy handles timeout
+    Given a CmdMox controller
+    And the command "echo" is spied to passthrough
+    And the command "echo" will timeout
+    When I replay the controller
+    And I run the command "echo" expecting failure
+    Then the exit code should be 124
+    And the stderr should contain "timeout after 30 seconds"
+    When I verify the controller
+    Then the spy "echo" should record 1 invocation


### PR DESCRIPTION
## Summary
- ensure PATH fallback uses os.environ in command runner
- return 127 for missing commands
- add passthrough tests for permission error and timeouts
- test env precedence in command runner
- refactor execute_double_strategy for clarity
- document passthrough behaviour and wrap docs

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688a7d30ba908322a010504c25ad4b8d

## Summary by Sourcery

Improve passthrough spy error handling by returning appropriate exit codes for missing, permission, and timeout errors, enhancing PATH resolution fallback, refactoring environment application logic in the controller, and adding corresponding tests and documentation.

Bug Fixes:
- Return distinct exit codes for missing commands (127), permission errors (126), and timeouts (124) in passthrough mode

Enhancements:
- Fallback to os.environ PATH when original environment PATH is unavailable
- Refactor controller’s execute_double_strategy with a helper for applying temporary environment

Documentation:
- Document passthrough spy behaviour and new original_environment property in design docs

Tests:
- Add BDD scenarios for passthrough spy permission errors and timeouts
- Add unit tests for command_runner env precedence and invalid passthrough usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages and exit codes for command execution failures, including clearer handling of not found, permission denied, and timeout errors.
  * Ensured that system PATH is used as a fallback when command lookup PATH is missing.

* **Refactor**
  * Streamlined environment variable handling and error response formatting for more consistent behavior.

* **Tests**
  * Added unit and behavior-driven tests for command execution, environment handling, passthrough spies, and error scenarios.

* **Documentation**
  * Minor wording update for improved clarity in the design documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->