### PR TITLE
Implement diff-style verification

### DIFF
--- a/cmd_mox/unittests/test_expectations.py
+++ b/cmd_mox/unittests/test_expectations.py
@@ -212,7 +212,7 @@ def test_expectation_times_alias(
                 run([str(paths["second"])], shell=False),
                 run([str(paths["first"])], shell=False),
             ),
-            UnfulfilledExpectationError,
+            UnexpectedCommandError,
             id="order-validation",
         ),
         pytest.param(

--- a/cmd_mox/unittests/test_order_verifier.py
+++ b/cmd_mox/unittests/test_order_verifier.py
@@ -1,0 +1,41 @@
+"""Tests for the ordered expectation verifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from cmd_mox.errors import UnexpectedCommandError
+from cmd_mox.expectations import Expectation
+from cmd_mox.ipc import Invocation
+from cmd_mox.verifiers import OrderVerifier
+
+
+def _invocation(command: str, *args: str) -> Invocation:
+    """Create a minimal invocation for *command* with *args*."""
+    return Invocation(command=command, args=list(args), stdin="", env={})
+
+
+def test_order_verifier_ignores_unordered_invocations_with_same_command() -> None:
+    """Unordered expectations sharing a command name should not trip ordering."""
+    fetch = Expectation("git").with_args("fetch").in_order()
+
+    journal = [
+        _invocation("git", "status"),
+        _invocation("git", "fetch"),
+    ]
+
+    OrderVerifier([fetch]).verify(journal)
+
+
+def test_order_verifier_flags_out_of_order_matches() -> None:
+    """An invocation matching a later ordered expectation should fail fast."""
+    first = Expectation("git").with_args("fetch").in_order()
+    second = Expectation("git").with_args("status").in_order()
+
+    journal = [
+        _invocation("git", "status"),
+        _invocation("git", "fetch"),
+    ]
+
+    with pytest.raises(UnexpectedCommandError):
+        OrderVerifier([first, second]).verify(journal)

--- a/cmd_mox/unittests/test_verification_errors.py
+++ b/cmd_mox/unittests/test_verification_errors.py
@@ -1,0 +1,103 @@
+"""Tests covering verification error reporting."""
+
+from __future__ import annotations
+
+import typing as t
+from pathlib import Path
+
+import pytest
+
+from cmd_mox.controller import CmdMox
+from cmd_mox.errors import UnexpectedCommandError, UnfulfilledExpectationError
+
+if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
+    import subprocess
+
+
+def test_unexpected_invocation_message_includes_diff(
+    run: t.Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """Mismatched arguments surface in the verification error message."""
+    mox = CmdMox()
+    mox.mock("git").with_args("status")
+    mox.__enter__()
+    mox.replay()
+
+    path = Path(mox.environment.shim_dir) / "git"
+    run([str(path), "commit"], shell=False)
+
+    with pytest.raises(UnexpectedCommandError) as excinfo:
+        mox.verify()
+
+    message = str(excinfo.value)
+    assert "Unexpected command invocation." in message
+    assert "git('status')" in message
+    assert "git('commit')" in message
+
+
+def test_unfulfilled_expectation_message_includes_counts(
+    run: t.Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """Unfulfilled expectations report expected and observed call counts."""
+    mox = CmdMox()
+    mox.mock("sync").returns(stdout="ok").times(2)
+    mox.__enter__()
+    mox.replay()
+
+    path = Path(mox.environment.shim_dir) / "sync"
+    run([str(path)], shell=False)
+
+    with pytest.raises(UnfulfilledExpectationError) as excinfo:
+        mox.verify()
+
+    message = str(excinfo.value)
+    assert "Unfulfilled expectation." in message
+    assert "expected calls=2" in message
+    assert "1 (expected 2)" in message
+
+
+def test_order_violation_reports_first_mismatch(
+    run: t.Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """Ordered expectations report the first mismatching position."""
+    mox = CmdMox()
+    mox.mock("first").with_args("a").returns(stdout="1").in_order()
+    mox.mock("second").with_args("b").returns(stdout="2").in_order()
+    mox.__enter__()
+    mox.replay()
+
+    shim_first = Path(mox.environment.shim_dir) / "first"
+    shim_second = Path(mox.environment.shim_dir) / "second"
+    run([str(shim_second), "b"], shell=False)
+    run([str(shim_first), "a"], shell=False)
+
+    with pytest.raises(UnexpectedCommandError) as excinfo:
+        mox.verify()
+
+    message = str(excinfo.value)
+    assert "Ordered expectation violated." in message
+    assert "position 1" in message
+    assert "first" in message
+    assert "second" in message
+
+
+def test_extra_invocation_reports_count(
+    run: t.Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """Extra invocations report the observed call count."""
+    mox = CmdMox()
+    mox.mock("echo").returns(stdout="ok").times(1)
+    mox.__enter__()
+    mox.replay()
+
+    path = Path(mox.environment.shim_dir) / "echo"
+    run([str(path)], shell=False)
+    run([str(path)], shell=False)
+
+    with pytest.raises(UnexpectedCommandError) as excinfo:
+        mox.verify()
+
+    message = str(excinfo.value)
+    assert "Unexpected additional invocation." in message
+    assert "Observed calls" in message
+    assert "Last call" in message

--- a/cmd_mox/unittests/test_verifier_helpers.py
+++ b/cmd_mox/unittests/test_verifier_helpers.py
@@ -1,0 +1,116 @@
+"""Unit tests for internal formatting helpers in :mod:`cmd_mox.verifiers`."""
+
+from __future__ import annotations
+
+import types
+
+from cmd_mox import verifiers as v
+from cmd_mox.expectations import Expectation
+from cmd_mox.ipc import Invocation
+
+
+def test_mask_env_value_redacts_sensitive_keys() -> None:
+    """Sensitive environment keys should be obscured."""
+    assert v._mask_env_value("API_KEY", "secret") == "***"
+    assert v._mask_env_value("token", "value") == "***"
+
+
+def test_mask_env_value_preserves_safe_values() -> None:
+    """Safe keys or missing values remain untouched."""
+    assert v._mask_env_value("PATH", "value") == "value"
+    assert v._mask_env_value("PATH", None) is None
+
+
+def test_format_env_masks_and_sorts_entries() -> None:
+    """Environment formatting redacts sensitive values and sorts keys."""
+    formatted = v._format_env({"PATH": "/bin", "API_KEY": "secret"})
+    assert formatted == "{'API_KEY': '***', 'PATH': '/bin'}"
+
+
+def test_format_args_handles_empty_and_content() -> None:
+    """Argument formatting should collapse empty sequences to an empty string."""
+    assert v._format_args([]) == ""
+    assert v._format_args(["alpha", "beta"]) == "'alpha', 'beta'"
+
+
+def test_format_matchers_handles_empty_and_content() -> None:
+    """Matcher formatting should mirror argument formatting semantics."""
+    assert v._format_matchers([]) == ""
+    assert v._format_matchers([str.isdigit]) == "<method 'isdigit' of 'str' objects>"
+
+
+def test_describe_expectation_renders_all_fields() -> None:
+    """Expectation descriptions include args, counts, stdin, and env."""
+    exp = Expectation("deploy")
+    exp.with_args("--flag")
+    exp.with_stdin("payload")
+    exp.with_env({"TOKEN": "classified"})
+    exp.times_called(2)
+
+    description = v._describe_expectation(exp, include_count=True)
+    assert description == (
+        "deploy('--flag')\nexpected calls=2\nstdin='payload'\nenv={'TOKEN': '***'}"
+    )
+
+
+def test_describe_expectation_without_optional_fields() -> None:
+    """Expectations without args, stdin, or env render with empty call signature."""
+    exp = Expectation("noop")
+    assert v._describe_expectation(exp) == "noop()"
+
+
+def test_describe_invocation_focuses_requested_env_keys() -> None:
+    """Invocation descriptions redact sensitive values and include stdin when asked."""
+    inv = Invocation(
+        command="deploy",
+        args=["--flag"],
+        stdin="payload",
+        env={"API_KEY": "secret", "PATH": "/bin"},
+    )
+
+    description = v._describe_invocation(
+        inv,
+        focus_env=["API_KEY"],
+        include_stdin=True,
+    )
+
+    assert description == "deploy('--flag')\nstdin='payload'\nenv={'API_KEY': '***'}"
+
+
+def test_numbered_renders_multiline_entries() -> None:
+    """Numbered helper should indent continuation lines."""
+    entries = ["first line", "second\nwith extra"]
+    assert v._numbered(entries) == "1. first line\n2. second\n   with extra"
+
+
+def test_format_sections_omits_empty_sections() -> None:
+    """Formatting helper should skip blank section bodies."""
+    body = v._format_sections(
+        "Header",
+        [("Empty", ""), ("Details", "line1\nline2")],
+    )
+
+    assert body == "Header\n\nDetails:\n  line1\n  line2"
+
+
+def test_list_expected_commands_excludes_stubs() -> None:
+    """Helper lists only commands that can raise unexpected-invocation errors."""
+    doubles = {
+        "alpha": types.SimpleNamespace(kind="mock"),
+        "beta": types.SimpleNamespace(kind="stub"),
+        "gamma": types.SimpleNamespace(kind="spy"),
+    }
+
+    assert v._list_expected_commands(doubles) == "'alpha', 'gamma'"
+
+
+def test_list_expected_commands_reports_when_only_stubs() -> None:
+    """When only stubs are registered, the helper documents the omission."""
+    doubles = {
+        "alpha": types.SimpleNamespace(kind="stub"),
+    }
+
+    assert (
+        v._list_expected_commands(doubles)
+        == "(none: stubs are excluded from expected commands)"
+    )

--- a/cmd_mox/verifiers.py
+++ b/cmd_mox/verifiers.py
@@ -295,8 +295,10 @@ class OrderVerifier:
         journal: t.Iterable[Invocation],
         ordered_seq: list[Expectation],
     ) -> list[Invocation]:
-        relevant_commands = {exp.name for exp in ordered_seq}
-        return [inv for inv in journal if inv.command in relevant_commands]
+        # Ignore invocations that do not satisfy any ordered expectation so
+        # unordered calls of the same command name do not trigger spurious
+        # ordering failures.
+        return [inv for inv in journal if any(exp.matches(inv) for exp in ordered_seq)]
 
     def _validate_expectations_order(
         self,

--- a/cmd_mox/verifiers.py
+++ b/cmd_mox/verifiers.py
@@ -3,13 +3,134 @@
 from __future__ import annotations
 
 import typing as t
+from collections import defaultdict
+from textwrap import indent
 
 from .errors import UnexpectedCommandError, UnfulfilledExpectationError
+from .expectations import SENSITIVE_ENV_KEY_TOKENS
 
 if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
     from .controller import CommandDouble
     from .expectations import Expectation
     from .ipc import Invocation
+
+_SENSITIVE_TOKENS: tuple[str, ...] = tuple(
+    token.casefold() for token in SENSITIVE_ENV_KEY_TOKENS
+)
+
+
+def _mask_env_value(key: str, value: str | None) -> str | None:
+    """Redact *value* when *key* appears sensitive."""
+    if value is None:
+        return None
+    key_cf = key.casefold()
+    if any(token in key_cf for token in _SENSITIVE_TOKENS):
+        return "***"
+    return value
+
+
+def _format_env(mapping: t.Mapping[str, str | None]) -> str:
+    """Return a deterministic representation of environment values."""
+    if not mapping:
+        return "{}"
+    parts = []
+    for key in sorted(mapping):
+        masked = _mask_env_value(key, mapping[key])
+        parts.append(f"{key!r}: {masked!r}")
+    return "{" + ", ".join(parts) + "}"
+
+
+def _format_args(args: t.Sequence[str] | None) -> str:
+    if not args:
+        return ""
+    return ", ".join(repr(arg) for arg in args)
+
+
+def _format_matchers(matchers: t.Sequence[t.Callable[[str], bool]] | None) -> str:
+    if not matchers:
+        return ""
+    return ", ".join(repr(matcher) for matcher in matchers)
+
+
+def _format_call(name: str, args_repr: str) -> str:
+    return f"{name}({args_repr})" if args_repr else f"{name}()"
+
+
+def _describe_expectation(exp: Expectation, *, include_count: bool = False) -> str:
+    """Return a human readable representation of *exp*."""
+    if exp.args is not None:
+        args_repr = _format_args(exp.args)
+    elif exp.match_args is not None:
+        args_repr = _format_matchers(exp.match_args)
+    else:
+        args_repr = ""
+    lines = [_format_call(exp.name, args_repr)]
+    if include_count:
+        lines.append(f"expected calls={exp.count}")
+    if exp.stdin is not None:
+        lines.append(f"stdin={exp.stdin!r}")
+    if exp.env:
+        lines.append(f"env={_format_env(exp.env)}")
+    return "\n".join(lines)
+
+
+def _describe_invocation(
+    inv: Invocation,
+    *,
+    focus_env: t.Iterable[str] | None = None,
+    include_stdin: bool = False,
+) -> str:
+    """Return a readable representation of *inv*."""
+    lines = [_format_call(inv.command, _format_args(inv.args))]
+    if include_stdin:
+        lines.append(f"stdin={inv.stdin!r}")
+    if focus_env:
+        env_subset = {key: inv.env.get(key) for key in sorted(focus_env)}
+        lines.append(f"env={_format_env(env_subset)}")
+    return "\n".join(lines)
+
+
+def _describe_invocations(
+    invocations: t.Sequence[Invocation],
+    *,
+    focus_env: t.Iterable[str] | None = None,
+    include_stdin: bool = False,
+) -> str:
+    if not invocations:
+        return "(none)"
+    return "\n".join(
+        _describe_invocation(inv, focus_env=focus_env, include_stdin=include_stdin)
+        for inv in invocations
+    )
+
+
+def _numbered(entries: t.Sequence[str], *, start: int = 1) -> str:
+    if not entries:
+        return "(none)"
+    lines: list[str] = []
+    for index, entry in enumerate(entries, start=start):
+        entry_lines = entry.splitlines() or [""]
+        lines.append(f"{index}. {entry_lines[0]}")
+        lines.extend(f"   {extra}" for extra in entry_lines[1:])
+    return "\n".join(lines)
+
+
+def _format_sections(title: str, sections: list[tuple[str, str]]) -> str:
+    parts = [title]
+    for label, body in sections:
+        if not body:
+            continue
+        parts.append("")
+        parts.append(f"{label}:")
+        parts.append(indent(body, "  "))
+    return "\n".join(parts)
+
+
+def _list_expected_commands(doubles: t.Mapping[str, CommandDouble]) -> str:
+    names = sorted(name for name, dbl in doubles.items() if dbl.kind != "stub")
+    if not names:
+        return "(none)"
+    return ", ".join(repr(name) for name in names)
 
 
 class UnexpectedCommandVerifier:
@@ -21,18 +142,64 @@ class UnexpectedCommandVerifier:
         doubles: t.Mapping[str, CommandDouble],
     ) -> None:
         """Raise if *journal* contains calls not matching registered doubles."""
+        mock_counts: dict[str, int] = defaultdict(int)
         for inv in journal:
             dbl = doubles.get(inv.command)
             if dbl is None:
-                msg = f"Unexpected commands invoked: {inv.command}"
-                raise UnexpectedCommandError(msg)
-            if dbl.kind != "stub" and not dbl.expectation.matches(inv):
-                reason = dbl.expectation.explain_mismatch(inv)
-                msg = (
-                    f"Unexpected invocation for {inv.command}: {reason}; "
-                    f"args={inv.args!r}"
+                msg = _format_sections(
+                    "Unexpected command invocation.",
+                    [
+                        (
+                            "Actual call",
+                            _describe_invocation(inv, include_stdin=bool(inv.stdin)),
+                        ),
+                        ("Registered expectations", _list_expected_commands(doubles)),
+                    ],
                 )
                 raise UnexpectedCommandError(msg)
+            if dbl.kind == "stub":
+                continue
+            exp = dbl.expectation
+            if not exp.matches(inv):
+                reason = exp.explain_mismatch(inv)
+                msg = _format_sections(
+                    "Unexpected command invocation.",
+                    [
+                        ("Expected", _describe_expectation(exp)),
+                        (
+                            "Actual",
+                            _describe_invocation(
+                                inv,
+                                focus_env=exp.env.keys(),
+                                include_stdin=exp.stdin is not None,
+                            ),
+                        ),
+                        ("Reason", reason),
+                    ],
+                )
+                raise UnexpectedCommandError(msg)
+            if dbl.kind == "mock":
+                mock_counts[dbl.name] += 1
+                if mock_counts[dbl.name] > exp.count:
+                    msg = _format_sections(
+                        "Unexpected additional invocation.",
+                        [
+                            (
+                                "Expected",
+                                _describe_expectation(exp, include_count=True),
+                            ),
+                            ("Observed calls", str(mock_counts[dbl.name])),
+                            (
+                                "Last call",
+                                _describe_invocation(
+                                    inv,
+                                    focus_env=exp.env.keys(),
+                                    include_stdin=exp.stdin is not None,
+                                ),
+                            ),
+                        ],
+                    )
+                    raise UnexpectedCommandError(msg)
 
 
 class OrderVerifier:
@@ -46,17 +213,75 @@ class OrderVerifier:
         ordered_seq: list[Expectation] = []
         for exp in self._ordered:
             ordered_seq.extend([exp] * exp.count)
-        index = 0
-        for inv in journal:
-            if index >= len(ordered_seq):
-                break
-            exp = ordered_seq[index]
-            if exp.matches(inv):
-                index += 1
-        if index != len(ordered_seq):
-            remaining = [e.name for e in ordered_seq[index:]]
-            msg = f"Expected commands not called in order: {remaining}"
-            raise UnfulfilledExpectationError(msg)
+        if not ordered_seq:
+            return
+        relevant_commands = {exp.name for exp in ordered_seq}
+        relevant_invocations = [
+            inv for inv in journal if inv.command in relevant_commands
+        ]
+        expected_descriptions = [_describe_expectation(exp) for exp in ordered_seq]
+        actual_descriptions = [
+            _describe_invocation(inv) for inv in relevant_invocations
+        ]
+        for index, exp in enumerate(ordered_seq):
+            if index >= len(relevant_invocations):
+                remaining = _numbered(expected_descriptions[index:], start=index + 1)
+                msg = _format_sections(
+                    "Ordered expectations not satisfied.",
+                    [
+                        ("Expected order", _numbered(expected_descriptions)),
+                        ("Observed order", _numbered(actual_descriptions)),
+                        ("Missing", remaining),
+                    ],
+                )
+                raise UnfulfilledExpectationError(msg)
+            actual_inv = relevant_invocations[index]
+            if exp.matches(actual_inv):
+                continue
+            reason = exp.explain_mismatch(actual_inv)
+            mismatch = "\n".join(
+                [
+                    f"position {index + 1}",
+                    "expected:\n"
+                    + indent(
+                        _describe_expectation(exp),
+                        "  ",
+                    ),
+                    "actual:\n"
+                    + indent(
+                        _describe_invocation(
+                            actual_inv,
+                            focus_env=exp.env.keys(),
+                            include_stdin=exp.stdin is not None,
+                        ),
+                        "  ",
+                    ),
+                ]
+            )
+            msg = _format_sections(
+                "Ordered expectation violated.",
+                [
+                    ("Expected order", _numbered(expected_descriptions)),
+                    ("Observed order", _numbered(actual_descriptions)),
+                    ("First mismatch", mismatch),
+                    ("Reason", reason),
+                ],
+            )
+            raise UnexpectedCommandError(msg)
+        if len(relevant_invocations) > len(ordered_seq):
+            extras = relevant_invocations[len(ordered_seq) :]
+            msg = _format_sections(
+                "Unexpected additional invocation.",
+                [
+                    ("Expected order", _numbered(expected_descriptions)),
+                    ("Observed order", _numbered(actual_descriptions)),
+                    (
+                        "Unexpected calls",
+                        _describe_invocations(extras, include_stdin=False),
+                    ),
+                ],
+            )
+            raise UnexpectedCommandError(msg)
 
 
 class CountVerifier:
@@ -69,11 +294,48 @@ class CountVerifier:
     ) -> None:
         """Validate invocation counts against ``expectations``."""
         for name, exp in expectations.items():
+            calls = invocations.get(name, [])
+            actual = len(calls)
             expected = exp.count
-            actual = len(invocations.get(name, []))
+            focus_env = exp.env.keys()
+            include_stdin = exp.stdin is not None
             if actual < expected:
-                msg = f"Expected {name} to be called {expected} times but got {actual}"
+                msg = _format_sections(
+                    "Unfulfilled expectation.",
+                    [
+                        (
+                            "Expected",
+                            _describe_expectation(exp, include_count=True),
+                        ),
+                        ("Observed calls", f"{actual} (expected {expected})"),
+                        (
+                            "Recorded invocations",
+                            _describe_invocations(
+                                calls,
+                                focus_env=focus_env,
+                                include_stdin=include_stdin,
+                            ),
+                        ),
+                    ],
+                )
                 raise UnfulfilledExpectationError(msg)
             if actual > expected:
-                msg = f"{name} called more than expected ({actual} > {expected})"
+                msg = _format_sections(
+                    "Unexpected additional invocation.",
+                    [
+                        (
+                            "Expected",
+                            _describe_expectation(exp, include_count=True),
+                        ),
+                        ("Observed calls", f"{actual} (expected {expected})"),
+                        (
+                            "Last call",
+                            _describe_invocation(
+                                calls[-1],
+                                focus_env=focus_env,
+                                include_stdin=include_stdin,
+                            ),
+                        ),
+                    ],
+                )
                 raise UnexpectedCommandError(msg)

--- a/cmd_mox/verifiers.py
+++ b/cmd_mox/verifiers.py
@@ -274,6 +274,8 @@ class OrderVerifier:
 
     def __init__(self, ordered: list[Expectation]) -> None:
         self._ordered = ordered
+        self._current_expected_descriptions: list[str] = []
+        self._current_actual_descriptions: list[str] = []
 
     def verify(self, journal: t.Iterable[Invocation]) -> None:
         """Ensure ordered expectations appear in order within *journal*."""
@@ -309,6 +311,8 @@ class OrderVerifier:
         actual_descriptions = [
             _describe_invocation(inv) for inv in relevant_invocations
         ]
+        self._current_expected_descriptions = expected_descriptions
+        self._current_actual_descriptions = actual_descriptions
 
         self._check_missing_expectations(
             ordered_seq,
@@ -370,8 +374,6 @@ class OrderVerifier:
                 exp,
                 actual_inv,
                 reason,
-                expected_descriptions,
-                actual_descriptions,
             )
             return
 
@@ -405,8 +407,6 @@ class OrderVerifier:
         exp: Expectation,
         actual_inv: Invocation,
         reason: str,
-        expected_descriptions: list[str],
-        actual_descriptions: list[str],
     ) -> None:
         mismatch = "\n".join(
             [
@@ -430,8 +430,14 @@ class OrderVerifier:
         msg = _format_sections(
             "Ordered expectation violated.",
             [
-                ("Expected order", _numbered(expected_descriptions)),
-                ("Observed order", _numbered(actual_descriptions)),
+                (
+                    "Expected order",
+                    _numbered(self._current_expected_descriptions),
+                ),
+                (
+                    "Observed order",
+                    _numbered(self._current_actual_descriptions),
+                ),
                 ("First mismatch", mismatch),
                 ("Reason", reason),
             ],

--- a/cmd_mox/verifiers.py
+++ b/cmd_mox/verifiers.py
@@ -23,8 +23,9 @@ def _mask_env_value(key: str, value: str | None) -> str | None:
     """Redact *value* when *key* appears sensitive."""
     if value is None:
         return None
-    key_cf = key.casefold()
-    return "***" if any(token in key_cf for token in _SENSITIVE_TOKENS) else value
+    else:  # noqa: RET505 - required for clarity per review guidance
+        key_cf = key.casefold()
+        return "***" if any(token in key_cf for token in _SENSITIVE_TOKENS) else value
 
 
 def _format_env(mapping: t.Mapping[str, str | None]) -> str:

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -119,15 +119,15 @@
   - [x] Store as a deque to preserve order during verification
   - [x] Configurable max journal size via `max_journal_entries`
 
-- [ ] **Verification Algorithm**
+- [x] **Verification Algorithm**
 
-  - [ ] Unexpected calls (fail early)
+  - [x] Unexpected calls (fail early)
 
-  - [ ] Unfulfilled expectations
+  - [x] Unfulfilled expectations
 
-  - [ ] Call counts, strict ordering checks
+  - [x] Call counts, strict ordering checks
 
-  - [ ] Clear diff-style error reporting (`VerificationError` etc.)
+  - [x] Clear diff-style error reporting (`VerificationError` etc.)
 
 ## **VI. Shim Behaviour**
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -810,8 +810,8 @@ for this purpose:
   `stderr`, and `exit_code`.
 
 - `spy.assert_called()`, `spy.assert_not_called()`, and
-  `spy.assert_called_with(*args, stdin=None, env=None)`: Convenience helpers
-  mirroring `unittest.mock` for asserting call presence, absence, and arguments.
+  `spy.assert_called_with(*args, stdin=None, env=None)`: Helpers mirroring
+  `unittest.mock` assertions for presence, absence, and arguments.
 
 *Example Assertion-Style Verification:*
 ```python

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1172,11 +1172,12 @@ state untouched.
 Verification is split into focused components. `UnexpectedCommandVerifier`
 checks that every journal entry matches a registered expectation.
 `OrderVerifier` ensures expectations marked `in_order()` appear in the same
-relative order in the journal, ignoring interleaved unordered mocks.
-`CountVerifier` verifies that each expectation was met exactly the declared
-number of times. This modular approach simplifies the logic within
-:meth:`CmdMox.verify` and clarifies how mixed ordered and unordered calls are
-handled.
+relative order in the journal. It filters the journal to invocations that match
+the ordered expectations so interleaved unordered mocks, even when they share a
+command name, are ignored. `CountVerifier` verifies that each expectation was
+met exactly the declared number of times. This modular approach simplifies the
+logic within :meth:`CmdMox.verify` and clarifies how mixed ordered and
+unordered calls are handled.
 
 The verifiers now emit diff-style diagnostics that show the expected call, the
 actual invocation, and any mismatching context such as stdin or environment

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -186,3 +186,23 @@ Feature: CmdMox basic functionality
 
   Scenario: invalid max journal size is rejected
     Given creating a CmdMox controller with max journal size -1 fails
+
+  Scenario: verification reports unexpected invocation details
+    Given a CmdMox controller
+    And the command "git" is mocked with args "status" returning "ok" any order
+    When I replay the controller
+    And I run the command "git" with arguments "commit"
+    When I verify the controller expecting an UnexpectedCommandError
+    Then the verification error message should contain "Unexpected command invocation."
+    And the verification error message should contain "git('status')"
+    And the verification error message should contain "git('commit')"
+
+  Scenario: verification reports missing invocations
+    Given a CmdMox controller
+    And the command "sync" is mocked to return "ok" times 2
+    When I replay the controller
+    And I run the command "sync"
+    When I verify the controller expecting an UnfulfilledExpectationError
+    Then the verification error message should contain "Unfulfilled expectation."
+    And the verification error message should contain "expected calls=2"
+    And the verification error message should contain "Observed calls"

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -197,6 +197,16 @@ Feature: CmdMox basic functionality
     And the verification error message should contain "git('status')"
     And the verification error message should contain "git('commit')"
 
+  Scenario: verification redacts sensitive environment values
+    Given a CmdMox controller
+    And the command "deploy" is mocked to return "ok"
+    And the command "deploy" requires env var "API_KEY"="expected"
+    When I replay the controller
+    And I set environment variable "API_KEY" to "leaked-secret"
+    And I run the command "deploy"
+    When I verify the controller expecting an UnexpectedCommandError
+    Then the verification error message should contain "env={'API_KEY': '***'}"
+
   Scenario: verification reports missing invocations
     Given a CmdMox controller
     And the command "sync" is mocked to return "ok" times 2

--- a/features/order_verifier.feature
+++ b/features/order_verifier.feature
@@ -1,0 +1,8 @@
+Feature: Ordered expectation verification
+  Scenario: unordered invocation of matching command is ignored
+    Given an ordered expectation for command "git" with args "fetch"
+    And an unordered expectation for command "git" with args "status"
+    And the journal contains invocation "git" with args "status"
+    And the journal contains invocation "git" with args "fetch"
+    When I validate ordered expectations
+    Then the ordered verification should succeed

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -14,6 +14,11 @@ from pytest_bdd import given, parsers, scenario, then, when
 
 from cmd_mox.comparators import Any, Contains, IsA, Predicate, Regex, StartsWith
 from cmd_mox.controller import CmdMox
+from cmd_mox.errors import (
+    UnexpectedCommandError,
+    UnfulfilledExpectationError,
+    VerificationError,
+)
 from tests.helpers.controller import (
     CommandExecution,
     JournalEntryExpectation,
@@ -26,6 +31,12 @@ if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
 
 
 FEATURES_DIR = Path(__file__).resolve().parent.parent / "features"
+
+_ERROR_TYPES: dict[str, type[VerificationError]] = {
+    "UnexpectedCommandError": UnexpectedCommandError,
+    "UnfulfilledExpectationError": UnfulfilledExpectationError,
+    "VerificationError": VerificationError,
+}
 
 
 @given("a CmdMox controller", target_fixture="mox")
@@ -239,6 +250,26 @@ def verify_controller(mox: CmdMox, mox_stack: contextlib.ExitStack) -> None:
 
 
 @when(
+    parsers.cfparse("I verify the controller expecting an {error_name}"),
+    target_fixture="verification_error",
+)
+def verify_controller_expect_error(
+    mox: CmdMox, mox_stack: contextlib.ExitStack, error_name: str
+) -> VerificationError:
+    """Invoke verification expecting a specific error type."""
+    error_type = _ERROR_TYPES.get(error_name)
+    if error_type is None:  # pragma: no cover - invalid feature configuration
+        msg = f"Unknown verification error type: {error_name}"
+        raise ValueError(msg)
+    try:
+        with pytest.raises(error_type) as excinfo:
+            mox.verify()
+    finally:
+        mox_stack.close()
+    return t.cast("VerificationError", excinfo.value)
+
+
+@when(
     parsers.cfparse('I run the command "{cmd}" using a with block'),
     target_fixture="result",
 )
@@ -264,6 +295,14 @@ def check_output(result: subprocess.CompletedProcess[str], text: str) -> None:
 def check_exit_code(result: subprocess.CompletedProcess[str], code: int) -> None:
     """Assert the process exit code equals *code*."""
     assert result.returncode == code
+
+
+@then(parsers.cfparse('the verification error message should contain "{text}"'))
+def verification_error_contains(
+    verification_error: VerificationError, text: str
+) -> None:
+    """Assert the captured verification error contains *text*."""
+    assert text in str(verification_error)
 
 
 @then(parsers.cfparse('the stderr should contain "{text}"'))
@@ -533,4 +572,22 @@ def test_journal_prunes_excess_entries() -> None:
 )
 def test_invalid_max_journal_size_is_rejected() -> None:
     """Controller rejects non-positive journal size."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
+    "verification reports unexpected invocation details",
+)
+def test_verification_reports_unexpected_invocation_details() -> None:
+    """Verification errors include details for unexpected invocations."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
+    "verification reports missing invocations",
+)
+def test_verification_reports_missing_invocations() -> None:
+    """Verification errors highlight unfulfilled expectations."""
     pass

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -169,6 +169,19 @@ def stub_with_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
     mox.stub(cmd).with_env({var: val}).runs(handler)
 
 
+@given(parsers.cfparse('the command "{cmd}" requires env var "{var}"="{val}"'))
+def command_requires_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
+    """Attach an environment requirement to an existing double."""
+    for collection in (mox.mocks, mox.stubs, mox.spies):
+        double = collection.get(cmd)
+        if double is not None:
+            double.expectation.with_env({var: val})
+            return
+
+    msg = f"Command {cmd!r} has not been registered"
+    raise AssertionError(msg)
+
+
 @given(parsers.cfparse('the command "{cmd}" resolves to a non-executable file'))
 def non_executable_command(
     tmp_path: Path,
@@ -581,6 +594,15 @@ def test_invalid_max_journal_size_is_rejected() -> None:
 )
 def test_verification_reports_unexpected_invocation_details() -> None:
     """Verification errors include details for unexpected invocations."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
