### PR TITLE
Improve IPC timeout docs

### DIFF
--- a/cmd_mox/ipc.py
+++ b/cmd_mox/ipc.py
@@ -92,9 +92,10 @@ class IPCServer:
     :class:`~cmd_mox.environment.EnvironmentManager`. Clients connect via the
     ``CMOX_IPC_SOCKET`` path and communicate using JSON messages. Connection
     attempts default to a five second timeout, but this can be overridden by
-    setting ``CMOX_IPC_TIMEOUT`` in the environment. See the `IPC server`
-    section of the design document for details on the rationale and
-    configuration: ``docs/python-native-command-mocking-design.md``.
+    setting :data:`~cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` in the
+    environment. See the `IPC server` section of the design document for
+    details on the rationale and configuration:
+    ``docs/python-native-command-mocking-design.md``.
     """
 
     def __init__(

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -456,7 +456,8 @@ parsed into `Invocation` objects and processed in background threads with
 reasonable timeouts. Responses are JSON encoded `stdout`, `stderr`, and
 `exit_code` data. The server cleans up the socket on shutdown to prevent stale
 sockets from interfering with subsequent tests. The communication timeout is
-configurable via the `CMOX_IPC_TIMEOUT` environment variable.
+configurable via the :data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV`
+environment variable.
 
 To avoid races and corrupted state, `IPCServer.start()` first checks if an
 existing socket is in use before unlinking it. After launching the background
@@ -536,7 +537,8 @@ that handles all modifications to the process environment.
 
   1. It will set any other necessary environment variables for the IPC
      mechanism, such as `CMOX_IPC_SOCKET`. Clients may additionally honour
-     `CMOX_IPC_TIMEOUT` to override the default connection timeout.
+     :data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` to override the default
+     connection timeout.
 
 - On `__exit__`:
 


### PR DESCRIPTION
## Summary
- clarify environment variable usage in `IPCServer` docstring

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6888f8a599e48322886b6a5de91a7103

## Summary by Sourcery

Improve IPCServer docstring to clarify usage of environment variables for socket path and timeout, and link to design documentation

Documentation:
- Clarify usage of CMOX_IPC_SOCKET for specifying the Unix domain socket path
- Document default 5-second IPC timeout and how to override it via CMOX_IPC_TIMEOUT
- Add reference to the IPC server section in the design document for further details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the documentation for the IPC server, providing detailed usage instructions, configuration options, and references to design documentation. No changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->