### PR TITLE
Refactor server shutdown helper

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -242,11 +242,7 @@ class CmdMox:
         if self._handle_auto_verify(exc_type):
             return
 
-        if self._server is not None:
-            try:
-                self._server.stop()
-            finally:
-                self._server = None
+        self._stop_server()
         if self._entered:
             self.environment.__exit__(exc_type, exc, tb)
             self._entered = False
@@ -371,13 +367,17 @@ class CmdMox:
         )
         self._server.start()
 
-    def _cleanup_after_replay_error(self) -> None:
-        """Stop the server and restore the environment after failure."""
+    def _stop_server(self) -> None:
+        """Stop the IPC server and clear the reference."""
         if self._server is not None:
             try:
                 self._server.stop()
             finally:
                 self._server = None
+
+    def _cleanup_after_replay_error(self) -> None:
+        """Stop the server and restore the environment after failure."""
+        self._stop_server()
         self.environment.__exit__(None, None, None)
         self._entered = False
 
@@ -401,11 +401,7 @@ class CmdMox:
 
     def _finalize_verification(self) -> None:
         """Stop the server, clean up the environment, and update phase."""
-        if self._server is not None:
-            try:
-                self._server.stop()
-            finally:
-                self._server = None
+        self._stop_server()
         if self._entered:
             self.environment.__exit__(None, None, None)
             self._entered = False


### PR DESCRIPTION
## Summary
- add `_stop_server()` to consolidate cleanup logic
- use new helper in `__exit__`, `_cleanup_after_replay_error`, and `_finalize_verification`

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f8c689c4832299f6742a3c2d5e74

## Summary by Sourcery

Introduce a dedicated `_stop_server()` method to centralize IPC server termination and update existing cleanup and exit routines to use this helper.

Enhancements:
- Extract server shutdown logic into a `_stop_server()` helper to consolidate repetitive cleanup code
- Replace direct server stop calls in `__exit__`, `_cleanup_after_replay_error`, and `_finalize_verification` with the new helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal server shutdown logic for greater code clarity and maintainability. No changes to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->