### PR TITLE
Consolidate TYPE_CHECKING block in controller

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -20,11 +20,6 @@ if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
 
     TracebackType = types.TracebackType
 
-T_Self = t.TypeVar("T_Self", bound="CommandDouble")
-
-
-if t.TYPE_CHECKING:  # pragma: no cover - typing only
-
     class _ExpectationProxy(t.Protocol):
         def with_args(self: T_Self, *args: str) -> T_Self: ...
 
@@ -47,6 +42,9 @@ else:  # pragma: no cover - runtime placeholder
 
     class _ExpectationProxy:
         pass
+
+
+T_Self = t.TypeVar("T_Self", bound="CommandDouble")
 
 
 class _CallbackIPCServer(IPCServer):


### PR DESCRIPTION
## Summary
- merge duplicate TYPE_CHECKING blocks in controller

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689279750d788322b8bc5c62f32c21e9

## Summary by Sourcery

Enhancements:
- Remove redundant TYPE_CHECKING guard and relocate the T_Self TypeVar definition adjacent to the _ExpectationProxy protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type variable placement for better consistency. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->