### PR TITLE
Add jitter and monotonic timing to IPC retries

### DIFF
--- a/cmd_mox/ipc.py
+++ b/cmd_mox/ipc.py
@@ -154,7 +154,9 @@ def _calculate_retry_delay(attempt: int, backoff: float, jitter: float) -> float
     """Return the sleep delay for a given *attempt*."""
     delay = backoff * (attempt + 1)
     if jitter:
-        factor = 1.0 - jitter + random.random() * 2 * jitter  # noqa: S311
+        # Randomise the linear backoff within the jitter bounds to avoid
+        # thundering herds if many clients retry simultaneously.
+        factor = random.uniform(1.0 - jitter, 1.0 + jitter)  # noqa: S311
         delay *= factor
     return delay
 

--- a/cmd_mox/unittests/test_ipc_server.py
+++ b/cmd_mox/unittests/test_ipc_server.py
@@ -14,7 +14,7 @@ from cmd_mox.ipc import (
     Invocation,
     IPCServer,
     RetryConfig,
-    _calculate_retry_delay,
+    calculate_retry_delay,
     invoke_server,
 )
 
@@ -191,8 +191,8 @@ def test_invoke_server_invalid_json(
 
 def test_calculate_retry_delay() -> None:
     """Retry delay scales linearly and applies jitter bounds."""
-    assert _calculate_retry_delay(1, 0.1, 0.0) == pytest.approx(0.2)
+    assert calculate_retry_delay(1, 0.1, 0.0) == pytest.approx(0.2)
     with patch("cmd_mox.ipc.random.uniform", return_value=1.25) as mock_uniform:
-        delay = _calculate_retry_delay(0, 1.0, 0.5)
+        delay = calculate_retry_delay(0, 1.0, 0.5)
         assert delay == pytest.approx(1.25)
         mock_uniform.assert_called_once_with(0.5, 1.5)

--- a/cmd_mox/unittests/test_ipc_server.py
+++ b/cmd_mox/unittests/test_ipc_server.py
@@ -4,6 +4,7 @@ import socket
 import threading
 import typing as t
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -165,5 +166,7 @@ def test_invoke_server_invalid_json(
 def test_calculate_retry_delay() -> None:
     """Retry delay scales linearly and applies jitter bounds."""
     assert _calculate_retry_delay(1, 0.1, 0.0) == pytest.approx(0.2)
-    delay = _calculate_retry_delay(0, 1.0, 0.5)
-    assert 0.5 <= delay <= 1.5
+    with patch("cmd_mox.ipc.random.uniform", return_value=1.25) as mock_uniform:
+        delay = _calculate_retry_delay(0, 1.0, 0.5)
+        assert delay == pytest.approx(1.25)
+        mock_uniform.assert_called_once_with(0.5, 1.5)

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -468,9 +468,10 @@ To avoid races and corrupted state, `IPCServer.start()` first checks if an
 existing socket is in use before unlinking it. After launching the background
 thread, the server polls for the socket path using an exponential backoff to
 ensure it appears before clients connect. On the client side, `invoke_server()`
-retries connection attempts a few times and validates that the server's reply
-is valid JSON, raising a `RuntimeError` if decoding fails. These safeguards
-make the IPC bus robust on slower or heavily loaded systems.
+retries connection attempts with a linear backoff and small jitter to avoid
+retry storms, then validates that the server's reply is valid JSON, raising a
+`RuntimeError` if decoding fails. These safeguards make the IPC bus robust on
+slower or heavily loaded systems.
 ```mermaid
 classDiagram
     class IPCServer {

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -469,9 +469,11 @@ existing socket is in use before unlinking it. After launching the background
 thread, the server polls for the socket path using an exponential backoff to
 ensure it appears before clients connect. On the client side, `invoke_server()`
 retries connection attempts with a linear backoff and small jitter to avoid
-retry storms, then validates that the server's reply is valid JSON, raising a
-`RuntimeError` if decoding fails. These safeguards make the IPC bus robust on
-slower or heavily loaded systems.
+retry storms. Retry behaviour is configured via the `RetryConfig` dataclass,
+which groups the retry count, backoff, and jitter parameters. The client then
+validates that the server's reply is valid JSON, raising a `RuntimeError` if
+decoding fails. These safeguards make the IPC bus robust on slower or heavily
+loaded systems.
 ```mermaid
 classDiagram
     class IPCServer {


### PR DESCRIPTION
## Summary
- use `time.monotonic` for socket wait deadlines
- add configurable jitter to IPC connection retries and improve unreachable code error
- validate jitter parameter and remove unnecessary daemon thread in tests
- document retry jitter in design guide

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a96badbbc48322aea637a93d1535e6

## Summary by Sourcery

Improve IPC retry robustness by adding configurable jitter and switching to monotonic timing, validating inputs, updating documentation, enhancing error messaging, and refining tests

New Features:
- Introduce configurable jitter fraction for IPC connection retries to randomize backoff delays
- Switch socket polling and retry deadlines to use time.monotonic instead of time.time

Bug Fixes:
- Validate jitter parameter to ensure it’s between 0.0 and 1.0 and finite
- Remove unnecessary daemon flag from IPC server test thread to prevent premature termination

Enhancements:
- Enhance connection retry loop to raise a detailed error when unreachable code is reached

Documentation:
- Document retry jitter in the design guide and update client retry description

Tests:
- Add tests for jitter parameter validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a unified retry configuration for connection attempts, with configurable retries, backoff and jitter.
  * Switches to jittered linear backoff to reduce retry storms and provides clearer errors when attempts are exhausted.
  * Improved timeout/wait behavior for more reliable connection handling.

* **Documentation**
  * Updated guidance to describe the new unified retry configuration, default values, linear backoff with jitter, and usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->