### PR TITLE
Document auto lifecycle precedence

### DIFF
--- a/cmd_mox/pytest_plugin.py
+++ b/cmd_mox/pytest_plugin.py
@@ -90,8 +90,8 @@ def _auto_lifecycle_enabled(request: pytest.FixtureRequest) -> bool:
     """Return whether the fixture should manage replay/verify automatically.
 
     Precedence flows from the most granular override to the global default:
-    a ``@pytest.mark.cmd_mox`` marker beats a fixture parameter, which in turn
-    overrides the command-line flag, and finally the ``pytest.ini`` value.
+    a ``@pytest.mark.cmd_mox`` marker has priority over a fixture parameter, which
+    has priority over the command-line option, and finally the ``pytest.ini`` setting.
     """
     marker_value = _get_marker_auto_lifecycle(request)
     if marker_value is not None:

--- a/cmd_mox/pytest_plugin.py
+++ b/cmd_mox/pytest_plugin.py
@@ -87,9 +87,12 @@ def pytest_runtest_makereport(
 
 
 def _auto_lifecycle_enabled(request: pytest.FixtureRequest) -> bool:
-    """Return whether the fixture should manage replay/verify automatically."""
-    # Priority order: marker > fixture param > CLI option > INI setting
+    """Return whether the fixture should manage replay/verify automatically.
 
+    Precedence flows from the most granular override to the global default:
+    a ``@pytest.mark.cmd_mox`` marker beats a fixture parameter, which in turn
+    overrides the command-line flag, and finally the ``pytest.ini`` value.
+    """
     marker_value = _get_marker_auto_lifecycle(request)
     if marker_value is not None:
         return marker_value


### PR DESCRIPTION
## Summary
- clarify the `_auto_lifecycle_enabled` docstring so the precedence ordering is spelled out for maintainers

## Testing
- make fmt
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d32520e8f48322b095a30ad1c2bced

## Summary by Sourcery

Documentation:
- Expand the `_auto_lifecycle_enabled` docstring to list the override hierarchy: marker, fixture parameter, CLI option, and pytest.ini

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified precedence rules for auto-lifecycle configuration in the plugin docs, showing how markers, fixture parameters, CLI options, and ini settings are considered.
  * Added explanatory text to help users predict which configuration source takes effect when multiple are present.
  * No behavioral changes — existing workflows and outcomes remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->