### PR TITLE
Refactor expectation proxy into factory

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -20,6 +20,13 @@ from .verifiers import CountVerifier, OrderVerifier, UnexpectedCommandVerifier
 
 
 def _create_expectation_proxy() -> type:
+    """Return a proxy type for expectation delegation.
+
+    Static type checking requires a protocol so ``CommandDouble`` exposes the
+    full expectation interface.  At runtime we return a minimal placeholder
+    whose methods raise ``NotImplementedError`` if accessed directly, making
+    this typing-only pattern explicit.
+    """
     if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
         from pathlib import Path  # noqa: F401
 
@@ -45,7 +52,29 @@ def _create_expectation_proxy() -> type:
         return _ExpectationProxy
 
     class _ExpectationProxy:  # pragma: no cover - runtime placeholder
-        pass
+        def with_args(self, *args: str) -> Self:
+            raise NotImplementedError("with_args is typing-only")
+
+        def with_matching_args(self, *matchers: t.Callable[[str], bool]) -> Self:
+            raise NotImplementedError("with_matching_args is typing-only")
+
+        def with_stdin(self, data: str | t.Callable[[str], bool]) -> Self:
+            raise NotImplementedError("with_stdin is typing-only")
+
+        def with_env(self, mapping: dict[str, str]) -> Self:
+            raise NotImplementedError("with_env is typing-only")
+
+        def times(self, count: int) -> Self:
+            raise NotImplementedError("times is typing-only")
+
+        def times_called(self, count: int) -> Self:
+            raise NotImplementedError("times_called is typing-only")
+
+        def in_order(self) -> Self:
+            raise NotImplementedError("in_order is typing-only")
+
+        def any_order(self) -> Self:
+            raise NotImplementedError("any_order is typing-only")
 
     return _ExpectationProxy
 


### PR DESCRIPTION
## Summary
- encapsulate typing-only _ExpectationProxy definition inside _create_expectation_proxy
- assign _ExpectationProxy from factory to simplify module globals

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f309a46c83229d1cbe681c5fbb10

## Summary by Sourcery

Refactor the ExpectationProxy by moving its typing-only Protocol definition into a factory function and assigning the result to the module global.

Enhancements:
- Encapsulate the _ExpectationProxy Protocol inside the _create_expectation_proxy factory to combine type-checking and runtime placeholders
- Assign the factory’s return value to the module-level _ExpectationProxy instead of defining it directly