### PR TITLE
Fix passthrough spies

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -344,7 +344,9 @@ class CmdMox:
     ) -> Response:
         """Run ``double``'s handler within its expectation environment."""
         env = double.expectation.env
-        if double.handler is None:
+        if double.passthrough_mode:
+            resp = self._runner.run(invocation, env)
+        elif double.handler is None:
             resp = double.response
         elif env:
             with temporary_env(env):

--- a/cmd_mox/unittests/test_controller.py
+++ b/cmd_mox/unittests/test_controller.py
@@ -16,7 +16,7 @@ from cmd_mox.errors import (
     MissingEnvironmentError,
     UnexpectedCommandError,
 )
-from cmd_mox.ipc import Response, Invokation
+from cmd_mox.ipc import Invocation, Response
 
 if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
     import subprocess


### PR DESCRIPTION
## Summary
- fix import typo in test_controller
- forward passthrough spies to the real command

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688cb80cbcfc83229c4b38dd79661edf

## Summary by Sourcery

Add passthrough mode handling in the controller to forward invocations to the actual runner and fix the import typo in the controller tests.

New Features:
- Add support for passthrough spies by forwarding invocations to the real command runner

Bug Fixes:
- Correct the import typo in test_controller from `Invokation` to `Invocation`