### PR TITLE
Add tests for times alias and unordered calls

### DIFF
--- a/cmd_mox/unittests/test_expectations.py
+++ b/cmd_mox/unittests/test_expectations.py
@@ -125,27 +125,26 @@ def test_multiple_any_order_expectations_do_not_enforce_order(
     run: t.Callable[..., subprocess.CompletedProcess[str]],
 ) -> None:
     """Unordered expectations remain unordered when combined."""
-    mox = CmdMox()
-    mox.mock("first").returns(stdout="1").any_order()
-    mox.mock("second").returns(stdout="2").any_order()
-    mox.mock("third").returns(stdout="3").any_order()
-    mox.__enter__()
-    mox.replay()
+    with CmdMox() as mox:
+        mox.mock("first").returns(stdout="1").any_order()
+        mox.mock("second").returns(stdout="2").any_order()
+        mox.mock("third").returns(stdout="3").any_order()
+        mox.replay()
 
-    path_first = Path(mox.environment.shim_dir) / "first"
-    path_second = Path(mox.environment.shim_dir) / "second"
-    path_third = Path(mox.environment.shim_dir) / "third"
+        path_first = Path(mox.environment.shim_dir) / "first"
+        path_second = Path(mox.environment.shim_dir) / "second"
+        path_third = Path(mox.environment.shim_dir) / "third"
 
-    # Call expectations in a different order than defined
-    run([str(path_third)], shell=False)
-    run([str(path_first)], shell=False)
-    run([str(path_second)], shell=False)
+        # Call expectations in a different order than defined
+        run([str(path_third)], shell=False)
+        run([str(path_first)], shell=False)
+        run([str(path_second)], shell=False)
 
-    mox.verify()
+        mox.verify()
 
-    assert len(mox.mocks["first"].invocations) == 1
-    assert len(mox.mocks["second"].invocations) == 1
-    assert len(mox.mocks["third"].invocations) == 1
+        assert len(mox.mocks["first"].invocations) == 1
+        assert len(mox.mocks["second"].invocations) == 1
+        assert len(mox.mocks["third"].invocations) == 1
 
 
 def _test_expectation_failure_helper(
@@ -231,6 +230,17 @@ def test_expectation_times_alias(
             lambda mox: (mox.mock("first").returns(stdout="1").any_order().times(2),),
             lambda run, paths: (run([str(paths["first"])], shell=False),),
             id="any_order_call_count_fail",
+        ),
+        pytest.param(
+            (
+                "any_order() expectations should fail when call count is incorrect "
+                "for times_called()."
+            ),
+            lambda mox: (
+                mox.mock("first").returns(stdout="1").any_order().times_called(2),
+            ),
+            lambda run, paths: (run([str(paths["first"])], shell=False),),
+            id="any_order_call_count_fail_times_called",
         ),
     ],
 )

