### PR TITLE
Refactor command name validation for clarity

### DIFF
--- a/cmd_mox/shimgen.py
+++ b/cmd_mox/shimgen.py
@@ -9,45 +9,28 @@ from pathlib import Path
 SHIM_PATH = Path(__file__).with_name("shim.py").resolve()
 
 
-def _check_not_empty(name: str, error_msg: str) -> None:
-    """Disallow empty names so we never create ``directory/`` itself."""
+def _validate_command_name(name: str) -> None:
+    """Validate *name* is a safe command filename."""
+    error_msg = f"Invalid command name: {name!r}"
+
+    # Disallow empty names so we never create ``directory/`` itself.
     if not name:
         raise ValueError(error_msg)
 
-
-def _check_not_special_dirs(name: str, error_msg: str) -> None:
-    """Reject ``.`` or ``..`` which would resolve to the current or parent directory."""
+    # Reject ``.`` or ``..`` which would resolve to the current or parent directory.
     if name in {".", ".."}:
         raise ValueError(error_msg)
 
-
-def _check_no_path_separators(name: str, error_msg: str) -> None:
-    """Ensure the name does not include path separators for portability."""
+    # Ensure the name does not include path separators for portability.
     separators = {"/", "\\", os.sep}
     if os.altsep:
         separators.add(os.altsep)
     if any(sep in name for sep in separators):
         raise ValueError(error_msg)
 
-
-def _check_no_nul_byte(name: str, error_msg: str) -> None:
-    """Reject names containing NUL bytes to avoid filename truncation."""
+    # Reject names containing NUL bytes to avoid filename truncation.
     if "\x00" in name:
         raise ValueError(error_msg)
-
-
-def _validate_command_name(name: str) -> None:
-    """Validate *name* is a safe command filename."""
-    error_msg = f"Invalid command name: {name!r}"
-
-    # Disallow empty names so we never create ``directory/`` itself.
-    _check_not_empty(name, error_msg)
-    # Reject ``.`` or ``..`` which would resolve to the current or parent directory.
-    _check_not_special_dirs(name, error_msg)
-    # Ensure the name does not include path separators for portability.
-    _check_no_path_separators(name, error_msg)
-    # Reject names containing NUL bytes to avoid filename truncation.
-    _check_no_nul_byte(name, error_msg)
 
 
 def create_shim_symlinks(directory: Path, commands: t.Iterable[str]) -> dict[str, Path]:


### PR DESCRIPTION
## Summary
- inline command name validation steps for readability

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688dce54df5c8322858dc76baf5eee0f