### PR TITLE
Add helpers to skip unsupported platforms

### DIFF
--- a/cmd_mox/__init__.py
+++ b/cmd_mox/__init__.py
@@ -6,6 +6,9 @@ documentation (`https://github.com/leynos/cmd-mox/blob/main/docs/contents.md`).
 
 from __future__ import annotations
 
+import importlib
+import typing as t
+
 from .comparators import Any, Contains, IsA, Predicate, Regex, StartsWith
 from .controller import CmdMox, CommandDouble, MockCommand, SpyCommand
 from .environment import EnvironmentManager, temporary_env
@@ -21,16 +24,52 @@ from .expectations import Expectation
 from .ipc import Invocation, IPCServer, Response
 from .platform import (
     PLATFORM_OVERRIDE_ENV,
+    is_supported,
     skip_if_unsupported,
     unsupported_reason,
 )
-from .platform import (
-    is_supported as is_supported_platform,
-)
-from .pytest_plugin import cmd_mox as cmd_mox_fixture
 from .shimgen import SHIM_PATH, create_shim_symlinks
 
-is_supported = is_supported_platform
+if t.TYPE_CHECKING:
+    from types import ModuleType as _ModuleType
+else:  # pragma: no cover - typing fallback only
+    _ModuleType = type(importlib)
+
+_CmdMoxFixture = t.Callable[..., object]
+
+_CMD_MOX_FIXTURE_PYTEST_REQUIRED_MESSAGE: t.Final[str] = (
+    "cmd_mox_fixture requires pytest; install 'pytest' to use the fixture."
+)
+
+
+@t.overload
+def __getattr__(name: t.Literal["cmd_mox_fixture"]) -> _CmdMoxFixture: ...
+
+
+@t.overload
+def __getattr__(name: str) -> _ModuleType: ...
+
+
+def __getattr__(name: str) -> _ModuleType | _CmdMoxFixture:
+    """Lazily import optional dependencies when requested."""
+    if name == "cmd_mox_fixture":
+        try:
+            from .pytest_plugin import cmd_mox as _cmd_mox_fixture
+        except ModuleNotFoundError as exc:  # pytest optional at runtime
+            raise RuntimeError(_CMD_MOX_FIXTURE_PYTEST_REQUIRED_MESSAGE) from exc
+        globals()[name] = _cmd_mox_fixture
+        return _cmd_mox_fixture
+
+    try:
+        module = importlib.import_module(f"{__name__}.{name}")
+    except ModuleNotFoundError as exc:
+        if exc.name in {f"{__name__}.{name}", name}:
+            raise AttributeError(name) from exc
+        raise
+
+    globals()[name] = module
+    return module
+
 
 __all__ = [
     "PLATFORM_OVERRIDE_ENV",
@@ -59,7 +98,6 @@ __all__ = [
     "cmd_mox_fixture",
     "create_shim_symlinks",
     "is_supported",
-    "is_supported_platform",
     "skip_if_unsupported",
     "temporary_env",
     "unsupported_reason",

--- a/cmd_mox/__init__.py
+++ b/cmd_mox/__init__.py
@@ -19,10 +19,21 @@ from .errors import (
 )
 from .expectations import Expectation
 from .ipc import Invocation, IPCServer, Response
+from .platform import (
+    PLATFORM_OVERRIDE_ENV,
+    skip_if_unsupported,
+    unsupported_reason,
+)
+from .platform import (
+    is_supported as is_supported_platform,
+)
 from .pytest_plugin import cmd_mox as cmd_mox_fixture
 from .shimgen import SHIM_PATH, create_shim_symlinks
 
+is_supported = is_supported_platform
+
 __all__ = [
+    "PLATFORM_OVERRIDE_ENV",
     "SHIM_PATH",
     "Any",
     "CmdMox",
@@ -47,5 +58,9 @@ __all__ = [
     "VerificationError",
     "cmd_mox_fixture",
     "create_shim_symlinks",
+    "is_supported",
+    "is_supported_platform",
+    "skip_if_unsupported",
     "temporary_env",
+    "unsupported_reason",
 ]

--- a/cmd_mox/platform.py
+++ b/cmd_mox/platform.py
@@ -1,0 +1,80 @@
+"""Platform helpers shared across cmd-mox modules.
+
+Centralising the logic keeps the supported/unsupported matrix in one place and
+lets both the pytest plug-in and external test suites react consistently.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import typing as t
+
+# ``pytester``-driven tests set this override to emulate alternative platforms
+# (for example Windows) without needing to spawn a different OS.
+PLATFORM_OVERRIDE_ENV: t.Final[str] = "CMD_MOX_PLATFORM_OVERRIDE"
+
+# Map ``sys.platform`` prefixes to user-facing skip reasons. Only Windows is
+# unsupported today, but the structure keeps future additions focused here.
+_UNSUPPORTED_PLATFORMS: t.Final[tuple[tuple[str, str], ...]] = (
+    ("win", "cmd-mox does not support Windows"),
+)
+
+_PYTEST_REQUIRED_MESSAGE: t.Final[str] = (
+    "pytest is required to automatically skip unsupported platforms."
+)
+
+
+def _normalise(platform: str) -> str:
+    """Return a lowercase version of *platform* suitable for prefix checks."""
+    return platform.strip().lower()
+
+
+def _current_platform(platform: str | None = None) -> str:
+    """Return the effective platform name, honouring test overrides."""
+    if platform:
+        return _normalise(platform)
+
+    override = os.getenv(PLATFORM_OVERRIDE_ENV)
+    if override:
+        return _normalise(override)
+
+    return _normalise(sys.platform)
+
+
+def unsupported_reason(platform: str | None = None) -> str | None:
+    """Return the skip reason for *platform*, or ``None`` when supported."""
+    platform_name = _current_platform(platform)
+    for prefix, reason in _UNSUPPORTED_PLATFORMS:
+        if platform_name.startswith(prefix):
+            return reason
+    return None
+
+
+def is_supported(platform: str | None = None) -> bool:
+    """Return ``True`` when *platform* (default: current) supports cmd-mox."""
+    return unsupported_reason(platform) is None
+
+
+def skip_if_unsupported(
+    *, reason: str | None = None, platform: str | None = None
+) -> None:
+    """Skip the current pytest test if cmd-mox is unavailable on *platform*."""
+    skip_reason = reason or unsupported_reason(platform)
+    if skip_reason is None:
+        return
+
+    try:
+        import pytest
+    except ModuleNotFoundError as exc:  # pragma: no cover - pytest is a test dep
+        raise RuntimeError(_PYTEST_REQUIRED_MESSAGE) from exc
+
+    pytest.skip(skip_reason)
+
+
+__all__ = [
+    "PLATFORM_OVERRIDE_ENV",
+    "is_supported",
+    "skip_if_unsupported",
+    "unsupported_reason",
+]

--- a/cmd_mox/platform.py
+++ b/cmd_mox/platform.py
@@ -66,12 +66,14 @@ def skip_if_unsupported(
     *, reason: str | None = None, platform: str | None = None
 ) -> None:
     """Skip the current pytest test if cmd-mox is unavailable on *platform*."""
-    skip_reason = unsupported_reason(platform)
-    if skip_reason is None:
+    platform_reason = unsupported_reason(platform)
+    if platform_reason is None:
         return
 
-    if reason is not None:
-        skip_reason = reason
+    # Custom skip messages should only apply once we've confirmed cmd-mox is
+    # unavailable on the requested platform. Supported systems must never skip
+    # just because a caller provided a message.
+    skip_reason = reason if reason is not None else platform_reason
 
     try:
         import pytest

--- a/cmd_mox/platform.py
+++ b/cmd_mox/platform.py
@@ -24,7 +24,9 @@ _UNSUPPORTED_PLATFORMS: t.Final[tuple[tuple[str, str], ...]] = (
 )
 
 _PYTEST_REQUIRED_MESSAGE: t.Final[str] = (
-    "pytest is required to automatically skip unsupported platforms."
+    "pytest is required to automatically skip unsupported platforms. "
+    "Install it with 'pip install pytest' or only call skip_if_unsupported within "
+    "pytest."
 )
 
 
@@ -45,7 +47,20 @@ def _current_platform(platform: str | None = None) -> str:
 
 
 def unsupported_reason(platform: str | None = None) -> str | None:
-    """Return the skip reason for *platform*, or ``None`` when supported."""
+    """Return the skip reason for a platform, or None when supported.
+
+    Parameters
+    ----------
+    platform : str, optional
+        A ``sys.platform``-like string. When ``None``, the current platform is
+        used and ``CMD_MOX_PLATFORM_OVERRIDE`` is honoured.
+
+    Returns
+    -------
+    str or None
+        The user-facing reason if the platform is unsupported; otherwise
+        ``None``.
+    """
     platform_name = _current_platform(platform)
     return next(
         (
@@ -58,14 +73,41 @@ def unsupported_reason(platform: str | None = None) -> str | None:
 
 
 def is_supported(platform: str | None = None) -> bool:
-    """Return ``True`` when *platform* (default: current) supports cmd-mox."""
+    """Return True when the platform supports cmd-mox.
+
+    Parameters
+    ----------
+    platform : str, optional
+        A ``sys.platform``-like string. When ``None``, the current platform is
+        used and ``CMD_MOX_PLATFORM_OVERRIDE`` is honoured.
+
+    Returns
+    -------
+    bool
+        ``True`` if cmd-mox is supported; ``False`` if unsupported.
+    """
     return unsupported_reason(platform) is None
 
 
 def skip_if_unsupported(
     *, reason: str | None = None, platform: str | None = None
 ) -> None:
-    """Skip the current pytest test if cmd-mox is unavailable on *platform*."""
+    """Skip the current pytest test on unsupported platforms.
+
+    Parameters
+    ----------
+    reason : str, optional
+        Custom message to display when skipping. Used only if the platform is
+        unsupported.
+    platform : str, optional
+        A ``sys.platform``-like string to evaluate. When ``None``, the current
+        platform is used and ``CMD_MOX_PLATFORM_OVERRIDE`` is honoured.
+
+    Raises
+    ------
+    RuntimeError
+        If pytest cannot be imported in the current environment.
+    """
     platform_reason = unsupported_reason(platform)
     if platform_reason is None:
         return
@@ -83,9 +125,9 @@ def skip_if_unsupported(
     pytest.skip(skip_reason)
 
 
-__all__ = [
+__all__ = (
     "PLATFORM_OVERRIDE_ENV",
     "is_supported",
     "skip_if_unsupported",
     "unsupported_reason",
-]
+)

--- a/cmd_mox/pytest_plugin.py
+++ b/cmd_mox/pytest_plugin.py
@@ -10,6 +10,7 @@ import pytest
 
 from .controller import CmdMox
 from .environment import EnvironmentManager
+from .platform import skip_if_unsupported
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,8 @@ logger = logging.getLogger(__name__)
 @pytest.fixture
 def cmd_mox(request: pytest.FixtureRequest) -> t.Generator[CmdMox, None, None]:
     """Provide a :class:`CmdMox` instance with environment active."""
+    skip_if_unsupported()
+
     worker_id = os.getenv("PYTEST_XDIST_WORKER")
     if worker_id is None:
         worker_id = getattr(

--- a/cmd_mox/unittests/test_verifier_helpers.py
+++ b/cmd_mox/unittests/test_verifier_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import types
 
-from cmd_mox import verifiers as v
+import cmd_mox.verifiers as v
 from cmd_mox.expectations import Expectation
 from cmd_mox.ipc import Invocation
 

--- a/tests/test_platform_support.py
+++ b/tests/test_platform_support.py
@@ -33,12 +33,30 @@ def test_override_env_forces_windows(monkeypatch: pytest.MonkeyPatch) -> None:
     assert platform.unsupported_reason() == WINDOWS_REASON
 
 
+def test_override_env_reports_supported_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Overrides should allow tests to simulate supported platforms as well."""
+    monkeypatch.setenv(platform.PLATFORM_OVERRIDE_ENV, "linux")
+    assert platform.is_supported() is True
+    assert platform.unsupported_reason() is None
+
+
 def test_skip_if_unsupported_triggers_pytest_skip() -> None:
     """Calling ``skip_if_unsupported`` on Windows short-circuits the test."""
     with pytest.raises(pytest.skip.Exception) as excinfo:
         platform.skip_if_unsupported(platform="win32")
 
     assert str(excinfo.value) == WINDOWS_REASON
+
+
+def test_skip_if_unsupported_allows_custom_reason() -> None:
+    """A provided reason should override the default skip message."""
+    custom_reason = "custom skip message"
+    with pytest.raises(pytest.skip.Exception) as excinfo:
+        platform.skip_if_unsupported(platform="win32", reason=custom_reason)
+
+    assert str(excinfo.value) == custom_reason
 
 
 def test_skip_if_unsupported_noop_on_supported_platform() -> None:

--- a/tests/test_platform_support.py
+++ b/tests/test_platform_support.py
@@ -33,7 +33,7 @@ def test_override_env_forces_windows(monkeypatch: pytest.MonkeyPatch) -> None:
     assert platform.unsupported_reason() == WINDOWS_REASON
 
 
-def test_override_env_reports_supported_platform(
+def test_override_env_forces_supported_platform(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Overrides should allow tests to simulate supported platforms as well."""
@@ -55,6 +55,19 @@ def test_skip_if_unsupported_allows_custom_reason() -> None:
     custom_reason = "custom skip message"
     with pytest.raises(pytest.skip.Exception) as excinfo:
         platform.skip_if_unsupported(platform="win32", reason=custom_reason)
+
+    assert str(excinfo.value) == custom_reason
+
+
+def test_skip_if_unsupported_uses_custom_reason_with_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Overrides should not stop callers from surfacing custom skip reasons."""
+    monkeypatch.setenv(platform.PLATFORM_OVERRIDE_ENV, "win32")
+    custom_reason = "custom skip via override"
+
+    with pytest.raises(pytest.skip.Exception) as excinfo:
+        platform.skip_if_unsupported(reason=custom_reason)
 
     assert str(excinfo.value) == custom_reason
 

--- a/tests/test_platform_support.py
+++ b/tests/test_platform_support.py
@@ -1,0 +1,65 @@
+"""Tests for platform detection and skip helpers."""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+import cmd_mox.platform as platform
+
+if t.TYPE_CHECKING:  # pragma: no cover - used only for type hints
+    from _pytest.pytester import Pytester
+
+
+WINDOWS_REASON = platform.unsupported_reason("win32")
+
+
+def test_is_supported_false_for_windows() -> None:
+    """Windows should be rejected because cmd-mox lacks support."""
+    assert WINDOWS_REASON == "cmd-mox does not support Windows"
+    assert platform.is_supported("win32") is False
+
+
+def test_is_supported_true_for_linux() -> None:
+    """Linux is currently supported."""
+    assert platform.is_supported("linux") is True
+
+
+def test_override_env_forces_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests can force alternate platforms via the override environment variable."""
+    monkeypatch.setenv(platform.PLATFORM_OVERRIDE_ENV, "win32")
+    assert platform.is_supported() is False
+    assert platform.unsupported_reason() == WINDOWS_REASON
+
+
+def test_skip_if_unsupported_triggers_pytest_skip() -> None:
+    """Calling ``skip_if_unsupported`` on Windows short-circuits the test."""
+    with pytest.raises(pytest.skip.Exception) as excinfo:
+        platform.skip_if_unsupported(platform="win32")
+
+    assert str(excinfo.value) == WINDOWS_REASON
+
+
+def test_skip_if_unsupported_noop_on_supported_platform() -> None:
+    """On supported platforms the helper should return quietly."""
+    platform.skip_if_unsupported(platform="linux")
+
+
+def test_cmd_mox_fixture_auto_skips_on_unsupported_platform(
+    pytester: Pytester, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pytest fixture should skip automatically when support is absent."""
+    monkeypatch.setenv(platform.PLATFORM_OVERRIDE_ENV, "win32")
+    test_file = pytester.makepyfile(
+        """
+        pytest_plugins = ("cmd_mox.pytest_plugin",)
+
+        def test_auto_skip(cmd_mox):
+            raise AssertionError("fixture should skip before running")
+        """
+    )
+
+    result = pytester.runpytest(str(test_file), "-rs")
+    result.assert_outcomes(skipped=1)
+    result.stdout.fnmatch_lines(["*cmd-mox does not support Windows*"])

--- a/tests/test_platform_support.py
+++ b/tests/test_platform_support.py
@@ -59,6 +59,14 @@ def test_skip_if_unsupported_allows_custom_reason() -> None:
     assert str(excinfo.value) == custom_reason
 
 
+def test_skip_if_unsupported_ignores_reason_on_supported_platform() -> None:
+    """Providing a reason must not skip when the platform is supported."""
+    try:
+        platform.skip_if_unsupported(platform="linux", reason="custom skip")
+    except pytest.skip.Exception as exc:  # pragma: no cover - indicates a bug
+        pytest.fail(f"unexpected skip: {exc}")
+
+
 def test_skip_if_unsupported_noop_on_supported_platform() -> None:
     """On supported platforms the helper should return quietly."""
     platform.skip_if_unsupported(platform="linux")

--- a/tests/test_shim_timeout.py
+++ b/tests/test_shim_timeout.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from cmd_mox import shim
+import cmd_mox.shim as shim
 from cmd_mox.environment import CMOX_IPC_SOCKET_ENV, CMOX_IPC_TIMEOUT_ENV
 
 


### PR DESCRIPTION
## Summary
- add a shared platform helper so the package and pytest plug-in agree on which systems are unsupported
- wire the pytest fixture to skip automatically on unsupported platforms and document how to gate tests explicitly
- cover the new helpers with unit tests that also exercise the pytest fixture via `pytester`

## Testing
- make fmt
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ce8144b6548322a11cf36e11d127f9

## Summary by Sourcery

Add shared platform support utilities to centralize unsupported platform detection and reasons, wire the pytest fixture to automatically skip tests on unsupported systems, extend the public API, update the documentation with usage instructions, and cover the new helpers with unit tests.

New Features:
- Introduce platform detection and skip helpers in cmd_mox.platform
- Automatically skip pytest tests on unsupported platforms via skip_if_unsupported

Enhancements:
- Export skip_if_unsupported, is_supported and unsupported_reason in the public API
- Update documentation to explain platform support, skip helper usage, and environment override

Tests:
- Add unit tests for platform helpers and pytest fixture behavior using pytester to validate automatic skipping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-aware helpers to detect unsupported systems, report reasons, and allow tests to skip automatically.
  * Environment variable to override detected platform for testing/CI.
  * Test fixture now auto-skips on unsupported platforms with a clear skip message.

* **Documentation**
  * Added Platform support section and refined usage, argument matching, spies, and Fluent API guidance.

* **Tests**
  * New tests for platform detection, override behavior, and auto-skip logic; minor test import adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->