--- a/cmd_mox/unittests/test_expectations.py
+++ b/cmd_mox/unittests/test_expectations.py
@@ -198,14 +198,12 @@ def test_expectation_times_alias(
 
 @pytest.mark.parametrize(
     (
-        "case_description",
         "mock_configurator",
         "execution_strategy",
         "expected_exception",
     ),
     [
         pytest.param(
-            "in_order() expectations should fail when invoked out of sequence.",
             lambda mox: (
                 mox.mock("first").returns(stdout="1").in_order(),
                 mox.mock("second").returns(stdout="2").in_order(),
@@ -218,7 +216,6 @@ def test_expectation_times_alias(
             id="order-validation",
         ),
         pytest.param(
-            "times() and times_called() should both enforce invocation counts.",
             lambda mox: (
                 mox.mock("first").returns(stdout="1").times(2),
                 mox.mock("second").returns(stdout="2").times_called(2),
@@ -231,17 +228,12 @@ def test_expectation_times_alias(
             id="count-validation",
         ),
         pytest.param(
-            "any_order() expectations should fail when call count is incorrect.",
             lambda mox: (mox.mock("first").returns(stdout="1").any_order().times(2),),
             lambda run, paths: (run([str(paths["first"])], shell=False),),
             UnfulfilledExpectationError,
             id="any_order_call_count_fail",
         ),
         pytest.param(
-            (
-                "any_order() expectations should fail when call count is incorrect "
-                "for times_called()."
-            ),
             lambda mox: (
                 mox.mock("first").returns(stdout="1").any_order().times_called(2),
             ),
@@ -250,7 +242,6 @@ def test_expectation_times_alias(
             id="any_order_call_count_fail_times_called",
         ),
         pytest.param(
-            "any_order() should fail when calls exceed expected for times().",
             lambda mox: (mox.mock("first").returns(stdout="1").any_order().times(1),),
             lambda run, paths: (
                 run([str(paths["first"])], shell=False),
@@ -260,7 +251,6 @@ def test_expectation_times_alias(
             id="any_order_call_count_excess_times",
         ),
         pytest.param(
-            "any_order() should fail when calls exceed expected for times_called().",
             lambda mox: (
                 mox.mock("first").returns(stdout="1").any_order().times_called(1),
             ),
@@ -275,7 +265,6 @@ def test_expectation_times_alias(
 )
 def test_expectation_failures(
     run: t.Callable[..., subprocess.CompletedProcess[str]],
-    case_description: str,
     mock_configurator: t.Callable[[CmdMox], None],
     execution_strategy: t.Callable[
         [t.Callable[..., subprocess.CompletedProcess[str]], dict[str, Path]], None
@@ -283,7 +272,6 @@ def test_expectation_failures(
     expected_exception: type[Exception],
 ) -> None:
     """Verify expectation scenarios that should fail verification."""
-    assert case_description
     _test_expectation_failure_helper(
         run, mock_configurator, execution_strategy, expected_exception
     )

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -39,6 +39,19 @@ Feature: CmdMox basic functionality
     And the mock "foo" should record 2 invocation
     And the spy "bar" should record 1 invocation
 
+  Scenario: times alias maps to times_called
+    Given a CmdMox controller
+    And the command "first" is mocked to return "one" times 2
+    And the command "second" is mocked to return "two" times called 2
+    When I replay the controller
+    And I run the command "first"
+    And I run the command "first"
+    And I run the command "second"
+    And I run the command "second"
+    When I verify the controller
+    Then the mock "first" should record 2 invocation
+    And the mock "second" should record 2 invocation
+
   Scenario: context manager usage
     Given a CmdMox controller
     And the command "hi" is stubbed to return "hello"

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -39,21 +39,21 @@ def mock_command(mox: CmdMox, cmd: str, text: str) -> None:
 
 
 @given(
-    parsers.cfparse('the command "{cmd}" is mocked to return "{text}" times {count:d}')
-)
-def mock_command_times(mox: CmdMox, cmd: str, text: str, count: int) -> None:
-    """Configure a mocked command with an expected call count."""
-    mox.mock(cmd).returns(stdout=text).times(count)
-
-
-@given(
-    parsers.cfparse(
-        'the command "{cmd}" is mocked to return "{text}" times called {count:d}'
+    parsers.re(
+        r'the command "(?P<cmd>[^"]+)" is mocked to return "(?P<text>[^"]+)" '
+        r"times(?P<alias> called)? (?P<count>\d+)"
     )
 )
-def mock_command_times_called(mox: CmdMox, cmd: str, text: str, count: int) -> None:
-    """Configure a mocked command with a times_called expectation."""
-    mox.mock(cmd).returns(stdout=text).times_called(count)
+def mock_command_times(
+    mox: CmdMox, cmd: str, text: str, count: str, alias: str | None = None
+) -> None:
+    """Configure a mocked command with an expected call count."""
+    expectation = mox.mock(cmd).returns(stdout=text)
+    count_int = int(count)
+    if alias:
+        expectation.times_called(count_int)
+    else:
+        expectation.times(count_int)
 
 
 @given(parsers.cfparse('the command "{cmd}" is spied to return "{text}"'))

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -41,19 +41,25 @@ def mock_command(mox: CmdMox, cmd: str, text: str) -> None:
 @given(
     parsers.re(
         r'the command "(?P<cmd>[^"]+)" is mocked to return "(?P<text>[^"]+)" '
-        r"times(?P<alias> called)? (?P<count>\d+)"
+        r"times (?P<count>\d+)"
     )
 )
-def mock_command_times(
-    mox: CmdMox, cmd: str, text: str, count: str, alias: str | None = None
-) -> None:
-    """Configure a mocked command with an expected call count."""
+def mock_command_times(mox: CmdMox, cmd: str, text: str, count: str) -> None:
+    """Configure a mocked command with an expected call count using times()."""
     expectation = mox.mock(cmd).returns(stdout=text)
-    count_int = int(count)
-    if alias:
-        expectation.times_called(count_int)
-    else:
-        expectation.times(count_int)
+    expectation.times(int(count))
+
+
+@given(
+    parsers.re(
+        r'the command "(?P<cmd>[^"]+)" is mocked to return "(?P<text>[^"]+)" '
+        r"times called (?P<count>\d+)"
+    )
+)
+def mock_command_times_called(mox: CmdMox, cmd: str, text: str, count: str) -> None:
+    """Configure a mocked command with an expected call count using times_called()."""
+    expectation = mox.mock(cmd).returns(stdout=text)
+    expectation.times_called(int(count))
 
 
 @given(parsers.cfparse('the command "{cmd}" is spied to return "{text}"'))

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -46,6 +46,16 @@ def mock_command_times(mox: CmdMox, cmd: str, text: str, count: int) -> None:
     mox.mock(cmd).returns(stdout=text).times(count)
 
 
+@given(
+    parsers.cfparse(
+        'the command "{cmd}" is mocked to return "{text}" times called {count:d}'
+    )
+)
+def mock_command_times_called(mox: CmdMox, cmd: str, text: str, count: int) -> None:
+    """Configure a mocked command with a times_called expectation."""
+    mox.mock(cmd).returns(stdout=text).times_called(count)
+
+
 @given(parsers.cfparse('the command "{cmd}" is spied to return "{text}"'))
 def spy_command(mox: CmdMox, cmd: str, text: str) -> None:
     """Configure a spied command."""
@@ -272,6 +282,12 @@ def test_spy_records_invocation() -> None:
 )
 def test_journal_preserves_order() -> None:
     """Journal records commands in order."""
+    pass
+
+
+@scenario(str(FEATURES_DIR / "controller.feature"), "times alias maps to times_called")
+def test_times_alias_maps_to_times_called() -> None:
+    """times() and times_called() behave identically in the DSL."""
     pass
 
 


### PR DESCRIPTION
## Summary
- cover times() and times_called() alias via controller BDD scenario
- ensure any_order expectations remain unordered and enforce call counts

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893dbb85a9c8322aab5237e18aff7af

## Summary by Sourcery

Add unit and BDD tests covering the times alias and times_called, and ensure unordered any_order expectations enforce correct call counts without enforcing invocation order.

New Features:
- Add BDD step for configuring mocks with times_called alias
- Add BDD scenario validating times() and times_called() alias behavior

Bug Fixes:
- Enforce call count validation on unordered any_order expectations

Enhancements:
- Introduce unit tests to verify that any_order expectations do not enforce call sequence

Tests:
- Add unit tests for multiple any_order mocks with out-of-order invocation
- Add parameterized test case to ensure any_order expectations fail on incorrect call count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tests to verify that multiple unordered expectations do not enforce call order.
  * Introduced feature tests confirming that "times" and "times called" are interchangeable in command mocking.

* **Tests**
  * Added new failure test cases for unordered expectations with incorrect call counts.
  * Updated and expanded step definitions to support both "times" and "times called" aliases in test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->