### PR TITLE
Refactor BDD controller tests and limit journal size

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -99,7 +99,7 @@ class _CallbackIPCServer(IPCServer):
         return self._handler(invocation)
 
 
-class CommandDouble(_ExpectationProxy):  # type: ignore[misc]
+class CommandDouble(_ExpectationProxy):  # type: ignore[misc]  # runtime proxy; satisfies typing-only protocol
     """Configuration for a stub, mock, or spy command."""
 
     __slots__ = (
@@ -525,14 +525,14 @@ class CmdMox:
     def _handle_invocation(self, invocation: Invocation) -> Response:
         """Record *invocation* and return the configured response."""
         if double := self._doubles.get(invocation.command):
-            if double.is_recording:
-                double.invocations.append(invocation)
             resp = self._invoke_handler(double, invocation)
         else:
             resp = Response(stdout=invocation.command)
         invocation.stdout = resp.stdout
         invocation.stderr = resp.stderr
         invocation.exit_code = resp.exit_code
+        if double and double.is_recording:
+            double.invocations.append(invocation)
         self.journal.append(invocation)
         return resp
 

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -524,13 +524,12 @@ class CmdMox:
 
     def _handle_invocation(self, invocation: Invocation) -> Response:
         """Record *invocation* and return the configured response."""
-        double = self._doubles.get(invocation.command)
-        if not double:
-            resp = Response(stdout=invocation.command)
-        else:
+        if double := self._doubles.get(invocation.command):
             if double.is_recording:
                 double.invocations.append(invocation)
             resp = self._invoke_handler(double, invocation)
+        else:
+            resp = Response(stdout=invocation.command)
         invocation.stdout = resp.stdout
         invocation.stderr = resp.stderr
         invocation.exit_code = resp.exit_code

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -351,8 +351,9 @@ class CmdMox:
             call :meth:`verify`. This catches missed verifications and ensures
             the environment is restored. Disable for explicit control.
         max_journal_entries:
-            Maximum number of invocations retained in the journal; older ones are
-            discarded once the limit is exceeded.
+            Maximum number of invocations retained in the journal. When ``None``,
+            the journal is unbounded. Older entries are discarded once the limit
+            is exceeded. The journal is cleared at the start of each ``replay()``.
         """
         self.environment = EnvironmentManager()
         self._server: _CallbackIPCServer | None = None

--- a/cmd_mox/ipc.py
+++ b/cmd_mox/ipc.py
@@ -71,7 +71,21 @@ class Invocation:
 
     def __repr__(self) -> str:
         """Return a convenient debug representation."""
-        return f"Invocation({self.to_dict()!r})"
+        data = self.to_dict()
+
+        for key in list(data["env"]):
+            if any(
+                token in key.upper() for token in ("KEY", "TOKEN", "SECRET", "PASSWORD")
+            ):
+                data["env"][key] = "<redacted>"
+
+        def _truncate(s: str, limit: int = 256) -> str:
+            return s if len(s) <= limit else s[: limit - 1] + "…"
+
+        for field in ("stdin", "stdout", "stderr"):
+            data[field] = _truncate(data[field])
+
+        return f"Invocation({data!r})"
 
 
 @dc.dataclass(slots=True)

--- a/cmd_mox/ipc.py
+++ b/cmd_mox/ipc.py
@@ -53,6 +53,25 @@ class Invocation:
     args: list[str]
     stdin: str
     env: dict[str, str]
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+
+    def to_dict(self) -> dict[str, t.Any]:
+        """Return a JSON-serializable mapping of this invocation."""
+        return {
+            "command": self.command,
+            "args": list(self.args),
+            "stdin": self.stdin,
+            "env": dict(self.env),
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "exit_code": self.exit_code,
+        }
+
+    def __repr__(self) -> str:
+        """Return a convenient debug representation."""
+        return f"Invocation({self.to_dict()!r})"
 
 
 @dc.dataclass(slots=True)

--- a/cmd_mox/shim.py
+++ b/cmd_mox/shim.py
@@ -29,8 +29,16 @@ def main() -> None:
         env=env,
     )
 
+    timeout_raw = os.environ.get(CMOX_IPC_TIMEOUT_ENV, "5.0")
     try:
-        timeout = float(os.environ.get(CMOX_IPC_TIMEOUT_ENV, "5.0"))
+        timeout = float(timeout_raw)
+    except ValueError:
+        print(f"IPC error: invalid timeout: {timeout_raw!r}", file=sys.stderr)
+        sys.exit(1)
+    if timeout <= 0:
+        print(f"IPC error: invalid timeout: {timeout_raw!r}", file=sys.stderr)
+        sys.exit(1)
+    try:
         response = invoke_server(invocation, timeout=timeout)
     except (
         OSError,

--- a/cmd_mox/shim.py
+++ b/cmd_mox/shim.py
@@ -21,17 +21,22 @@ def main() -> None:
         sys.exit(1)
 
     stdin_data = "" if sys.stdin.isatty() else sys.stdin.read()
+    env: dict[str, str] = dict(os.environ)  # shallow copy is sufficient (str -> str)
     invocation = Invocation(
         command=cmd_name,
         args=sys.argv[1:],
         stdin=stdin_data,
-        env=dict(os.environ),
+        env=env,
     )
 
     try:
         timeout = float(os.environ.get(CMOX_IPC_TIMEOUT_ENV, "5.0"))
         response = invoke_server(invocation, timeout=timeout)
-    except (OSError, json.JSONDecodeError) as exc:  # pragma: no cover - network issues
+    except (
+        OSError,
+        RuntimeError,
+        json.JSONDecodeError,
+    ) as exc:  # pragma: no cover - network issues
         print(f"IPC error: {exc}", file=sys.stderr)
         sys.exit(1)
 

--- a/cmd_mox/shim.py
+++ b/cmd_mox/shim.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import sys
@@ -25,7 +26,7 @@ def main() -> None:
         command=cmd_name,
         args=sys.argv[1:],
         stdin=stdin_data,
-        env=dict(os.environ),
+        env=dict(copy.deepcopy(os.environ)),
     )
 
     try:

--- a/cmd_mox/shim.py
+++ b/cmd_mox/shim.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import copy
 import json
 import os
 import sys
@@ -26,7 +25,7 @@ def main() -> None:
         command=cmd_name,
         args=sys.argv[1:],
         stdin=stdin_data,
-        env=dict(copy.deepcopy(os.environ)),
+        env=dict(os.environ),
     )
 
     try:

--- a/cmd_mox/unittests/test_invocation_journal.py
+++ b/cmd_mox/unittests/test_invocation_journal.py
@@ -1,0 +1,97 @@
+"""Tests for invocation journal capturing."""
+
+from __future__ import annotations
+
+import os
+import typing as t
+
+if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
+    import subprocess
+    from pathlib import Path
+
+from cmd_mox.controller import CmdMox
+from cmd_mox.ipc import Invocation
+
+
+def test_journal_records_full_invocation(
+    run: t.Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """Journal records command, arguments, stdin, and environment."""
+    with CmdMox(verify_on_exit=False) as mox:
+        mox.stub("rec").returns(stdout="ok")
+        mox.replay()
+        cmd_path = t.cast("Path", mox.environment.shim_dir) / "rec"
+        env = os.environ | {"EXTRA": "1"}
+        result = run([str(cmd_path), "a", "b"], input="payload", env=env)
+        mox.verify()
+
+    assert result.stdout == "ok"
+    assert len(mox.journal) == 1
+    inv = mox.journal[0]
+    assert inv.command == "rec"
+    assert inv.args == ["a", "b"]
+    assert inv.stdin == "payload"
+    assert inv.env["EXTRA"] == "1"
+    assert inv.stdout == "ok"
+    assert inv.stderr == ""
+    assert inv.exit_code == 0
+
+
+def test_journal_env_is_deep_copied(
+    run: t.Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """Captured env is isolated from later mutations."""
+    with CmdMox(verify_on_exit=False) as mox:
+        mox.stub("rec").returns(stdout="ok")
+        mox.replay()
+        cmd_path = t.cast("Path", mox.environment.shim_dir) / "rec"
+        env = os.environ | {"EXTRA": "1"}
+        result = run([str(cmd_path)], env=env)
+        env["EXTRA"] = "2"
+        os.environ["EXTRA"] = "3"
+        mox.verify()
+
+    assert result.stdout == "ok"
+    inv = mox.journal[0]
+    assert inv.env["EXTRA"] == "1"
+    assert inv.stdout == "ok"
+    assert inv.stderr == ""
+    assert inv.exit_code == 0
+
+
+def test_journal_prunes_to_maxlen(
+    run: t.Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """Old journal entries are discarded once the max length is exceeded."""
+    with CmdMox(verify_on_exit=False, max_journal_entries=2) as mox:
+        mox.stub("rec").returns(stdout="ok")
+        mox.replay()
+        cmd_path = t.cast("Path", mox.environment.shim_dir) / "rec"
+        for i in range(3):
+            run([str(cmd_path), str(i)])
+        mox.verify()
+
+    assert len(mox.journal) == 2
+    assert [inv.args for inv in mox.journal] == [["1"], ["2"]]
+
+
+def test_invocation_to_dict() -> None:
+    """Invocation.to_dict returns a serializable mapping."""
+    inv = Invocation(
+        command="cmd",
+        args=["a"],
+        stdin="in",
+        env={"X": "1"},
+        stdout="out",
+        stderr="err",
+        exit_code=2,
+    )
+    assert inv.to_dict() == {
+        "command": "cmd",
+        "args": ["a"],
+        "stdin": "in",
+        "env": {"X": "1"},
+        "stdout": "out",
+        "stderr": "err",
+        "exit_code": 2,
+    }

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -111,11 +111,12 @@
 
   - [x] Flexible matcher plumbing in mock argument matching
 
-- [ ] **Invocation Journal**
+- [x] **Invocation Journal**
 
-  - [ ] Capture: command, args, stdin, env per invocation
+  - [x] Capture: command, args, stdin, env per invocation
 
-  - [ ] Store as list or deque, preserve order for verify
+  - [x] Store as deque, preserve order for verify
+  - [x] Configurable max journal size
 
 - [ ] **Verification Algorithm**
 

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -113,10 +113,11 @@
 
 - [x] **Invocation Journal**
 
-  - [x] Capture: command, args, stdin, env per invocation
+- [x] Capture: command, args, stdin, env, stdout, stderr, exit_code per
+  invocation
 
-  - [x] Store as deque, preserve order for verify
-  - [x] Configurable max journal size
+  - [x] Store as a deque to preserve order during verification
+  - [x] Configurable max journal size via `max_journal_entries`
 
 - [ ] **Verification Algorithm**
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -289,10 +289,10 @@ provided `exit_code`.
   `CmdMox` framework when the mock is invoked. The callable receives a
   structured `Invocation` object containing details of the call (args, `stdin`,
   env). The handler must return a tuple of `(stdout, stderr, exit_code)` using
-  UTF-8 decoded strings. Handlers may return raw bytes, which are decoded with
-  UTF-8 before being recorded onto the `Invocation` for journal inspection.
-  This is a significant enhancement of PyMox's callback feature, enabling
-  stateful mocks and complex conditional logic.
+  UTF-8–decoded strings. Handlers may return raw bytes; these are decoded as
+  UTF-8 before the values are recorded on the `Invocation` for journal
+  inspection. This is a significant enhancement of PyMox's callback feature,
+  enabling stateful mocks and complex conditional logic.
 
 - `.times(count: int)`**:** Specifies the exact number of times this specific
   expectation is expected to be met. This is inspired by PyMox's
@@ -463,11 +463,11 @@ The initial implementation ships with a lightweight `IPCServer` class. It uses
 Python's `socketserver.ThreadingUnixStreamServer` to listen on a Unix domain
 socket path provided by the `EnvironmentManager`. Incoming JSON messages are
 parsed into `Invocation` objects and processed in background threads with
-reasonable timeouts (default: 10.0s). The corresponding response data
-(`stdout`, `stderr`, and `exit_code`) is attached to the invocation before it
-is journaled. The server cleans up the socket on shutdown to prevent stale
-sockets from interfering with subsequent tests. The timeout is configurable via
-:data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` (seconds).
+reasonable timeouts (default: 10.0s). The server attaches the corresponding
+response data (`stdout`, `stderr`, `exit_code`) to the `Invocation` before
+appending it to the journal. The server cleans up the socket on shutdown to
+prevent stale sockets interfering with subsequent tests. The timeout is
+configurable via :data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` (seconds).
 
 To avoid races and corrupted state, `IPCServer.start()` first checks if an
 existing socket is in use before unlinking it. After launching the background
@@ -591,7 +591,7 @@ constructs an `Invocation` object containing the command name, arguments,
 `stdin`, and environment. After the handler runs, the controller attaches the
 resulting `stdout`, `stderr`, and `exit_code` to the `Invocation` and then
 appends it to the journal. `verify()` uses this enriched journal as the
-definitive record, comparing it against the predefined expectations to detect
+definitive record, comparing it against predefined expectations to detect
 discrepancies.
 
 ## IV. Feature Deep Dive: Stubbing

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -288,9 +288,11 @@ provided `exit_code`.
   behavior. The `handler` is a Python callable that will be executed by the
   `CmdMox` framework when the mock is invoked. The callable receives a
   structured `Invocation` object containing details of the call (args, `stdin`,
-  env) and must return a tuple of `(stdout_bytes, stderr_bytes, exit_code)`.
-  This is a significant enhancement of PyMox's callback feature, enabling
-  stateful mocks and complex conditional logic.
+  env). The handler must return a tuple of
+  `(stdout_bytes, stderr_bytes, exit_code)`, which the controller records back
+  onto the `Invocation` for journal inspection. This is a significant
+  enhancement of PyMox's callback feature, enabling stateful mocks and complex
+  conditional logic.
 
 - `.times(count: int)`**:** Specifies the exact number of times this specific
   expectation is expected to be met. This is inspired by PyMox's
@@ -429,14 +431,16 @@ same host. The workflow is as follows:
 
 4. **Invocation Reporting:** The shim gathers all relevant invocation data: the
    command name, the list of arguments (`sys.argv[1:]`), the complete content
-   of its standard input, and a snapshot of its current environment variables.
-   It serializes this data into a structured format like JSON and sends it over
-   the socket to the server.
+   of its standard input, and a deep-copied snapshot of its current environment
+   variables. It serializes this data into a structured format like JSON and
+   sends it over the socket to the server.
 
 5. **Server-Side Processing:** The server thread in the main process receives
    the JSON payload. It deserializes it into an `Invocation` object and records
-   it in the in-memory Invocation Journal. It then searches its list of
-   `Expectation` objects to find a match for this invocation.
+   it in the in-memory Invocation Journal after the handler runs. At that point
+   the invocation also captures the resulting `stdout`, `stderr`, and
+   `exit_code`. The server then searches its list of `Expectation` objects to
+   find a match for this invocation.
 
 6. **Response Delivery:** Once a matching expectation is found, the server
    determines the prescribed response. If it's a static `.returns()` value, it
@@ -458,11 +462,11 @@ The initial implementation ships with a lightweight `IPCServer` class. It uses
 Python's `socketserver.ThreadingUnixStreamServer` to listen on a Unix domain
 socket path provided by the `EnvironmentManager`. Incoming JSON messages are
 parsed into `Invocation` objects and processed in background threads with
-reasonable timeouts. Responses are JSON encoded `stdout`, `stderr`, and
-`exit_code` data. The server cleans up the socket on shutdown to prevent stale
-sockets from interfering with subsequent tests. The communication timeout is
-configurable via the :data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV`
-environment variable.
+reasonable timeouts. The corresponding response data (`stdout`, `stderr`, and
+`exit_code`) is attached to the invocation before it is journaled. The server
+cleans up the socket on shutdown to prevent stale sockets from interfering with
+subsequent tests. The communication timeout is configurable via the
+:data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` environment variable.
 
 To avoid races and corrupted state, `IPCServer.start()` first checks if an
 existing socket is in use before unlinking it. After launching the background
@@ -499,6 +503,10 @@ classDiagram
         + list[str] args
         + str stdin
         + dict[str, str] env
+        + str stdout
+        + str stderr
+        + int exit_code
+        + dict[str, Any] to_dict()
     }
     class Response {
         + str stdout
@@ -538,25 +546,25 @@ that handles all modifications to the process environment.
 
   1. It will save a copy of the original `os.environ`.
 
-  1. It will create the temporary shim directory.
+  2. Create the temporary shim directory.
 
-  1. It will prepend the shim directory's path to `os.environ`.
+  3. Prepend the shim directory's path to `os.environ`.
 
-  1. It will set any other necessary environment variables for the IPC
+  4. Set any other necessary environment variables for the IPC
      mechanism, such as `CMOX_IPC_SOCKET`. Clients may additionally honour
      :data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` to override the default
      connection timeout.
 
 - On `__exit__`:
 
-  1. It will execute in a `finally` block to guarantee cleanup, even if the test
-     fails with an exception.
+  1. Execute in a `finally` block to guarantee cleanup, even if the test fails
+     with an exception.
 
-  1. It will restore the original `PATH` and unset any `CmdMox`-specific
-     environment variables.
+  2. Restore the original `PATH` and unset any `CmdMox`-specific environment
+     variables.
 
-  1. It will perform a recursive deletion of the temporary shim directory and
-     all its contents (symlinks and the IPC socket).
+  3. Perform a recursive deletion of the temporary shim directory and all its
+     contents (symlinks and the IPC socket).
 
 The manager is not reentrant. Nested usage would overwrite the saved
 environment snapshot, so attempts to use it recursively will raise
@@ -578,10 +586,12 @@ chronological record of all command calls that occurred during the replay phase.
 
 Each time the IPC server thread receives an invocation report from a shim, it
 constructs a structured `Invocation` object (e.g., a dataclass or `NamedTuple`)
-containing the command name, arguments, `stdin`, and environment. This object
-is then appended to the journal. The `verify()` method uses this journal as the
-definitive record of what actually happened, comparing it against the
-predefined expectations to detect any discrepancies.
+containing the command name, arguments, `stdin`, and environment. After the
+handler runs, the controller attaches the resulting `stdout`, `stderr`, and
+`exit_code` to that `Invocation` before appending it to the journal. The
+`verify()` method uses this enriched journal as the definitive record of what
+actually happened, comparing it against the predefined expectations to detect
+any discrepancies.
 
 ## IV. Feature Deep Dive: Stubbing
 
@@ -640,7 +650,9 @@ The implementation of this feature leverages the IPC architecture:
 
 3. The IPC server thread—which runs within the main test process and therefore
    has direct access to `my_date_handler`—executes the handler. It passes the
-   structured `Invocation` object as an argument to the handler.
+   structured `Invocation` object as an argument to the handler and, after the
+   handler returns, records the resulting output streams and exit code on that
+   invocation.
 
 4. The handler performs its logic (which can involve accessing or modifying
    state within the test function's scope) and returns a result tuple:
@@ -797,7 +809,8 @@ for this purpose:
   command was called.
 
 - `spy.invocations`: A list of `Invocation` objects, where each object provides
-  structured access to a single call's details.
+  structured access to a single call's details, including captured `stdout`,
+  `stderr`, and `exit_code`.
 
 - `spy.assert_called()`, `spy.assert_not_called()`, and
   `spy.assert_called_with(*args, stdin=None, env=None)`: Convenience helpers
@@ -1220,3 +1233,14 @@ user-supplied predicates to participate alongside the built-ins. Regular
 expressions are compiled once per comparator and ``IsA`` relies on type
 conversion to avoid bespoke parsing logic. Comparator exceptions surface their
 class and message in mismatch reports.
+
+### 8.8 Design Decisions for the Invocation Journal
+
+The controller maintains a ``journal`` attribute to record every invocation in
+chronological order. Each entry is an :class:`Invocation` dataclass containing
+the command name, argument list, captured standard input, and the environment
+at call time. A ``collections.deque`` backs the journal to guarantee append
+performance and preserve ordering for later verification. The deque may be
+bounded by ``CmdMox(max_journal_entries=n)`` to discard the oldest entries and
+cap memory use. Verifiers consume this deque directly, ensuring that
+verification reflects the exact sequence observed during replay.

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -431,9 +431,9 @@ same host. The workflow is as follows:
 
 4. **Invocation Reporting:** The shim gathers all relevant invocation data: the
    command name, the list of arguments (`sys.argv[1:]`), the complete content
-   of its standard input, and a deep-copied snapshot of its current environment
-   variables. It serializes this data into a structured format like JSON and
-   sends it over the socket to the server.
+   of its standard input, and a copy of its current environment variables. It
+   serializes this data into a structured format like JSON and sends it over
+   the socket to the server.
 
 5. **Server-Side Processing:** The server thread in the main process receives
    the JSON payload. It deserializes it into an `Invocation` object and records

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -291,8 +291,8 @@ provided `exit_code`.
   env). The handler must return a tuple of `(stdout, stderr, exit_code)` using
   UTF-8–decoded strings. Handlers may return raw bytes; these are decoded as
   UTF-8 before the values are recorded on the `Invocation` for journal
-  inspection. This is a significant enhancement of PyMox's callback feature,
-  enabling stateful mocks and complex conditional logic.
+  inspection. This significantly enhances PyMox's callback feature, enabling
+  stateful mocks and complex conditional logic.
 
 - `.times(count: int)`**:** Specifies the exact number of times this specific
   expectation is expected to be met. This is inspired by PyMox's
@@ -466,7 +466,7 @@ parsed into `Invocation` objects and processed in background threads with
 reasonable timeouts (default: 10.0s). The server attaches the corresponding
 response data (`stdout`, `stderr`, `exit_code`) to the `Invocation` before
 appending it to the journal. The server cleans up the socket on shutdown to
-prevent stale sockets interfering with subsequent tests. The timeout is
+prevent stale sockets from interfering with subsequent tests. The timeout is
 configurable via :data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` (seconds).
 
 To avoid races and corrupted state, `IPCServer.start()` first checks if an
@@ -582,17 +582,15 @@ reliable testing framework.
 
 The Invocation Journal is a simple but crucial in-memory data structure within
 each `CmdMox` controller instance. A `collections.deque` backs the journal,
-preserving call order and enabling efficient pruning when bounded. Its sole
-purpose is to store a chronological record of command calls during the replay
-phase.
+preserving call order and enabling efficient pruning when bounded. It stores a
+chronological record of command calls during replay.
 
 Each time the IPC server thread receives an invocation report from a shim, it
 constructs an `Invocation` object containing the command name, arguments,
 `stdin`, and environment. After the handler runs, the controller attaches the
-resulting `stdout`, `stderr`, and `exit_code` to the `Invocation` and then
-appends it to the journal. `verify()` uses this enriched journal as the
-definitive record, comparing it against predefined expectations to detect
-discrepancies.
+resulting `stdout`, `stderr`, and `exit_code` to the `Invocation` and appends
+it to the journal. `verify()` uses this enriched journal as the definitive
+record, comparing it against predefined expectations to detect discrepancies.
 
 ## IV. Feature Deep Dive: Stubbing
 

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -156,8 +156,8 @@ Feature: CmdMox basic functionality
     When I replay the controller
     And I run the command "flex" with arguments "anything 123 foo7 barbar bazooka HELLO"
     Then the output should be "ok"
-  When I verify the controller
-  Then the journal should contain 1 invocation of "flex"
+    When I verify the controller
+    Then the journal should contain 1 invocation of "flex"
 
   Scenario: journal captures invocation details
     Given a CmdMox controller
@@ -179,5 +179,6 @@ Feature: CmdMox basic functionality
     And I run the command "beta"
     And I run the command "gamma"
     When I verify the controller
-    Then the journal should contain 2 invocation of "beta"
+    Then the journal should contain 1 invocation of "beta"
+    And the journal should contain 1 invocation of "gamma"
     And the journal order should be beta,gamma

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -181,4 +181,8 @@ Feature: CmdMox basic functionality
     When I verify the controller
     Then the journal should contain 1 invocation of "beta"
     And the journal should contain 1 invocation of "gamma"
+    And the journal should contain 0 invocation of "alpha"
     And the journal order should be beta,gamma
+
+  Scenario: invalid max journal size is rejected
+    Given creating a CmdMox controller with max journal size -1 fails

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -156,5 +156,28 @@ Feature: CmdMox basic functionality
     When I replay the controller
     And I run the command "flex" with arguments "anything 123 foo7 barbar bazooka HELLO"
     Then the output should be "ok"
+  When I verify the controller
+  Then the journal should contain 1 invocation of "flex"
+
+  Scenario: journal captures invocation details
+    Given a CmdMox controller
+    And the command "rec" is stubbed to return "ok"
+    When I replay the controller
+    And I run the command "rec" with arguments "alpha beta" using stdin "payload" and env var "EXTRA"="42"
+    And I set environment variable "EXTRA" to "99"
     When I verify the controller
-    Then the journal should contain 1 invocation of "flex"
+    Then the journal entry for "rec" should record arguments "alpha beta" stdin "payload" env var "EXTRA"="42"
+    And the journal entry for "rec" should record stdout "ok" stderr "" exit code 0
+
+  Scenario: journal prunes excess entries
+    Given a CmdMox controller with max journal size 2
+    And the command "alpha" is stubbed to return "ok"
+    And the command "beta" is stubbed to return "ok"
+    And the command "gamma" is stubbed to return "ok"
+    When I replay the controller
+    And I run the command "alpha"
+    And I run the command "beta"
+    And I run the command "gamma"
+    When I verify the controller
+    Then the journal should contain 2 invocation of "beta"
+    And the journal order should be beta,gamma

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -181,7 +181,7 @@ Feature: CmdMox basic functionality
     When I verify the controller
     Then the journal should contain 1 invocation of "beta"
     And the journal should contain 1 invocation of "gamma"
-    And the journal should contain 0 invocation of "alpha"
+    And the journal should contain 0 invocations of "alpha"
     And the journal order should be beta,gamma
 
   Scenario: invalid max journal size is rejected

--- a/tests/helpers/controller.py
+++ b/tests/helpers/controller.py
@@ -10,6 +10,8 @@ import shlex
 import subprocess
 import typing as t
 
+RUN_TIMEOUT_SECONDS = 30
+
 if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
     from cmd_mox.controller import CmdMox
     from cmd_mox.ipc import Invocation
@@ -55,7 +57,7 @@ def _execute_command_with_params(
         check=params.check,
         shell=False,
         env=env,
-        timeout=30,
+        timeout=RUN_TIMEOUT_SECONDS,
     )
 
 
@@ -77,10 +79,7 @@ def _find_matching_journal_entry(
         candidates = [inv for inv in candidates if list(inv.args) == wanted_args]
     inv = candidates[-1] if candidates else None
     if inv is None:
-        available = [
-            (i.command, list(i.args))
-            for i in mox.journal  # type: ignore[attr-defined]
-        ]
+        available = [(i.command, list(i.args)) for i in mox.journal]
         msg = (
             f"Journal does not contain expected entry for {expectation.cmd!r} "
             f"with args {expectation.args!r}. Available: {available!r}"

--- a/tests/helpers/controller.py
+++ b/tests/helpers/controller.py
@@ -1,0 +1,105 @@
+"""Shared helpers for controller tests."""
+
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import dataclasses as dc
+import os
+import shlex
+import subprocess
+import typing as t
+
+if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
+    from cmd_mox.controller import CmdMox
+
+
+@dc.dataclass(slots=True, frozen=True)
+class CommandExecution:
+    """Parameters for command execution with stdin and environment."""
+
+    cmd: str
+    args: str
+    stdin: str
+    env_var: str
+    env_val: str
+
+
+@dc.dataclass(slots=True, frozen=True)
+class JournalEntryExpectation:
+    """Expected details for a journal entry."""
+
+    cmd: str
+    args: str | None = None
+    stdin: str | None = None
+    env_var: str | None = None
+    env_val: str | None = None
+    stdout: str | None = None
+    stderr: str | None = None
+    exit_code: int | None = None
+
+
+def _execute_command_with_params(
+    params: CommandExecution,
+) -> subprocess.CompletedProcess[str]:
+    """Execute a command described by *params*."""
+    env = os.environ | {params.env_var: params.env_val}
+    argv = [params.cmd, *shlex.split(params.args)]
+    return subprocess.run(  # noqa: S603
+        argv,
+        input=params.stdin,
+        capture_output=True,
+        text=True,
+        check=True,
+        shell=False,
+        env=env,
+        timeout=30,
+    )
+
+
+def execute_command_with_details(
+    mox: CmdMox, execution: CommandExecution
+) -> subprocess.CompletedProcess[str]:
+    """Run the command specified by *execution*."""
+    del mox
+    return _execute_command_with_params(execution)
+
+
+def _verify_journal_entry_with_expectation(
+    mox: CmdMox, expectation: JournalEntryExpectation
+) -> None:
+    """Assert journal entry for *expectation.cmd* matches provided expectation."""
+    inv = next((inv for inv in mox.journal if inv.command == expectation.cmd), None)
+    assert inv is not None, f"Journal does not contain command: {expectation.cmd!r}"
+    if expectation.args is not None:
+        assert list(inv.args) == shlex.split(expectation.args), (
+            f"args mismatch: {list(inv.args)!r} != {shlex.split(expectation.args)!r}"
+        )
+    if expectation.stdin is not None:
+        assert inv.stdin == expectation.stdin, (
+            f"stdin mismatch: {inv.stdin!r} != {expectation.stdin!r}"
+        )
+    if expectation.env_var is not None:
+        assert inv.env.get(expectation.env_var) == expectation.env_val, (
+            f"env[{expectation.env_var!r}] mismatch: "
+            f"{inv.env.get(expectation.env_var)!r} != {expectation.env_val!r}"
+        )
+    if expectation.stdout is not None:
+        assert inv.stdout == expectation.stdout, (
+            f"stdout mismatch: {inv.stdout!r} != {expectation.stdout!r}"
+        )
+    if expectation.stderr is not None:
+        assert inv.stderr == expectation.stderr, (
+            f"stderr mismatch: {inv.stderr!r} != {expectation.stderr!r}"
+        )
+    if expectation.exit_code is not None:
+        assert inv.exit_code == expectation.exit_code, (
+            f"exit_code mismatch: {inv.exit_code!r} != {expectation.exit_code!r}"
+        )
+
+
+def verify_journal_entry_details(
+    mox: CmdMox, expectation: JournalEntryExpectation
+) -> None:
+    """Public helper to verify journal entry details."""
+    _verify_journal_entry_with_expectation(mox, expectation)

--- a/tests/helpers/controller.py
+++ b/tests/helpers/controller.py
@@ -85,26 +85,21 @@ def _verify_journal_entry_with_expectation(
             f"with args {expectation.args!r}. Available: {available!r}"
         )
         raise AssertionError(msg)
-    if expectation.stdin is not None:
-        assert inv.stdin == expectation.stdin, (
-            f"stdin mismatch: {inv.stdin!r} != {expectation.stdin!r}"
-        )
+    checks = {
+        "stdin": expectation.stdin,
+        "stdout": expectation.stdout,
+        "stderr": expectation.stderr,
+        "exit_code": expectation.exit_code,
+    }
+    for field, expected in checks.items():
+        if expected is not None:
+            actual = getattr(inv, field)
+            assert actual == expected, f"{field} mismatch: {actual!r} != {expected!r}"
     if expectation.env_var is not None:
-        assert inv.env.get(expectation.env_var) == expectation.env_val, (
+        actual_env = inv.env.get(expectation.env_var)
+        assert actual_env == expectation.env_val, (
             f"env[{expectation.env_var!r}] mismatch: "
-            f"{inv.env.get(expectation.env_var)!r} != {expectation.env_val!r}"
-        )
-    if expectation.stdout is not None:
-        assert inv.stdout == expectation.stdout, (
-            f"stdout mismatch: {inv.stdout!r} != {expectation.stdout!r}"
-        )
-    if expectation.stderr is not None:
-        assert inv.stderr == expectation.stderr, (
-            f"stderr mismatch: {inv.stderr!r} != {expectation.stderr!r}"
-        )
-    if expectation.exit_code is not None:
-        assert inv.exit_code == expectation.exit_code, (
-            f"exit_code mismatch: {inv.exit_code!r} != {expectation.exit_code!r}"
+            f"{actual_env!r} != {expectation.env_val!r}"
         )
 
 

--- a/tests/helpers/controller.py
+++ b/tests/helpers/controller.py
@@ -76,7 +76,7 @@ def _find_matching_journal_entry(
     candidates = [inv for inv in mox.journal if inv.command == expectation.cmd]
     if expectation.args is not None:
         wanted_args = shlex.split(expectation.args)
-        candidates = [inv for inv in candidates if list(inv.args) == wanted_args]
+        candidates = [inv for inv in candidates if inv.args == wanted_args]
     inv = candidates[-1] if candidates else None
     if inv is None:
         available = [(i.command, list(i.args)) for i in mox.journal]

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -266,10 +266,9 @@ def check_stderr(result: subprocess.CompletedProcess[str], text: str) -> None:
 
 @then(parsers.cfparse('the journal should contain {count:d} invocation of "{cmd}"'))
 def check_journal(mox: CmdMox, count: int, cmd: str) -> None:
-    """Verify the journal contains the expected command invocation."""
-    assert len(mox.journal) == count
-    if count > 0:
-        assert mox.journal[0].command == cmd
+    """Verify the journal records *count* invocations of *cmd*."""
+    matches = [inv for inv in mox.journal if inv.command == cmd]
+    assert len(matches) == count
 
 
 @then(parsers.cfparse('the spy "{cmd}" should record {count:d} invocation'))

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -272,11 +272,16 @@ def check_stderr(result: subprocess.CompletedProcess[str], text: str) -> None:
     assert text in result.stderr
 
 
-@then(parsers.cfparse('the journal should contain {count:d} invocation of "{cmd}"'))
-def check_journal(mox: CmdMox, count: int, cmd: str) -> None:
+@then(
+    parsers.re(
+        r"the journal should contain (?P<count>\d+) "
+        r'invocation(?:s)? of "(?P<cmd>[^\"]+)"'
+    )
+)
+def check_journal(mox: CmdMox, count: str, cmd: str) -> None:
     """Verify the journal records *count* invocations of *cmd*."""
     matches = [inv for inv in mox.journal if inv.command == cmd]
-    assert len(matches) == count
+    assert len(matches) == int(count)
 
 
 @then(parsers.cfparse('the spy "{cmd}" should record {count:d} invocation'))

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -450,6 +450,13 @@ def run_command_args_stdin_env(
     return execute_command_with_details(mox, params)
 
 
+def _validate_journal_entry_details(
+    mox: CmdMox, expectation: JournalEntryExpectation
+) -> None:
+    """Validate journal entry records invocation details."""
+    _verify_journal_entry_with_expectation(mox, expectation)
+
+
 @then(
     parsers.cfparse(
         'the journal entry for "{cmd}" should record arguments "{args}" '
@@ -465,9 +472,8 @@ def check_journal_entry_details(  # noqa: PLR0913, RUF100 - pytest-bdd step wrap
     val: str,
 ) -> None:
     """Validate journal entry records invocation details."""
-    _verify_journal_entry_with_expectation(
-        mox, JournalEntryExpectation(cmd, args, stdin, var, val)
-    )
+    expectation = JournalEntryExpectation(cmd, args, stdin, var, val)
+    _validate_journal_entry_details(mox, expectation)
 
 
 @then(

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import shlex
 import subprocess
 import typing as t
 from pathlib import Path
@@ -12,11 +13,18 @@ from pytest_bdd import given, parsers, scenario, then, when
 
 from cmd_mox.comparators import Any, Contains, IsA, Predicate, Regex, StartsWith
 from cmd_mox.controller import CmdMox
+from tests.helpers.controller import (
+    CommandExecution,
+    JournalEntryExpectation,
+    execute_command_with_details,
+    verify_journal_entry_details,
+)
 
 if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
     import pytest
 
     from cmd_mox.ipc import Invocation
+
 
 FEATURES_DIR = Path(__file__).resolve().parent.parent / "features"
 
@@ -25,6 +33,15 @@ FEATURES_DIR = Path(__file__).resolve().parent.parent / "features"
 def create_controller() -> CmdMox:
     """Create a fresh CmdMox instance."""
     return CmdMox()
+
+
+@given(
+    parsers.cfparse("a CmdMox controller with max journal size {size:d}"),
+    target_fixture="mox",
+)
+def create_controller_with_limit(size: int) -> CmdMox:
+    """Create a CmdMox instance with bounded journal."""
+    return CmdMox(max_journal_entries=size)
 
 
 @given(parsers.cfparse('the command "{cmd}" is stubbed to return "{text}"'))
@@ -110,7 +127,7 @@ def stub_runs(mox: CmdMox, cmd: str) -> None:
 )
 def mock_with_args_in_order(mox: CmdMox, cmd: str, args: str, text: str) -> None:
     """Configure an ordered mock with arguments."""
-    mox.mock(cmd).with_args(*args.split()).returns(stdout=text).in_order()
+    mox.mock(cmd).with_args(*shlex.split(args)).returns(stdout=text).in_order()
 
 
 @given(
@@ -120,7 +137,7 @@ def mock_with_args_in_order(mox: CmdMox, cmd: str, args: str, text: str) -> None
 )
 def mock_with_args_any_order(mox: CmdMox, cmd: str, args: str, text: str) -> None:
     """Configure an unordered mock with arguments."""
-    mox.mock(cmd).with_args(*args.split()).returns(stdout=text).any_order()
+    mox.mock(cmd).with_args(*shlex.split(args)).returns(stdout=text).any_order()
 
 
 @given(parsers.cfparse('the command "{cmd}" is stubbed with env var "{var}"="{val}"'))
@@ -135,7 +152,9 @@ def stub_with_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
 
 @given(parsers.cfparse('the command "{cmd}" resolves to a non-executable file'))
 def non_executable_command(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cmd: str
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cmd: str,
 ) -> None:
     """Patch ``shutil.which`` so *cmd* resolves to a non-executable file."""
     dummy = tmp_path / cmd
@@ -195,10 +214,12 @@ def run_command_failure(cmd: str) -> subprocess.CompletedProcess[str]:
     target_fixture="result",
 )
 def run_command_args(
-    mox: CmdMox, cmd: str, args: str
+    mox: CmdMox,
+    cmd: str,
+    args: str,
 ) -> subprocess.CompletedProcess[str]:
     """Run *cmd* with additional arguments."""
-    argv = [cmd, *args.split()]
+    argv = [cmd, *shlex.split(args)]
     return subprocess.run(argv, capture_output=True, text=True, check=True, shell=False)  # noqa: S603
 
 
@@ -280,7 +301,7 @@ def spy_assert_called(mox: CmdMox, cmd: str) -> None:
 def spy_assert_called_with(mox: CmdMox, cmd: str, args: str) -> None:
     """Assert the spy's last call used the given arguments."""
     assert cmd in mox.spies, f"Spy for command '{cmd}' not found"
-    mox.spies[cmd].assert_called_with(*args.split())
+    mox.spies[cmd].assert_called_with(*shlex.split(args))
 
 
 @then(parsers.cfparse('the spy "{cmd}" should not have been called'))
@@ -406,4 +427,84 @@ def test_passthrough_spy_timeout() -> None:
 )
 def test_mock_matches_arguments_with_comparators() -> None:
     """Mocks can use comparator objects for flexible argument matching."""
