### PR TITLE
Refactor comparator reprs

### DIFF
--- a/cmd_mox/comparators.py
+++ b/cmd_mox/comparators.py
@@ -7,11 +7,16 @@ import typing as t
 
 
 class _ReprMixin:
-    """Provide a generic ``__repr__`` based on public attributes."""
+    """Generate ``repr`` from public attributes.
 
-    def __repr__(self) -> str:  # pragma: no cover - debug helper
+    Private attributes (those starting with ``_``) are omitted. Attributes are
+    sorted alphabetically to keep the output stable even if ``__init__`` order
+    changes.
+    """
+
+    def __repr__(self) -> str:
         attrs = ", ".join(
-            f"{k}={v!r}" for k, v in vars(self).items() if not k.startswith("_")
+            f"{k}={v!r}" for k, v in sorted(vars(self).items()) if not k.startswith("_")
         )
         return f"{self.__class__.__name__}({attrs})"
 

--- a/cmd_mox/comparators.py
+++ b/cmd_mox/comparators.py
@@ -6,6 +6,16 @@ import re
 import typing as t
 
 
+class _ReprMixin:
+    """Provide a generic ``__repr__`` based on public attributes."""
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        attrs = ", ".join(
+            f"{k}={v!r}" for k, v in vars(self).items() if not k.startswith("_")
+        )
+        return f"{self.__class__.__name__}({attrs})"
+
+
 class Comparator(t.Protocol):
     """Callable returning ``True`` when a value matches."""
 
@@ -14,19 +24,15 @@ class Comparator(t.Protocol):
         ...
 
 
-class Any:
+class Any(_ReprMixin):
     """Match any value."""
 
     def __call__(self, value: str) -> bool:
         """Return ``True`` for any input."""
         return True
 
-    def __repr__(self) -> str:  # pragma: no cover - debug helper
-        """Return a debug representation."""
-        return "Any()"
 
-
-class IsA:
+class IsA(_ReprMixin):
     """Match values convertible to ``typ``."""
 
     def __init__(self, typ: type) -> None:
@@ -40,27 +46,20 @@ class IsA:
             return False
         return True
 
-    def __repr__(self) -> str:  # pragma: no cover - debug helper
-        """Return a debug representation."""
-        return f"IsA({self.typ.__name__})"
 
-
-class Regex:
+class Regex(_ReprMixin):
     """Match if *value* matches ``pattern``."""
 
     def __init__(self, pattern: str) -> None:
+        self.pattern = pattern
         self._pattern = re.compile(pattern)
 
     def __call__(self, value: str) -> bool:
         """Return ``True`` if the regex matches *value*."""
         return bool(self._pattern.search(value))
 
-    def __repr__(self) -> str:  # pragma: no cover - debug helper
-        """Return a debug representation."""
-        return f"Regex({self._pattern.pattern!r})"
 
-
-class Contains:
+class Contains(_ReprMixin):
     """Match if ``substring`` is found in *value*."""
 
     def __init__(self, substring: str) -> None:
@@ -70,12 +69,8 @@ class Contains:
         """Return ``True`` if ``substring`` is in *value*."""
         return self.substring in value
 
-    def __repr__(self) -> str:  # pragma: no cover - debug helper
-        """Return a debug representation."""
-        return f"Contains({self.substring!r})"
 
-
-class StartsWith:
+class StartsWith(_ReprMixin):
     """Match if *value* begins with ``prefix``."""
 
     def __init__(self, prefix: str) -> None:
@@ -85,12 +80,8 @@ class StartsWith:
         """Return ``True`` if *value* starts with ``prefix``."""
         return value.startswith(self.prefix)
 
-    def __repr__(self) -> str:  # pragma: no cover - debug helper
-        """Return a debug representation."""
-        return f"StartsWith({self.prefix!r})"
 
-
-class Predicate:
+class Predicate(_ReprMixin):
     """Use a custom ``func`` to determine a match."""
 
     def __init__(self, func: t.Callable[[str], bool]) -> None:
