### PR TITLE
Refactor spy validation helpers

### DIFF
--- a/cmd_mox/unittests/test_spy_assertions.py
+++ b/cmd_mox/unittests/test_spy_assertions.py
@@ -341,3 +341,9 @@ class TestSpyAssertions:
         post = post_validations.get(scenario["method"])
         if post is not None:
             post(spy)
+
+    # ------------------------------------------------------------------
+    def test_assert_equal_passes_on_match(self) -> None:
+        """_assert_equal returns quietly when values match."""
+        spy = self._create_spy_with_invocation("hi", [], "", {})
+        assert spy._assert_equal("label", "expected", "expected") is None

--- a/cmd_mox/unittests/test_spy_assertions.py
+++ b/cmd_mox/unittests/test_spy_assertions.py
@@ -283,6 +283,18 @@ class TestSpyAssertions:
                 "'hi' called with env {'A': '1'}, expected {'B': '2'}"
             ),
         },
+        {
+            "name": "assert_equal_raises_on_mismatch",
+            "setup": lambda self, run: self._create_spy_with_invocation(
+                "hi", [], "", {}
+            ),
+            "method": "_assert_equal",
+            "args": lambda spy: ("label", "actual", "expected"),
+            "kwargs": lambda spy: {},
+            "expected_message": (
+                "'hi' called with label 'actual', expected 'expected'"
+            ),
+        },
     ]
 
     # ------------------------------------------------------------------
@@ -324,6 +336,7 @@ class TestSpyAssertions:
             "_validate_environment": lambda s: s._validate_environment(
                 s.invocations[0], s.invocations[0].env
             ),
+            "_assert_equal": lambda s: s._assert_equal("label", "expected", "expected"),
         }
         post = post_validations.get(scenario["method"])
         if post is not None:


### PR DESCRIPTION
## Summary
- centralize assertion formatting via `_assert_equal`
- reuse helper in argument, stdin, and environment validations
- add unit tests for the new helper

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4fc25e3008322ab8a7c6c031d5b07

## Summary by Sourcery

Centralize assertion formatting by introducing a reusable _assert_equal helper, refactor argument, stdin, and environment validations to use it, and add unit tests for the new helper.

Enhancements:
- Introduce a generic _assert_equal method to standardize assertion messages.
- Refactor _validate_arguments, _validate_stdin, and _validate_environment to delegate to _assert_equal.

Tests:
- Add unit tests covering _assert_equal behavior and its integration with spy validations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Standardized validation and error messages across command argument, input, and environment checks for clearer, consistent failures.
  * Centralized equality checks to reduce duplication and improve maintainability.

* Tests
  * Added new scenarios to verify assertion behavior on both matching and mismatching values.
  * Extended existing suites to cover post-validation checks, ensuring robustness of the new standardized messages and validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->