### PR TITLE
Refactor EnvironmentManager state tracking

### DIFF
--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -259,7 +259,7 @@ def _test_environment_cleanup_error(
             mgr,
         ):
             pass
-        assert envmod._active_manager is None
+        assert envmod.EnvironmentManager._active_manager is None
         if test_case.config.check_cause:
             assert isinstance(excinfo.value.__cause__, OSError)
             assert str(excinfo.value.__cause__) == test_case.error_message

--- a/conftest.py
+++ b/conftest.py
@@ -10,8 +10,8 @@ import cmd_mox.environment
 @pytest.fixture(autouse=True)
 def reset_environment_manager_state() -> t.Generator[None, None, None]:
     """Ensure clean global state for EnvironmentManager between tests."""
-    # Reset global state before test
-    cmd_mox.environment._active_manager = None
+    # Reset class state before test
+    cmd_mox.environment.EnvironmentManager._active_manager = None
     yield
-    # Reset global state after test
-    cmd_mox.environment._active_manager = None
+    # Reset class state after test
+    cmd_mox.environment.EnvironmentManager._active_manager = None

--- a/conftest.py
+++ b/conftest.py
@@ -9,9 +9,7 @@ import cmd_mox.environment
 
 @pytest.fixture(autouse=True)
 def reset_environment_manager_state() -> t.Generator[None, None, None]:
-    """Ensure clean global state for EnvironmentManager between tests."""
-    # Reset class state before test
-    cmd_mox.environment.EnvironmentManager._active_manager = None
+    """Ensure clean state for ``EnvironmentManager`` between tests."""
+    cmd_mox.environment.EnvironmentManager.reset_active_manager()
     yield
-    # Reset class state after test
-    cmd_mox.environment.EnvironmentManager._active_manager = None
+    cmd_mox.environment.EnvironmentManager.reset_active_manager()


### PR DESCRIPTION
## Summary
- move EnvironmentManager active state to a class attribute
- adjust tests to reset and verify the class-level state

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893d3897180832283327bb86802f547

## Summary by Sourcery

Refactor EnvironmentManager to track its active instance using a class-level attribute instead of a module-level variable and update tests accordingly.

Enhancements:
- Move EnvironmentManager's active-instance tracking from a module-level variable to a class-level attribute
- Update context manager methods to reference the class variable for nested usage and state resets

Tests:
- Update pytest fixture to reset the class-level _active_manager before and after tests
- Adjust unit tests to assert against the class-level _active_manager attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced environment manager to track active state separately for each thread, improving concurrency handling.  
* **Tests**
  * Added tests to verify thread-local behavior of environment manager state.  
  * Updated existing tests and fixtures to support the new thread-local state management.  
* **Documentation**
  * Updated docstrings to reflect refined state reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->