### PR TITLE
Fix replay error cleanup

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -373,13 +373,7 @@ class CmdMox:
 
     def _cleanup_after_replay_error(self) -> None:
         """Stop the server and restore the environment after failure."""
-        if self._server is not None:
-            try:
-                self._server.stop()
-            finally:
-                self._server = None
-        self.environment.__exit__(None, None, None)
-        self._entered = False
+        self.__exit__(None, None, None)
 
     def _check_verify_preconditions(self) -> None:
         """Ensure verify() is called in the correct phase."""

--- a/tests/test_replay_error.py
+++ b/tests/test_replay_error.py
@@ -1,0 +1,30 @@
+"""Tests for replay error cleanup logic."""
+
+from __future__ import annotations
+
+import os
+import typing as t
+
+import pytest
+
+import cmd_mox.controller as controller
+from cmd_mox import CmdMox
+
+
+def test_replay_cleanup_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure environment is restored when replay setup fails."""
+    mox = CmdMox()
+    pre_env = os.environ.copy()
+    mox.__enter__()
+
+    def boom(*_args: object, **_kwargs: object) -> t.NoReturn:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(controller, "create_shim_symlinks", boom)
+
+    with pytest.raises(RuntimeError):
+        mox.replay()
+
+    assert mox._server is None
+    assert not mox._entered
+    assert os.environ == pre_env


### PR DESCRIPTION
## Summary
- use `__exit__` helper in `_cleanup_after_replay_error`
- verify the environment resets when replay fails

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6888f89edf40832281f3e8bafc33f8e8

## Summary by Sourcery

Fix the cleanup logic after a replay error by replacing manual teardown with the __exit__ helper and validate the cleanup behavior with a new test

Enhancements:
- Simplify replay error cleanup by delegating to the __exit__ helper

Tests:
- Add a test to verify server shutdown, environment reset, and entered flag reset when replay fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify proper cleanup of environment and internal state after a replay error.

* **Refactor**
  * Simplified the cleanup process after a replay error by consolidating logic into a single method call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->