### PR TITLE
Refactor temporary directory cleanup checks

### DIFF
--- a/cmd_mox/environment.py
+++ b/cmd_mox/environment.py
@@ -223,8 +223,8 @@ class EnvironmentManager:
     def _cleanup_temporary_directory(self, _cleanup_errors: list[CleanupError]) -> None:
         """Remove the temporary directory created by ``__enter__``."""
         try:
-            if self._should_remove_created_dir():
-                _robust_rmtree(t.cast("Path", self.shim_dir))
+            if self._should_remove_created_dir() and self.shim_dir is not None:
+                _robust_rmtree(self.shim_dir)
         finally:
             self._created_dir = None
 

--- a/cmd_mox/environment.py
+++ b/cmd_mox/environment.py
@@ -210,17 +210,21 @@ class EnvironmentManager:
         global _active_manager
         _active_manager = None
 
+    def _should_remove_created_dir(self) -> bool:
+        """Return ``True`` if the manager created a directory that still exists."""
+        return (
+            self._created_dir is not None
+            and self.shim_dir is not None
+            and self.shim_dir == self._created_dir
+            and self.shim_dir.exists()
+        )
+
     @_collect_os_error("Directory cleanup failed")
     def _cleanup_temporary_directory(self, _cleanup_errors: list[CleanupError]) -> None:
         """Remove the temporary directory created by ``__enter__``."""
         try:
-            if (
-                self._created_dir
-                and self.shim_dir
-                and self.shim_dir == self._created_dir
-                and self.shim_dir.exists()
-            ):
-                _robust_rmtree(self.shim_dir)
+            if self._should_remove_created_dir():
+                _robust_rmtree(t.cast("Path", self.shim_dir))
         finally:
             self._created_dir = None
 

--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -294,6 +294,28 @@ def test_environment_manager_cleanup_error_handling(
     _test_environment_cleanup_error(test_case)
 
 
+def test_should_remove_created_dir_when_directory_exists() -> None:
+    """Return True when the manager created a directory that still exists."""
+    with EnvironmentManager() as env:
+        assert env._should_remove_created_dir()
+
+
+def test_should_remove_created_dir_returns_false_when_directory_missing() -> None:
+    """Return False if the managed directory has been removed."""
+    with EnvironmentManager() as env:
+        assert env.shim_dir is not None
+        _robust_rmtree(env.shim_dir)
+        assert not env._should_remove_created_dir()
+
+
+def test_should_remove_created_dir_returns_false_after_exit() -> None:
+    """Return False once the context has cleaned up state."""
+    env = EnvironmentManager()
+    with env:
+        pass
+    assert not env._should_remove_created_dir()
+
+
 def test_environment_manager_readonly_file_cleanup(tmp_path: Path) -> None:
     """Test that cleanup handles read-only files appropriately."""
     # This test primarily checks the Windows-specific path but runs on all platforms

--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -316,6 +316,25 @@ def test_should_remove_created_dir_returns_false_after_exit() -> None:
     assert not env._should_remove_created_dir()
 
 
+def test_should_remove_created_dir_returns_false_when_never_entered() -> None:
+    """Return False if EnvironmentManager was never entered."""
+    env = EnvironmentManager()
+    assert not env._should_remove_created_dir()
+
+
+def test_cleanup_temporary_directory_skips_when_predicate_false() -> None:
+    """Skip directory removal if predicate returns False."""
+    mgr = EnvironmentManager()
+    with (
+        patch.object(mgr, "_should_remove_created_dir", return_value=False) as pred,
+        patch("cmd_mox.environment._robust_rmtree") as rm,
+    ):
+        cleanup_errors: list[envmod.CleanupError] = []
+        EnvironmentManager._cleanup_temporary_directory(mgr, cleanup_errors)
+    pred.assert_called_once()
+    rm.assert_not_called()
+
+
 def test_environment_manager_readonly_file_cleanup(tmp_path: Path) -> None:
     """Test that cleanup handles read-only files appropriately."""
     # This test primarily checks the Windows-specific path but runs on all platforms


### PR DESCRIPTION
## Summary
- factor out `_should_remove_created_dir` to isolate directory existence checks
- call helper from `_cleanup_temporary_directory`
- add unit tests for cleanup predicate

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6891ace2571883229106e148021f6286

## Summary by Sourcery

Extract the directory removal predicate into a dedicated helper, update the temporary directory cleanup to use this helper, and add unit tests for the new predicate.

Enhancements:
- Extract _should_remove_created_dir helper to encapsulate directory existence checks
- Update _cleanup_temporary_directory to use the new helper

Tests:
- Add unit tests for _should_remove_created_dir covering existing directory, missing directory, and post-exit scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new unit tests to verify directory cleanup behavior in environment management, ensuring correct handling of temporary directories under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->