+    "verification redacts sensitive environment values",
+)
+def test_verification_redacts_sensitive_environment_values() -> None:
+    """Verification errors should redact sensitive environment variables."""
     pass
 
 

--- a/tests/test_order_verifier_bdd.py
+++ b/tests/test_order_verifier_bdd.py
@@ -1,0 +1,111 @@
+"""Behavioural tests exercising the order verifier in isolation."""
+
+import shlex
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, parsers, scenario, then, when
+
+from cmd_mox.expectations import Expectation
+from cmd_mox.ipc import Invocation
+from cmd_mox.verifiers import OrderVerifier
+
+FEATURES_DIR = Path(__file__).resolve().parent.parent / "features"
+
+
+@pytest.fixture
+def ordered_expectations() -> list[Expectation]:
+    """Collect expectations that must appear in order."""
+    return []
+
+
+@pytest.fixture
+def unordered_expectations() -> list[Expectation]:
+    """Collect expectations that are not part of the ordered sequence."""
+    return []
+
+
+@pytest.fixture
+def journal() -> list[Invocation]:
+    """Accumulate recorded invocations for verification."""
+    return []
+
+
+@pytest.fixture
+def verification_context() -> dict[str, Exception | None]:
+    """Store verification outcomes for assertions."""
+    return {}
+
+
+@given(
+    parsers.cfparse('an ordered expectation for command "{command}" with args "{args}"')
+)
+def create_ordered_expectation(
+    command: str, args: str, ordered_expectations: list[Expectation]
+) -> None:
+    """Add an ordered expectation for *command* with parsed *args*."""
+    expectation = Expectation(command)
+    if args:
+        expectation.with_args(*shlex.split(args))
+    expectation.in_order()
+    ordered_expectations.append(expectation)
+
+
+@given(
+    parsers.cfparse(
+        'an unordered expectation for command "{command}" with args "{args}"'
+    )
+)
+def create_unordered_expectation(
+    command: str, args: str, unordered_expectations: list[Expectation]
+) -> None:
+    """Record an unordered expectation to mirror setup complexity."""
+    expectation = Expectation(command)
+    if args:
+        expectation.with_args(*shlex.split(args))
+    unordered_expectations.append(expectation)
+
+
+@given(
+    parsers.cfparse('the journal contains invocation "{command}" with args "{args}"')
+)
+def add_invocation(command: str, args: str, journal: list[Invocation]) -> None:
+    """Append an invocation for *command* with parsed *args*."""
+    invocation = Invocation(
+        command=command,
+        args=list(shlex.split(args)) if args else [],
+        stdin="",
+        env={},
+    )
+    journal.append(invocation)
+
+
+@when("I validate ordered expectations")
+def validate_order(
+    ordered_expectations: list[Expectation],
+    journal: list[Invocation],
+    verification_context: dict[str, Exception | None],
+) -> None:
+    """Run the order verifier and capture any raised error."""
+    verifier = OrderVerifier(ordered_expectations)
+    try:
+        verifier.verify(journal)
+    except Exception as exc:  # noqa: BLE001 - capturing for assertion
+        verification_context["error"] = exc
+    else:
+        verification_context["error"] = None
+
+
+@then("the ordered verification should succeed")
+def assert_order_success(verification_context: dict[str, Exception | None]) -> None:
+    """Assert that the verification completed without raising."""
+    assert verification_context.get("error") is None
+
+
+@scenario(
+    str(FEATURES_DIR / "order_verifier.feature"),
+    "unordered invocation of matching command is ignored",
+)
+def test_order_verifier_ignores_unordered_invocation() -> None:
+    """Order verifier ignores invocations satisfied by unordered expectations."""
+    pass


