### PR TITLE
Improve shim command validation

### DIFF
--- a/cmd_mox/shimgen.py
+++ b/cmd_mox/shimgen.py
@@ -9,40 +9,45 @@ from pathlib import Path
 SHIM_PATH = Path(__file__).with_name("shim.py").resolve()
 
 
-def _check_not_empty(name: str) -> None:
+def _check_not_empty(name: str, error_msg: str) -> None:
     """Disallow empty names so we never create ``directory/`` itself."""
     if not name:
-        msg = f"Invalid command name: {name!r}"
-        raise ValueError(msg)
+        raise ValueError(error_msg)
 
 
-def _check_not_special_dirs(name: str) -> None:
+def _check_not_special_dirs(name: str, error_msg: str) -> None:
     """Reject ``.`` or ``..`` which would resolve to the current or parent directory."""
     if name in {".", ".."}:
-        msg = f"Invalid command name: {name!r}"
-        raise ValueError(msg)
+        raise ValueError(error_msg)
 
 
-def _check_no_path_separators(name: str) -> None:
+def _check_no_path_separators(name: str, error_msg: str) -> None:
     """Ensure the name does not include path separators for portability."""
-    if any(sep in name for sep in ("/", "\\")):
-        msg = f"Invalid command name: {name!r}"
-        raise ValueError(msg)
+    separators = {"/", "\\", os.sep}
+    if os.altsep:
+        separators.add(os.altsep)
+    if any(sep in name for sep in separators):
+        raise ValueError(error_msg)
 
 
-def _check_no_nul_byte(name: str) -> None:
+def _check_no_nul_byte(name: str, error_msg: str) -> None:
     """Reject names containing NUL bytes to avoid filename truncation."""
     if "\x00" in name:
-        msg = f"Invalid command name: {name!r}"
-        raise ValueError(msg)
+        raise ValueError(error_msg)
 
 
 def _validate_command_name(name: str) -> None:
     """Validate *name* is a safe command filename."""
-    _check_not_empty(name)
-    _check_not_special_dirs(name)
-    _check_no_path_separators(name)
-    _check_no_nul_byte(name)
+    error_msg = f"Invalid command name: {name!r}"
+
+    # Disallow empty names so we never create ``directory/`` itself.
+    _check_not_empty(name, error_msg)
+    # Reject ``.`` or ``..`` which would resolve to the current or parent directory.
+    _check_not_special_dirs(name, error_msg)
+    # Ensure the name does not include path separators for portability.
+    _check_no_path_separators(name, error_msg)
+    # Reject names containing NUL bytes to avoid filename truncation.
+    _check_no_nul_byte(name, error_msg)
 
 
 def create_shim_symlinks(directory: Path, commands: t.Iterable[str]) -> dict[str, Path]:


### PR DESCRIPTION
## Summary
- clarify `_validate_command_name` checks
- keep behaviour but add explicit comments

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f8a83b2c832297a088fb9c3a984e

## Summary by Sourcery

Refactor shim command name validation to use explicit checks with explanatory comments

Enhancements:
- Split the combined invalid-name condition into separate checks for empty names, "."/"..", path separators, and NUL bytes
- Add descriptive comments and dedicated error messages for each invalid case to clarify the validation logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the clarity and granularity of command name validation error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->