### PR TITLE
Refactor precondition checks into helpers

### DIFF
--- a/cmd_mox/unittests/test_controller.py
+++ b/cmd_mox/unittests/test_controller.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from cmd_mox.controller import CmdMox, MockCommand, SpyCommand, StubCommand
+from cmd_mox.controller import CmdMox, MockCommand, Phase, SpyCommand, StubCommand
 from cmd_mox.errors import (
     LifecycleError,
     MissingEnvironmentError,
@@ -127,6 +127,23 @@ def test_cmdmox_missing_environment_attributes(monkeypatch: pytest.MonkeyPatch) 
     with pytest.raises(MissingEnvironmentError, match="socket_path"):
         mox.replay()
 
+    mox.__exit__(None, None, None)
+
+
+def test_require_phase_mismatch() -> None:
+    """_require_phase raises when current phase does not match."""
+    mox = CmdMox()
+    with pytest.raises(LifecycleError, match="expected 'replay'"):
+        mox._require_phase(Phase.REPLAY)
+
+
+def test_require_env_attrs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_require_env_attrs reports missing EnvironmentManager attributes."""
+    mox = CmdMox()
+    mox.__enter__()
+    monkeypatch.setattr(mox.environment, "shim_dir", None)
+    with pytest.raises(MissingEnvironmentError, match="shim_dir"):
+        mox._require_env_attrs("shim_dir", "socket_path")
     mox.__exit__(None, None, None)
 
 


### PR DESCRIPTION
## Summary
- add internal helpers for phase and environment validation
- use helpers in replay and verify precondition checks
- test phase/env helpers directly

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688dcebf5668832294b8111b92387307

## Summary by Sourcery

Extract phase and environment validation into reusable helpers and streamline precondition checks in replay and verify methods

Enhancements:
- Add _require_phase helper to enforce lifecycle phase requirements
- Add _require_env_attrs helper to validate non-null environment attributes
- Refactor _check_replay_preconditions and _check_verify_preconditions to use the new helpers

Tests:
- Add unit tests for _require_phase phase mismatch error
- Add unit tests for _require_env_attrs missing environment attributes error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal validation for lifecycle phase and environment attributes, centralizing error handling for more consistent checks.
* **Tests**
  * Added new tests to verify error handling for phase mismatches and missing environment attributes during key operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->