### PR TITLE
Call __exit__ for replay cleanup

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -254,11 +254,18 @@ class CmdMox:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         tb: TracebackType | None,
-    ) -> None:  # pragma: no cover - thin wrapper
+    ) -> None:
         """Exit context, optionally verifying and cleaning up."""
         if self._handle_auto_verify(exc_type):
             return
-        self._stop_server_and_exit_env(exc_type, exc, tb)
+        if self._server is not None:
+            try:
+                self._server.stop()
+            finally:
+                self._server = None
+        if self._entered:
+            self.environment.__exit__(exc_type, exc, tb)
+            self._entered = False
 
     def _handle_auto_verify(self, exc_type: type[BaseException] | None) -> bool:
         """Invoke :meth:`verify` when exiting a replay block."""
@@ -390,38 +397,6 @@ class CmdMox:
         )
         self._server.start()
 
-    def _stop_server_and_exit_env(
-        self,
-        exc_type: type[BaseException] | None = None,
-        exc: BaseException | None = None,
-        tb: TracebackType | None = None,
-    ) -> None:
-        """Stop the IPC server and exit the environment manager.
-
-        This helper underpins :py:meth:`__exit__`,
-        :py:meth:`_cleanup_after_replay_error`, and
-        :py:meth:`_finalize_verification`.
-
-        Parameters
-        ----------
-        exc_type, exc, tb:
-            Exception information forwarded to
-            :meth:`EnvironmentManager.__exit__`. Pass ``None`` for all three
-            when no exception is being handled.
-
-        This method is idempotent so it is safe to call multiple times from
-        different cleanup paths.
-        """
-        if self._server is not None:
-            try:
-                self._server.stop()
-            finally:
-                self._server = None
-
-        if self._entered:
-            self.environment.__exit__(exc_type, exc, tb)
-            self._entered = False
-
     def _cleanup_after_replay_error(self) -> None:
         """Stop the server and restore the environment after failure."""
         self.__exit__(None, None, None)
@@ -446,5 +421,10 @@ class CmdMox:
 
     def _finalize_verification(self) -> None:
         """Stop the server, clean up the environment, and update phase."""
-        self._stop_server_and_exit_env()
+        verify_on_exit = self._verify_on_exit
+        self._verify_on_exit = False
+        try:
+            self.__exit__(None, None, None)
+        finally:
+            self._verify_on_exit = verify_on_exit
         self._phase = Phase.VERIFY

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -424,7 +424,7 @@ class CmdMox:
 
     def _cleanup_after_replay_error(self) -> None:
         """Stop the server and restore the environment after failure."""
-        self._stop_server_and_exit_env()
+        self.__exit__(None, None, None)
 
     def _check_verify_preconditions(self) -> None:
         """Ensure verify() is called in the correct phase."""

--- a/tests/test_replay_error.py
+++ b/tests/test_replay_error.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import os
 import typing as t
 
+if t.TYPE_CHECKING:  # pragma: no cover - typing only
+    from types import TracebackType
+
 import pytest
 
 import cmd_mox.controller as controller
@@ -17,14 +20,30 @@ def test_replay_cleanup_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
     pre_env = os.environ.copy()
     mox.__enter__()
 
+    called: list[
+        tuple[type[BaseException] | None, BaseException | None, TracebackType | None]
+    ] = []
+    orig_exit = CmdMox.__exit__
+
+    def fake_exit(
+        self: CmdMox,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        called.append((exc_type, exc, tb))
+        orig_exit(self, exc_type, exc, tb)
+
     def boom(*_args: object, **_kwargs: object) -> t.NoReturn:
         raise RuntimeError("boom")
 
+    monkeypatch.setattr(CmdMox, "__exit__", fake_exit)
     monkeypatch.setattr(controller, "create_shim_symlinks", boom)
 
     with pytest.raises(RuntimeError):
         mox.replay()
 
+    assert called == [(None, None, None)]
     assert mox._server is None
     assert not mox._entered
     assert os.environ == pre_env


### PR DESCRIPTION
## Summary
- simplify replay error handling by delegating cleanup to `__exit__`
- assert `__exit__` invocation during replay failure

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688dce2f5b44832281c35e16cc5ca07b

## Summary by Sourcery

Delegate replay error cleanup to the context manager's __exit__ method and assert its invocation in tests

Enhancements:
- Simplify replay error cleanup by replacing direct call to _stop_server_and_exit_env with a call to __exit__

Tests:
- Monkeypatch CmdMox.__exit__ in test_replay_error to capture its arguments and assert it's called with (None, None, None) on replay failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced tests to verify proper cleanup and exception handling during error scenarios.
  * Added a new test to confirm that the correct exception details are passed during context exit.
  * Improved assertions to ensure environment and internal state are restored after errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->