### PR TITLE
Remove unused stop event from IPC server

### DIFF
--- a/cmd_mox/ipc.py
+++ b/cmd_mox/ipc.py
@@ -106,7 +106,6 @@ class IPCServer:
         self.accept_timeout = accept_timeout or min(0.1, timeout / 10)
         self._server: _InnerServer | None = None
         self._thread: threading.Thread | None = None
-        self._stop = threading.Event()
 
     # ------------------------------------------------------------------
     # Context manager protocol
@@ -134,7 +133,6 @@ class IPCServer:
             msg = "IPC server already started"
             raise RuntimeError(msg)
 
-        self._stop.clear()
         if self.socket_path.exists():
             try:
                 # Verify the socket isn't in use before removing it to avoid
@@ -175,7 +173,6 @@ class IPCServer:
 
     def stop(self) -> None:
         """Stop the server and clean up the socket."""
-        self._stop.set()
         if self._server:
             self._server.shutdown()
             self._server.server_close()

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -472,7 +472,6 @@ classDiagram
         - float timeout
         - _InnerServer _server
         - Thread _thread
-        - Event _stop
         + __enter__() IPCServer
         + __exit__(exc_type, exc, tb) None
         + start() None


### PR DESCRIPTION
## Summary
- drop `_stop` event from IPCServer
- update design document diagram

## Testing
- `make lint`
- `make typecheck`
- `make markdownlint`
- `make test`
- `make nixie` *(fails: ENOENT reading puppeteer browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6888f8c98b0883229f64c35e5bace7dc

## Summary by Sourcery

Remove the unused _stop event from the IPCServer implementation and update the design documentation to reflect this change.

Enhancements:
- Remove the _stop threading.Event and its related calls from the IPCServer class

Documentation:
- Update the class diagram in the design document to remove the _stop event attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the design document to remove references to a private event attribute in the IPCServer class diagram, simplifying its representation.

* **Refactor**
  * Internal event signaling mechanism removed from the IPCServer, streamlining its lifecycle management. No changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->