### PR TITLE
Link module docstring to docs contents index

### DIFF
--- a/cmd_mox/__init__.py
+++ b/cmd_mox/__init__.py
@@ -1,7 +1,7 @@
 """Python-native command mocking built around a record-replay-verify lifecycle.
 
-For an overview of the architecture and guiding design, see the documentation
-in ``docs/contents.md``.
+For an overview of the architecture and guiding design, see the project
+documentation (`https://github.com/leynos/cmd-mox/blob/main/docs/contents.md`).
 """
 
 from __future__ import annotations

--- a/cmd_mox/__init__.py
+++ b/cmd_mox/__init__.py
@@ -1,7 +1,7 @@
 """Python-native command mocking built around a record-replay-verify lifecycle.
 
 For an overview of the architecture and guiding design, see the documentation
-in ``docs/``.
+in ``docs/contents.md``.
 """
 
 from __future__ import annotations

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -1,0 +1,8 @@
+# Documentation Contents
+
+- [Usage Guide](./usage-guide.md): Common patterns for mocking, stubbing and
+  spying on external commands.
+- [Python-native Command Mocking Design](./python-native-command-mocking-design.md)
+  : Architectural design and rationale.
+- [CmdMox Implementation Roadmap](./cmd-mox-roadmap.md): Planned features and
+  project progression.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -1,8 +1,5 @@
 # Documentation Contents
 
-- [Usage Guide](./usage-guide.md): Common patterns for mocking, stubbing and
-  spying on external commands.
-- [Python-native Command Mocking Design](./python-native-command-mocking-design.md)
-  : Architectural design and rationale.
-- [CmdMox Implementation Roadmap](./cmd-mox-roadmap.md): Planned features and
-  project progression.
+- [Usage Guide](./usage-guide.md): Mocking, stubbing, and spying on commands.
+- [Design Doc](./python-native-command-mocking-design.md): Design rationale.
+- [Roadmap](./cmd-mox-roadmap.md): Planned features and progression.


### PR DESCRIPTION
## Summary
- add `docs/contents.md` as an index of key project docs
- link `cmd_mox.__init__` module docstring to `docs/contents.md`

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: use strict: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891ee5d39608322bbdca76817ba5bfc

## Summary by Sourcery

Add a documentation contents index and update the module docstring to reference it

Enhancements:
- Link module docstring to documentation contents index for improved discoverability

Documentation:
- Add contents.md as an index of key project documentation and link to it from the module docstring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated module documentation reference for improved accuracy.
  * Added a new contents file with structured links to key documentation, including usage guides, design documents, and the project roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->