+    pass
+
+
+@when(
+    parsers.cfparse(
+        'I run the command "{cmd}" with arguments "{args}" '
+        'using stdin "{stdin}" and env var "{var}"="{val}"'
+    ),
+    target_fixture="result",
+)
+def run_command_args_stdin_env(
+    mox: CmdMox,
+    cmd: str,
+    args: str,
+    stdin: str,
+    var: str,
+    val: str,
+) -> subprocess.CompletedProcess[str]:  # noqa: PLR0913, RUF100 - pytest-bdd step wrapper requires all parsed params
+    """Run *cmd* with arguments, stdin, and an environment variable."""
+    params = CommandExecution(cmd=cmd, args=args, stdin=stdin, env_var=var, env_val=val)
+    return execute_command_with_details(mox, params)
+
+
+@then(
+    parsers.cfparse(
+        'the journal entry for "{cmd}" should record arguments "{args}" '
+        'stdin "{stdin}" env var "{var}"="{val}"'
+    )
+)
+def check_journal_entry_details(  # noqa: PLR0913, RUF100 - pytest-bdd step wrapper requires all parsed params
+    mox: CmdMox,
+    cmd: str,
+    args: str,
+    stdin: str,
+    var: str,
+    val: str,
+) -> None:
+    """Validate journal entry records invocation details."""
+    verify_journal_entry_details(
+        mox, JournalEntryExpectation(cmd, args, stdin, var, val)
+    )
+
+
+@then(
+    parsers.re(
+        r'the journal entry for "(?P<cmd>[^"]+)" should record stdout '
+        r'"(?P<stdout>[^"]*)" stderr "(?P<stderr>[^"]*)" exit code (?P<code>\d+)'
+    )
+)
+def check_journal_entry_result(  # noqa: PLR0913, RUF100 - pytest-bdd step wrapper requires all parsed params
+    mox: CmdMox,
+    cmd: str,
+    stdout: str,
+    stderr: str,
+    code: str,
+) -> None:
+    """Validate journal entry records command results."""
+    expectation = JournalEntryExpectation(
+        cmd, stdout=stdout, stderr=stderr, exit_code=int(code)
+    )
+    verify_journal_entry_details(mox, expectation)
+
+
+@when(parsers.cfparse('I set environment variable "{var}" to "{val}"'))
+def set_env_var(var: str, val: str) -> None:
+    """Adjust environment variable to new value."""
+    os.environ[var] = val
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"), "journal captures invocation details"
+)
+def test_journal_captures_invocation_details() -> None:
+    """Journal records full invocation details."""
+    pass
+
+
+@scenario(str(FEATURES_DIR / "controller.feature"), "journal prunes excess entries")
+def test_journal_prunes_excess_entries() -> None:
+    """Journal drops older entries beyond configured size."""
     pass

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -491,9 +491,9 @@ def check_journal_entry_result(  # noqa: PLR0913, RUF100 - pytest-bdd step wrapp
 
 
 @when(parsers.cfparse('I set environment variable "{var}" to "{val}"'))
-def set_env_var(var: str, val: str) -> None:
-    """Adjust environment variable to new value."""
-    os.environ[var] = val
+def set_env_var(monkeypatch: pytest.MonkeyPatch, var: str, val: str) -> None:
+    """Adjust environment variable to new value (scoped to the test)."""
+    monkeypatch.setenv(var, val)
 
 
 @scenario(

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -16,6 +16,7 @@ from cmd_mox.controller import CmdMox
 from tests.helpers.controller import (
     CommandExecution,
     JournalEntryExpectation,
+    _verify_journal_entry_with_expectation,
     execute_command_with_details,
     verify_journal_entry_details,
 )
@@ -464,11 +465,8 @@ def check_journal_entry_details(  # noqa: PLR0913, RUF100 - pytest-bdd step wrap
     val: str,
 ) -> None:
     """Validate journal entry records invocation details."""
-    verify_journal_entry_details(
-        mox,
-        JournalEntryExpectation(
-            cmd=cmd, args=args, stdin=stdin, env_var=var, env_val=val
-        ),
+    _verify_journal_entry_with_expectation(
+        mox, JournalEntryExpectation(cmd, args, stdin, var, val)
     )
 
 

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -465,7 +465,10 @@ def check_journal_entry_details(  # noqa: PLR0913, RUF100 - pytest-bdd step wrap
 ) -> None:
     """Validate journal entry records invocation details."""
     verify_journal_entry_details(
-        mox, JournalEntryExpectation(cmd, args, stdin, var, val)
+        mox,
+        JournalEntryExpectation(
+            cmd=cmd, args=args, stdin=stdin, env_var=var, env_val=val
+        ),
     )
 
 
@@ -484,7 +487,7 @@ def check_journal_entry_result(  # noqa: PLR0913, RUF100 - pytest-bdd step wrapp
 ) -> None:
     """Validate journal entry records command results."""
     expectation = JournalEntryExpectation(
-        cmd, stdout=stdout, stderr=stderr, exit_code=int(code)
+        cmd=cmd, stdout=stdout, stderr=stderr, exit_code=int(code)
     )
     verify_journal_entry_details(mox, expectation)
 

--- a/tests/test_controller_helpers.py
+++ b/tests/test_controller_helpers.py
@@ -1,0 +1,55 @@
+"""Unit tests for controller helper functions."""
+
+from __future__ import annotations
+
+import typing as t
+
+from cmd_mox.controller import CmdMox
+
+if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
+    from cmd_mox.ipc import Invocation
+
+from tests.helpers.controller import (
+    CommandExecution,
+    JournalEntryExpectation,
+    _execute_command_with_params,
+    _verify_journal_entry_with_expectation,
+)
+
+
+def test_execute_and_verify_helpers() -> None:
+    """Ensure helper functions execute and verify invocations."""
+    mox = CmdMox()
+
+    def handler(inv: Invocation) -> tuple[str, str, int]:
+        assert inv.args == ["--flag"]
+        assert inv.stdin == "stdin"
+        assert inv.env.get("ENV_VAR") == "VALUE"
+        return ("handled", "", 0)
+
+    mox.stub("foo").runs(handler)
+
+    with mox:
+        mox.replay()
+        params = CommandExecution(
+            cmd="foo",
+            args="--flag",
+            stdin="stdin",
+            env_var="ENV_VAR",
+            env_val="VALUE",
+        )
+        result = _execute_command_with_params(params)
+    # Sanity-check handler result
+    assert result.stdout.strip() == "handled"
+    assert result.returncode == 0
+    expectation = JournalEntryExpectation(
+        cmd="foo",
+        args="--flag",
+        stdin="stdin",
+        env_var="ENV_VAR",
+        env_val="VALUE",
+        stdout="handled",
+        stderr="",
+        exit_code=0,
+    )
+    _verify_journal_entry_with_expectation(mox, expectation)

--- a/tests/test_controller_helpers.py
+++ b/tests/test_controller_helpers.py
@@ -19,7 +19,6 @@ from tests.helpers.controller import (
 
 def test_execute_and_verify_helpers() -> None:
     """Ensure helper functions execute and verify invocations."""
-    mox = CmdMox()
 
     def handler(inv: Invocation) -> tuple[str, str, int]:
         assert inv.args == ["--flag"]
@@ -27,9 +26,8 @@ def test_execute_and_verify_helpers() -> None:
         assert inv.env.get("ENV_VAR") == "VALUE"
         return ("handled", "", 0)
 
-    mox.stub("foo").runs(handler)
-
-    with mox:
+    with CmdMox() as mox:
+        mox.stub("foo").runs(handler)
         mox.replay()
         params = CommandExecution(
             cmd="foo",


### PR DESCRIPTION
## Summary
- parse BDD command args with `shlex.split` and annotate step params
- make helper dataclasses immutable and slotted
- improve journal verification with explicit assertions and clearer failures
- document deque-backed journal and streamline environment manager steps
- harden invocation journal test and remove redundant imports
- factor command execution and journal verification into reusable helpers for BDD steps
- deep copy shim environment to protect invocation history
- verify environment snapshots with dedicated unit and BDD tests
- add configurable journal size limit with pruning and corresponding tests
- capture command results in invocation records and serialize with `to_dict`
- enrich docs and BDD scenarios to exercise stdout, stderr, and exit codes
- centralize controller test helpers in `tests/helpers/controller.py`

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68ba171b4f6c8322a83beea0786b75f5

## Summary by Sourcery

Enhance the invocation journal to record full command details (including outputs), support a configurable size limit with pruning, serialize entries, and ensure environment isolation. Refactor and centralize controller test helpers, update BDD tests to use shlex-based parsing, and extend documentation and tests to cover these changes.

New Features:
- Introduce configurable max journal entries with automatic pruning of old invocations
- Capture stdout, stderr, and exit codes in each invocation journal entry
- Add Invocation.to_dict method for serializing journal entries

Enhancements:
- Refactor BDD controller tests to use reusable helpers and shlex-based argument parsing
- Make test helper dataclasses immutable and slotted
- Deep copy shim environment to isolate logged invocation history

Documentation:
- Update design docs to describe enriched invocation entries and bounded deque journal

Tests:
- Add unit tests for invocation journal (full capture, deep copy, pruning, serialization) and controller helper functions
- Add BDD scenarios and step definitions for verifying journal entry details and pruning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounded invocation journal with configurable max size; older entries pruned and unknown commands recorded.
  * Journal entries now include stdout, stderr, and exit code; JSON-serializable export and safe debug output (redaction/truncation).

* **Bug Fixes**
  * Journal cleared before replay; improved controller phase transitions and rejection of invalid max sizes.
  * IPC shim validates timeout and improves error handling.

* **Documentation**
  * Roadmap and design docs updated for enriched invocation model and handler contract.

* **Tests**
  * New unit and end-to-end tests and helpers for journaling, pruning, and entry detail verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->