### PR TITLE
Refactor journal test and truncate with f-string

### DIFF
--- a/cmd_mox/ipc.py
+++ b/cmd_mox/ipc.py
@@ -80,6 +80,8 @@ class Invocation:
                 data["env"][key] = "<redacted>"
 
         def _truncate(s: str, limit: int = 256) -> str:
+            if limit <= 1:
+                return "" if len(s) <= limit else "…"
             return s if len(s) <= limit else f"{s[: limit - 1]}…"
 
         for field in ("stdin", "stdout", "stderr"):

--- a/cmd_mox/unittests/test_invocation_journal.py
+++ b/cmd_mox/unittests/test_invocation_journal.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 import os
 import typing as t
-from pathlib import Path
 
 import pytest
 
@@ -30,7 +29,8 @@ def _run_full_invocation() -> tuple[
     with CmdMox(verify_on_exit=False) as mox:
         mox.stub("rec").returns(stdout="ok")
         mox.replay()
-        cmd_path = t.cast(Path, mox.environment.shim_dir) / "rec"  # noqa: TC006
+        assert mox.environment.shim_dir is not None
+        cmd_path = mox.environment.shim_dir / "rec"
         params = CommandExecution(
             cmd=str(cmd_path),
             args="a b",
@@ -50,6 +50,7 @@ def _run_full_invocation() -> tuple[
         stderr="",
         exit_code=0,
     )
+    # Return mox only for journal inspection; context has exited.
     return mox, result, expectation
 
 
@@ -68,7 +69,8 @@ def test_journal_env_is_deep_copied(
     with CmdMox(verify_on_exit=False) as mox:
         mox.stub("rec").returns(stdout="ok")
         mox.replay()
-        cmd_path = t.cast(Path, mox.environment.shim_dir) / "rec"  # noqa: TC006
+        assert mox.environment.shim_dir is not None
+        cmd_path = mox.environment.shim_dir / "rec"
         run([str(cmd_path)], env=os.environ | {"EXTRA": "1"})
         monkeypatch.setenv("EXTRA", "3")
         run([str(cmd_path)], env=os.environ | {"EXTRA": "2"})
@@ -94,7 +96,8 @@ def test_journal_pruning(
     with CmdMox(verify_on_exit=False, max_journal_entries=maxlen) as mox:
         mox.stub("rec").returns(stdout="ok")
         mox.replay()
-        cmd_path = t.cast(Path, mox.environment.shim_dir) / "rec"  # noqa: TC006
+        assert mox.environment.shim_dir is not None
+        cmd_path = mox.environment.shim_dir / "rec"
         for i in range(3):
             run([str(cmd_path), str(i)])
         mox.verify()


### PR DESCRIPTION
## Summary
- use f-string for invocation truncation
- extract helper for full invocation journal test

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bcd67ab594832283adc9fe6b33871a

## Summary by Sourcery

Refactor the invocation journal test to extract a helper for full invocation and streamline assertions, and simplify the IPC truncate function by using an f-string for string slicing.

Enhancements:
- Use an f-string in the IPC `_truncate` function for cleaner string truncation.

Tests:
- Extract a `_run_full_invocation` helper and refactor `test_journal_records_full_invocation` to use it and assert stdout after invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.

- Style
  - Minor formatting update to string representation; no behavioral impact.

- Tests
  - Refactored test logic into a reusable helper for clearer, more maintainable tests.
  - Streamlined assertions to improve readability and verification flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->