@@ -99,10 +90,6 @@ class Predicate:
     def __call__(self, value: str) -> bool:
         """Return ``True`` if ``func(value)`` is truthy."""
         return bool(self.func(value))
-
-    def __repr__(self) -> str:  # pragma: no cover - debug helper
-        """Return a debug representation."""
-        return f"Predicate({self.func})"
 
 
 __all__ = [

--- a/tests/test_comparators_repr.py
+++ b/tests/test_comparators_repr.py
@@ -13,6 +13,18 @@ def test_is_a_repr() -> None:
     assert repr(IsA(int)) == "IsA(typ=<class 'int'>)"
 
 
+class CustomType:
+    """Example user-defined type for ``IsA`` tests."""
+
+    pass
+
+
+def test_is_a_repr_with_custom_type() -> None:
+    """User-defined classes show their fully-qualified name."""
+    expected = f"IsA(typ=<class '{CustomType.__module__}.{CustomType.__qualname__}'>)"
+    assert repr(IsA(CustomType)) == expected
+
+
 def test_regex_repr() -> None:
     """``Regex`` exposes its original pattern string."""
     assert repr(Regex(r"^foo$")) == "Regex(pattern='^foo$')"
@@ -36,4 +48,20 @@ def test_predicate_repr() -> None:
 
     rep = repr(Predicate(func))
     assert rep.startswith("Predicate(func=<function")
+    assert rep.endswith(")")
+
+
+def test_predicate_repr_lambda() -> None:
+    """Lambda functions are represented generically."""
+    rep = repr(Predicate(lambda v: True))
+    assert rep.startswith("Predicate(func=<function")
+    assert "lambda" in rep
+    assert rep.endswith(")")
+
+
+def test_predicate_repr_builtin() -> None:
+    """Built-in functions include their name."""
+    rep = repr(Predicate(str.isdigit))
+    assert "isdigit" in rep
+    assert rep.startswith("Predicate(func=<")
     assert rep.endswith(")")

--- a/tests/test_comparators_repr.py
+++ b/tests/test_comparators_repr.py
@@ -1,0 +1,39 @@
+"""Unit tests for :mod:`cmd_mox.comparators` repr behaviour."""
+
+from cmd_mox.comparators import Any, Contains, IsA, Predicate, Regex, StartsWith
+
+
+def test_any_repr() -> None:
+    """``Any`` shows only its class name."""
+    assert repr(Any()) == "Any()"
+
+
+def test_is_a_repr() -> None:
+    """``IsA`` includes the ``typ`` parameter."""
+    assert repr(IsA(int)) == "IsA(typ=<class 'int'>)"
+
+
+def test_regex_repr() -> None:
+    """``Regex`` exposes its original pattern string."""
+    assert repr(Regex(r"^foo$")) == "Regex(pattern='^foo$')"
+
+
+def test_contains_repr() -> None:
+    """``Contains`` shows the substring."""
+    assert repr(Contains("bar")) == "Contains(substring='bar')"
+
+
+def test_startswith_repr() -> None:
+    """``StartsWith`` shows the prefix."""
+    assert repr(StartsWith("bar")) == "StartsWith(prefix='bar')"
+
+
+def test_predicate_repr() -> None:
+    """``Predicate`` includes the callable reference."""
+
+    def func(v: str) -> bool:
+        return True
+
+    rep = repr(Predicate(func))
+    assert rep.startswith("Predicate(func=<function")
+    assert rep.endswith(")")


### PR DESCRIPTION
## Summary
- create `_ReprMixin` to provide a generic `__repr__`
- use mixin across all comparator classes
- add regression tests for repr logic

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888f8d95f6c8322a1bb02da2979abcd

## Summary by Sourcery

Provide a reusable repr mixin for comparators and clean up redundant __repr__ methods while adding tests for consistent repr output

Enhancements:
- Introduce _ReprMixin to generate __repr__ based on public attributes
- Update all comparator classes to inherit from _ReprMixin and remove custom __repr__ implementations

Tests:
- Add regression tests to verify repr outputs for all comparator classes