### PR DESCRIPTION
## Summary
- add diff-style reporting to the verification engine, including sensitive env redaction and eager call count failures
- extend pytest-bdd steps and scenarios to exercise verification error messages
- add unit tests covering verification errors and update existing expectation failure expectations
- record the design decision and mark the roadmap item complete

## Testing
- make fmt
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68c990b050848322803fa9851f29360f

## Summary by Sourcery

Implement diff-style verification with detailed, redacted error reporting and early failure for extra calls, extend BDD and unit tests to exercise these messages, and update documentation to mark the verification roadmap items complete.

New Features:
- Add diff-style error reporting to verifiers with multi-section diagnostics and sensitive environment variable redaction.
- Extend pytest-bdd steps and scenarios to support asserting on verification error messages.

Enhancements:
- Introduce formatting utilities (_mask_env_value, _format_env, _describe_expectation, etc.) to compose human-readable verification diffs.
- Eagerly fail on excess mock and ordered calls within UnexpectedCommandVerifier, OrderVerifier, and CountVerifier.

Documentation:
- Update design documentation to describe new diff-style diagnostics and mark verification algorithm tasks in the roadmap as complete.

Tests:
- Add unit tests covering diff-style error output for unexpected invocations, unfulfilled expectations, order violations, and extra calls.
- Extend BDD features and step definitions to capture and assert on verification error messages.

Chores:
- Record the design decision for diff-style verification in documentation and mark corresponding roadmap items done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Rich, diff-style verification errors showing expected vs. observed, call counts, stdin/env (with redaction), and last/recorded calls.
  - Sensitive environment values are redacted in all failure messages.
  - Clearer ordering diagnostics highlighting the first mismatch and extra invocations.

- Bug Fixes
  - More accurate error types surfaced for out-of-order invocations.

- Documentation
  - Roadmap items completed for verification.
  - Expanded design docs on unified doubles, diagnostics, spies/passthrough, parallel isolation, and journal sizing.

- Tests
  - New unit and BDD scenarios validating detailed error messages, redaction, and missing/extra invocation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->