### PR TITLE
Add fluent expectation DSL

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -120,7 +120,7 @@ class CommandDouble(_ExpectationProxy):
         "with_matching_args": "with_matching_args",
         "with_stdin": "with_stdin",
         "with_env": "with_env",
-        "times": "times_called",
+        "times": "times",
         "times_called": "times_called",
         "in_order": "in_order",
         "any_order": "any_order",

--- a/cmd_mox/expectations.py
+++ b/cmd_mox/expectations.py
@@ -18,7 +18,7 @@ class Expectation:
     match_args: list[t.Callable[[str], bool]] | None = None
     stdin: str | t.Callable[[str], bool] | None = None
     env: dict[str, str] = dc.field(default_factory=dict)
-    times: int = 1
+    count: int = 1
     ordered: bool = False
 
     def with_args(self, *args: str) -> Expectation:
@@ -43,8 +43,12 @@ class Expectation:
 
     def times_called(self, count: int) -> Expectation:
         """Set the required invocation count to ``count``."""
-        self.times = count
+        self.count = count
         return self
+
+    def times(self, count: int) -> Expectation:
+        """Alias for :meth:`times_called` matching the fluent DSL."""
+        return self.times_called(count)
 
     def in_order(self) -> Expectation:
         """Mark this expectation as ordered relative to others."""

--- a/cmd_mox/verifiers.py
+++ b/cmd_mox/verifiers.py
@@ -41,7 +41,7 @@ class OrderVerifier:
         """Ensure ordered expectations appear in order within *journal*."""
         ordered_seq: list[Expectation] = []
         for exp in self._ordered:
-            ordered_seq.extend([exp] * exp.times)
+            ordered_seq.extend([exp] * exp.count)
         index = 0
         for inv in journal:
             if index >= len(ordered_seq):
@@ -65,7 +65,7 @@ class CountVerifier:
     ) -> None:
         """Validate invocation counts against ``expectations``."""
         for name, exp in expectations.items():
-            expected = exp.times
+            expected = exp.count
             actual = len(invocations.get(name, []))
             if actual < expected:
                 msg = f"Expected {name} to be called {expected} times but got {actual}"

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -97,7 +97,9 @@
 
 ### Fluent API Enhancements
 
-- [ ] Fluent expectation DSL (see [design section](python-native-command-mocking-design.md#24-the-fluent-api-for-defining-expectations))
+- [x] Fluent expectation DSL (see
+    [design section](python-native-command-mocking-design.md#24-the-fluent-api-for-defining-expectations)
+    )
 - [ ] Assertion helpers for spy inspection mirroring `unittest.mock`
     semantics (`assert_called`, `assert_called_with`)
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -301,6 +301,11 @@ provided `exit_code`.
   `.any_order()` modifier can be provided for expectations where the calling
   order is not significant, mirroring PyMox's behavior.
 
+Implementation note: the concrete implementation stores the expected call count
+in a ``count`` attribute but exposes a ``times()`` convenience method to match
+the DSL described here. The more explicit ``times_called()`` alias remains
+available for readability when desired.
+
 To ensure `CmdMox` is a compelling replacement for `shellmock`, the following
 table maps the core features of `shellmock` to their more expressive `CmdMox`
 API equivalents, demonstrating complete functional parity.
@@ -955,6 +960,7 @@ Language (DSL) used to build expectations.
 | .runs(handler)                      | Provides a callable for dynamic, stateful behavior.               | .runs(my_handler_func)                              |
 | .times(count)                       | Sets the expected number of times the command will be called.     | .times(2)                                           |
 | .in_order()                         | Marks this expectation as part of an ordered sequence.            | .in_order()                                         |
+| .any_order()                        | Explicitly opts out of ordered verification.                      | .any_order()                                        |
 | .passthrough()                      | (Spy only) Executes the real command and records the interaction. | mox.spy('ssh').passthrough()                        |
 
 <!-- markdownlint-enable MD013 -->

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -158,6 +158,7 @@ not recommended unless explicitly required and documented.*
 - `runs(handler)` – call a function to produce dynamic output.
 - `times(count)` – expect the command exactly `count` times.
 - `in_order()` – enforce strict ordering with other expectations.
+- `any_order()` – allow the expectation to be satisfied in any position.
 - `passthrough()` – for spies, run the real command while recording it.
 
 Refer to the [design document](./python-native-command-mocking-design.md) for

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -65,6 +65,16 @@ Feature: CmdMox basic functionality
     When I verify the controller
     Then the journal order should be first,second
 
+  Scenario: any_order mock can run before ordered expectation
+    Given a CmdMox controller
+    And the command "first" is mocked with args "a" returning "one" in order
+    And the command "second" is mocked with args "b" returning "two" any order
+    When I replay the controller
+    And I run the command "second" with arguments "b"
+    And I run the command "first" with arguments "a"
+    When I verify the controller
+    Then the journal order should be second,first
+
   Scenario: environment variables can be injected
     Given a CmdMox controller
     And the command "envcmd" is stubbed with env var "HELLO"="WORLD"

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -79,6 +79,16 @@ def mock_with_args_in_order(mox: CmdMox, cmd: str, args: str, text: str) -> None
     mox.mock(cmd).with_args(*args.split()).returns(stdout=text).in_order()
 
 
+@given(
+    parsers.cfparse(
+        'the command "{cmd}" is mocked with args "{args}" returning "{text}" any order'
+    )
+)
+def mock_with_args_any_order(mox: CmdMox, cmd: str, args: str, text: str) -> None:
+    """Configure an unordered mock with arguments."""
+    mox.mock(cmd).with_args(*args.split()).returns(stdout=text).any_order()
+
+
 @given(parsers.cfparse('the command "{cmd}" is stubbed with env var "{var}"="{val}"'))
 def stub_with_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
     """Stub command that outputs an injected env variable."""


### PR DESCRIPTION
## Summary
- add times() alias and any_order() handling for expectation configuration
- exercise the fluent DSL through unit and BDD coverage
- document fluent expectation DSL and mark roadmap entry complete

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: ENOENT reading puppeteer modules)*

------
https://chatgpt.com/codex/tasks/task_e_6892a19276a083228ec28001df1c8f5b