### PR TITLE
Delegate expectation helpers via __getattr__

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -193,11 +193,16 @@ def _make_proxy(name: str, exp_name: str) -> t.Callable[..., CommandDouble]:
     return proxy
 
 
-for _name, _exp_name in CommandDouble._DELEGATED_METHODS.items():
-    if not hasattr(Expectation, _exp_name):  # pragma: no cover - sanity check
-        msg = f"Expectation has no method {_exp_name}"
-        raise AttributeError(msg)
-    setattr(CommandDouble, _name, _make_proxy(_name, _exp_name))
+def _setup_delegated_methods() -> None:
+    """Set up proxy methods on CommandDouble for expectation delegation."""
+    for _name, _exp_name in CommandDouble._DELEGATED_METHODS.items():
+        if not hasattr(Expectation, _exp_name):  # pragma: no cover - sanity check
+            msg = f"Expectation has no method {_exp_name}"
+            raise AttributeError(msg)
+        setattr(CommandDouble, _name, _make_proxy(_name, _exp_name))
+
+
+_setup_delegated_methods()
 
 
 # Backwards compatibility aliases


### PR DESCRIPTION
## Summary
- delegate expectation helper calls through `__getattr__`

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6891acdc87608322a50162ee6258889d

## Summary by Sourcery

Delegate expectation helper methods to the underlying expectation via __getattr__, removing explicit boilerplate helpers and centralizing delegation logic.

Enhancements:
- Introduce a DELEGATED_METHODS mapping and __getattr__ to dynamically proxy expectation methods.
- Remove explicit expectation helper methods (with_args, with_matching_args, with_stdin, with_env, times, in_order, any_order) from CommandDouble.
- Retain in_order and any_order ordering updates within the dynamic wrapper to manage controller._ordered correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved maintainability by centralizing and automating the delegation of expectation-related methods, reducing boilerplate and streamlining method chaining for command configuration.
* **Style**
  * Minor adjustments to import and type variable placement for improved code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->