### PR TITLE
Clarify CommandRunner run docstring

### DIFF
--- a/cmd_mox/command_runner.py
+++ b/cmd_mox/command_runner.py
@@ -28,10 +28,11 @@ class CommandRunner:
         any keys in ``invocation.env`` take precedence over both. The returned
         :class:`Response` includes the applied overrides in ``Response.env``.
 
-        Common failures follow POSIX conventions:
+        Common failures follow POSIX-like shell conventions:
 
         * ``127`` - command not found
-        * ``126`` - target exists but is not executable
+        * ``126`` - command found but not executable or execution failed
+          (e.g., permission denied)
         * ``124`` - execution timed out
         """
         resolved = self._resolve_and_validate_command(invocation.command)


### PR DESCRIPTION
## Summary
- document environment precedence and common error codes

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4fc0c5230832290022aabcdfb53a1

## Summary by Sourcery

Documentation:
- Clarify CommandRunner.run docstring to document environment override precedence and list common POSIX exit codes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded command execution documentation to clearly describe environment override order, including how per-invocation settings take precedence and what environment is reported back.
  - Added guidance on typical failure/exit codes (e.g., not found, not executable, timeout) to help interpret results.
  - Clarified behavior without altering functionality or APIs.
  - Improves user understanding of configuration and outcomes during command runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->