### PR TITLE
Refactor controller shutdown logic

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -397,6 +397,10 @@ class CmdMox:
     ) -> None:
         """Stop the IPC server and exit the environment manager.
 
+        This helper underpins :py:meth:`__exit__`,
+        :py:meth:`_cleanup_after_replay_error`, and
+        :py:meth:`_finalize_verification`.
+
         Parameters
         ----------
         exc_type, exc, tb:

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -259,7 +259,7 @@ class CmdMox:
         if self._handle_auto_verify(exc_type):
             return
 
-        self._shutdown(exc_type, exc, tb)
+        self._stop_server_and_exit_env(exc_type, exc, tb)
 
     def _handle_auto_verify(self, exc_type: type[BaseException] | None) -> bool:
         """Invoke :meth:`verify` when exiting a replay block."""
@@ -389,25 +389,37 @@ class CmdMox:
         )
         self._server.start()
 
-    def _shutdown(
+    def _stop_server_and_exit_env(
         self,
         exc_type: type[BaseException] | None = None,
         exc: BaseException | None = None,
         tb: TracebackType | None = None,
     ) -> None:
-        """Stop the IPC server and exit the environment manager."""
+        """Stop the IPC server and exit the environment manager.
+
+        Parameters
+        ----------
+        exc_type, exc, tb:
+            Exception information forwarded to
+            :meth:`EnvironmentManager.__exit__`. Pass ``None`` for all three
+            when no exception is being handled.
+
+        This method is idempotent so it is safe to call multiple times from
+        different cleanup paths.
+        """
         if self._server is not None:
             try:
                 self._server.stop()
             finally:
                 self._server = None
+
         if self._entered:
             self.environment.__exit__(exc_type, exc, tb)
             self._entered = False
 
     def _cleanup_after_replay_error(self) -> None:
         """Stop the server and restore the environment after failure."""
-        self._shutdown()
+        self._stop_server_and_exit_env()
 
     def _check_verify_preconditions(self) -> None:
         """Ensure verify() is called in the correct phase."""
@@ -429,5 +441,5 @@ class CmdMox:
 
     def _finalize_verification(self) -> None:
         """Stop the server, clean up the environment, and update phase."""
-        self._shutdown()
+        self._stop_server_and_exit_env()
         self._phase = Phase.VERIFY


### PR DESCRIPTION
## Summary
- introduce `_shutdown` helper to encapsulate server stop and environment exit
- use this helper in `__exit__`, `_cleanup_after_replay_error`, and `_finalize_verification`

## Testing
- `make typecheck`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f8af60508322b948b3469d00ad3b

## Summary by Sourcery

Refactor controller shutdown logic to centralize server stopping and environment cleanup into a new _shutdown helper, replacing duplicated code in exit, error cleanup, and verification finalization.

Enhancements:
- Introduce a _shutdown helper to encapsulate stopping the IPC server and exiting the environment manager
- Replace duplicated shutdown code in __exit__, _cleanup_after_replay_error, and _finalize_verification with calls to _shutdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal cleanup processes for stopping the server and exiting the environment manager, consolidating duplicated logic for greater reliability and maintainability. No changes to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->