### PR TITLE
Document and test shim startup behaviour

### DIFF
--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -207,8 +207,8 @@
         `windows-latest` GH runner with IPC + shims enabled).
 
   - [ ] Validate environment management and filesystem helpers on Windows,
-        addressing portability gaps discovered during testing (cover:
-        `PATHEXT` lookup semantics, CRLF line endings for batch shims, argument
+        addressing portability gaps discovered during testing (cover: `PATHEXT`
+        lookup semantics, CRLF line endings for batch shims, argument
         quoting/escaping rules with spaces and carets, max path handling,
         case-insensitive filesystem behaviour).
 

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -131,17 +131,17 @@
 
 ## **VI. Shim Behaviour**
 
-- [ ] **Shim Startup Logic**
+- [x] **Shim Startup Logic**
 
-  - [ ] Determine which command to simulate via `argv[0]`
+  - [x] Determine which command to simulate via `argv[0]`
 
-  - [ ] Connect to IPC socket
+  - [x] Connect to IPC socket
 
-  - [ ] Capture stdin, argv, env
+  - [x] Capture stdin, argv, env
 
-  - [ ] Send invocation to IPC server, wait for response
+  - [x] Send invocation to IPC server, wait for response
 
-  - [ ] Apply returned behaviour: print `stdout`, `stderr`, exit with code
+  - [x] Apply returned behaviour: print `stdout`, `stderr`, exit with code
 
 - [ ] **Passthrough Spies**
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -497,7 +497,8 @@ features that are infeasible with file-based logging.
   directory.
 - Standard input is eagerly read when the shim detects it is connected to a
   pipe. Guarding the read with ``sys.stdin.isatty()`` avoids blocking when a
-  user invokes an interactive command during a test run.
+  user invokes an interactive command during a test run, and the implementation
+  explicitly skips calling ``read()`` on terminal-bound streams.
 - The shim sends a shallow copy of ``os.environ`` to the IPC server. This
   captures environment variables at call time without mutating the caller's
   process state.
@@ -505,13 +506,17 @@ features that are infeasible with file-based logging.
   ``stderr`` before the process exits using the supplied exit code. Any
   environment overrides returned by the server are merged into the shim's
   process environment, enabling later invocations in the same process to see
-  those changes.
+  those changes. Successive overrides accumulate, so commands executed within
+  the same process observe the union of all previously injected variables.
+- The shim reads :data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` to determine
+  its IPC timeout, defaulting to ``5.0`` seconds. Non-default overrides are
+  validated to ensure they remain positive, finite floats before being applied.
 
 The initial implementation ships with a lightweight `IPCServer` class. It uses
 Python's `socketserver.ThreadingUnixStreamServer` to listen on a Unix domain
 socket path provided by the `EnvironmentManager`. Incoming JSON messages are
 parsed into `Invocation` objects and processed in background threads with
-reasonable timeouts (default: 10.0s). The server attaches the corresponding
+reasonable timeouts (default: 5.0s). The server attaches the corresponding
 response data (`stdout`, `stderr`, `exit_code`) to the `Invocation` before
 appending it to the journal. The server cleans up the socket on shutdown to
 prevent stale sockets from interfering with subsequent tests. The timeout is
@@ -1072,8 +1077,8 @@ Darwin environments, several avenues for future expansion exist.
     3.9+, expose `AF_UNIX`, but the port omits ancillary-data/`SCM_RIGHTS`
     semantics—so we must avoid file-descriptor passing. When capability checks
     (`hasattr(socket, 'AF_UNIX')` plus a bind probe) fail or fd-passing is
-    required, fall back to Windows Named Pipes (`\\.\\pipe\\cmdmox-<id>`)
-    with per-test unique pipe names for isolation. Document the minimum
+    required, fall back to Windows Named Pipes (`\\.\\pipe\\cmdmox-<id>`) with
+    per-test unique pipe names for isolation. Document the minimum
     Windows/Python versions and runtime fallback behaviour so adopters
     understand the selection flow.
 
@@ -1088,11 +1093,11 @@ Darwin environments, several avenues for future expansion exist.
     `EnvironmentManager` under Windows to confirm that `PATH` manipulation via
     `os.pathsep` behaves as intended. Any remaining direct `os.path` usages
     should migrate to `pathlib` for consistent path handling across drives, and
-    the existing `_fix_windows_permissions` helper in
-    `cmd_mox/environment.py` will anchor permission adjustments for shim
-    directories. Also account for `MAX_PATH` constraints (prefer temp-based
-    directories or long-path enablement) and avoid symlink requirements by
-    leaning on wrappers when elevated privileges are unavailable.
+    the existing `_fix_windows_permissions` helper in `cmd_mox/environment.py`
+    will anchor permission adjustments for shim directories. Also account for
+    `MAX_PATH` constraints (prefer temp-based directories or long-path
+    enablement) and avoid symlink requirements by leaning on wrappers when
+    elevated privileges are unavailable.
 
   - **CI and verification.** Add a `windows-latest` job in GitHub Actions to
     exercise named-pipe IPC, batch shim invocation, passthrough spies, and

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -171,7 +171,9 @@ mox.spy("aws").passthrough()
 This "record mode" is helpful for capturing real interactions and later turning
 them into mocks.
 
-Spies provide assertion helpers inspired by `unittest.mock` that can be called in the test body or after verification:
+Spies provide assertion helpers inspired by `unittest.mock` that can be called
+in the test body or after verification:
+
 ```python
 spy.assert_called()
 spy.assert_called_with("--silent", stdin="payload")
@@ -204,12 +206,19 @@ assert [call.command for call in cmd_mox.journal] == ["git", "curl"]
 # Verification will run during fixture teardown.
 ```
 
-When you want to intercept a command without configuring a double—for example to ensure it is treated as unexpected—register it explicitly. Any invocation of a registered command without a matching double will be reported as unexpected during verification:
+When you want to intercept a command without configuring a double—for example
+to ensure it is treated as unexpected—register it explicitly. Any invocation of
+a registered command without a matching double will be reported as unexpected
+during verification:
+
 ```python
 cmd_mox.register_command("name")
 ```
 
-CmdMox will create the shim so the command is routed through the IPC server even without a stub, mock, or spy. Shims are cleaned up automatically during fixture teardown.
+CmdMox will create the shim so the command is routed through the IPC server
+even without a stub, mock, or spy. Shims are cleaned up automatically during
+fixture teardown.
+
 ## Fluent API reference
 
 The DSL methods closely mirror those described in the design specification. A
@@ -225,7 +234,9 @@ few common ones are:
   values; CmdMox operates in text mode—pass `str` (bytes are not supported).
   Note: For binary payloads, prefer `passthrough()` or encode/decode at the
   boundary (e.g., base64) so handlers exchange `str`.
-- `runs(handler)` – call a function to produce dynamic output. The handler receives an `Invocation` and should return either a `(stdout, stderr, exit_code)` tuple or a `Response` instance.
+- `runs(handler)` – call a function to produce dynamic output. The handler
+  receives an `Invocation` and should return either a
+  `(stdout, stderr, exit_code)` tuple or a `Response` instance.
 
   Example:
 
@@ -238,6 +249,7 @@ few common ones are:
   cmd_mox.mock("tool").with_args("run").runs(handler)
   ```- `times(count)` – expect the command exactly `count` times.
 - `times_called(count)` – alias for `times` that emphasizes spy call counts.
+
 - `in_order()` – enforce strict ordering with other expectations.
 - `any_order()` – allow the expectation to be satisfied in any position.
 - `passthrough()` – for spies, run the real command while recording it.

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -19,6 +19,19 @@ Feature: CmdMox basic functionality
     When I verify the controller
     Then the journal should contain 1 invocation of "shimcmd"
 
+  Scenario: shim merges environment overrides across invocations
+    Given a CmdMox controller
+    And the command "seedshim" seeds shim env var "ALPHA"="one"
+    And the command "propagateshim" expects shim env var "ALPHA"="one" and seeds "BETA"="two"
+    And the command "inspectshim" records shim env vars "ALPHA"="one" and "BETA"="two"
+    When I replay the controller
+    And I run the shim sequence "seedshim propagateshim inspectshim"
+    Then the output should be "one+two"
+    When I verify the controller
+    Then the journal should contain 1 invocation of "seedshim"
+    And the journal should contain 1 invocation of "propagateshim"
+    And the journal should contain 1 invocation of "inspectshim"
+
   Scenario: mocked command execution
     Given a CmdMox controller
     And the command "hi" is mocked to return "hello"

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -8,6 +8,17 @@ Feature: CmdMox basic functionality
     When I verify the controller
     Then the journal should contain 1 invocation of "hi"
 
+  Scenario: shim forwards stdout stderr and exit code
+    Given a CmdMox controller
+    And the command "shimcmd" is stubbed to return stdout "shim says" stderr "warn" exit code 3
+    When I replay the controller
+    And I run the command "shimcmd" expecting failure
+    Then the output should be "shim says"
+    And the stderr should contain "warn"
+    And the exit code should be 3
+    When I verify the controller
+    Then the journal should contain 1 invocation of "shimcmd"
+
   Scenario: mocked command execution
     Given a CmdMox controller
     And the command "hi" is mocked to return "hello"

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -18,6 +18,7 @@ Feature: CmdMox basic functionality
     And the exit code should be 3
     When I verify the controller
     Then the journal should contain 1 invocation of "shimcmd"
+    And the journal entry for "shimcmd" should record stdout "shim says" stderr "warn" exit code 3
 
   Scenario: shim merges environment overrides across invocations
     Given a CmdMox controller

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -73,16 +73,16 @@ def stub_command(mox: CmdMox, cmd: str, text: str) -> None:
 
 
 @given(
-    parsers.re(
-        r'the command "(?P<cmd>[^"]+)" is stubbed to return stdout '
-        r'"(?P<stdout>[^"]*)" stderr "(?P<stderr>[^"]*)" exit code (?P<code>\d+)'
+    parsers.cfparse(
+        'the command "{cmd}" is stubbed to return stdout "{stdout}" '
+        'stderr "{stderr}" exit code {code:d}'
     )
 )
 def stub_command_full(
-    mox: CmdMox, cmd: str, stdout: str, stderr: str, code: str
+    mox: CmdMox, cmd: str, stdout: str, stderr: str, code: int
 ) -> None:
     """Configure a stubbed command with explicit streams and exit code."""
-    mox.stub(cmd).returns(stdout=stdout, stderr=stderr, exit_code=int(code))
+    mox.stub(cmd).returns(stdout=stdout, stderr=stderr, exit_code=code)
 
 
 @given(parsers.cfparse('the command "{cmd}" is mocked to return "{text}"'))

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -6,6 +6,8 @@ import contextlib
 import os
 import shlex
 import subprocess
+import sys
+import textwrap
 import typing as t
 from pathlib import Path
 
@@ -19,6 +21,7 @@ from cmd_mox.errors import (
     UnfulfilledExpectationError,
     VerificationError,
 )
+from cmd_mox.ipc import Response
 from tests.helpers.controller import (
     CommandExecution,
     JournalEntryExpectation,
@@ -182,6 +185,70 @@ def stub_with_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
     mox.stub(cmd).with_env({var: val}).runs(handler)
 
 
+@given(parsers.cfparse('the command "{cmd}" seeds shim env var "{var}"="{val}"'))
+def stub_seeds_shim_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
+    """Stub command that injects an environment override for future shims."""
+
+    def handler(_: Invocation) -> Response:
+        return Response(env={var: val})
+
+    mox.stub(cmd).runs(handler)
+
+
+@given(
+    parsers.cfparse(
+        'the command "{cmd}" expects shim env var "{expected}"="{value}" '
+        'and seeds "{var}"="{val}"'
+    )
+)
+def stub_expect_and_seed_env(
+    mox: CmdMox, cmd: str, expected: str, value: str, var: str, val: str
+) -> None:
+    """Stub that validates an inherited env var before injecting another."""
+
+    def handler(invocation: Invocation) -> Response:
+        actual = invocation.env.get(expected)
+        if actual != value:
+            msg = (
+                f"expected shim env {expected!r} to equal {value!r} but got {actual!r}"
+            )
+            raise AssertionError(msg)
+        return Response(env={var: val})
+
+    mox.stub(cmd).runs(handler)
+
+
+@given(
+    parsers.cfparse(
+        'the command "{cmd}" records shim env vars "{first}"="{first_val}" '
+        'and "{second}"="{second_val}"'
+    )
+)
+def stub_records_merged_env(
+    mox: CmdMox, cmd: str, first: str, first_val: str, second: str, second_val: str
+) -> None:
+    """Stub that asserts merged shim environment values."""
+
+    def handler(invocation: Invocation) -> tuple[str, str, int]:
+        actual_first = invocation.env.get(first)
+        actual_second = invocation.env.get(second)
+        if actual_first != first_val:
+            msg = (
+                "expected shim env "
+                f"{first!r} to equal {first_val!r} but got {actual_first!r}"
+            )
+            raise AssertionError(msg)
+        if actual_second != second_val:
+            msg = (
+                "expected shim env "
+                f"{second!r} to equal {second_val!r} but got {actual_second!r}"
+            )
+            raise AssertionError(msg)
+        return (f"{actual_first}+{actual_second}", "", 0)
+
+    mox.stub(cmd).runs(handler)
+
+
 @given(parsers.cfparse('the command "{cmd}" requires env var "{var}"="{val}"'))
 def command_requires_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
     """Attach an environment requirement to an existing double."""
@@ -241,6 +308,63 @@ def run_command(mox: CmdMox, cmd: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(  # noqa: S603
         [cmd], capture_output=True, text=True, check=True, shell=False
     )
+
+
+@when(
+    parsers.cfparse('I run the shim sequence "{sequence}"'),
+    target_fixture="result",
+)
+def run_shim_sequence(sequence: str) -> subprocess.CompletedProcess[str]:
+    """Invoke a list of shim commands within a single Python process."""
+    commands = shlex.split(sequence)
+    script = textwrap.dedent(
+        """
+        import contextlib
+        import io
+        import sys
+
+        import cmd_mox.shim as shim
+
+        def invoke(name: str) -> tuple[str, str, int]:
+            original_argv = sys.argv[:]
+            original_stdin = sys.stdin
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            sys.argv = [name]
+            sys.stdin = io.StringIO("")
+            try:
+                with contextlib.redirect_stdout(stdout):
+                    with contextlib.redirect_stderr(stderr):
+                        try:
+                            shim.main()
+                        except SystemExit as exc:
+                            code = exc.code
+                            if code is None:
+                                code = 0
+                            elif not isinstance(code, int):
+                                code = 1
+                        else:
+                            code = 0
+            finally:
+                sys.argv = original_argv
+                sys.stdin = original_stdin
+            return stdout.getvalue(), stderr.getvalue(), code
+
+        last_stdout = ""
+        last_stderr = ""
+        code = 0
+        for cmd_name in sys.argv[1:]:
+            last_stdout, last_stderr, code = invoke(cmd_name)
+            if code != 0:
+                break
+
+        sys.stdout.write(last_stdout)
+        sys.stderr.write(last_stderr)
+        sys.exit(code)
+        """
+    )
+    argv = [sys.executable, "-c", script, *commands]
+    return subprocess.run(argv, capture_output=True, text=True, check=True, shell=False)  # noqa: S603
 
 
 @when(
@@ -407,6 +531,24 @@ def check_journal_order(mox: CmdMox, commands: str) -> None:
 @scenario(str(FEATURES_DIR / "controller.feature"), "stubbed command execution")
 def test_stubbed_command_execution() -> None:
     """Stubbed command returns expected output."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
+    "shim forwards stdout stderr and exit code",
+)
+def test_shim_forwards_streams() -> None:
+    """Shim applies server provided stdout, stderr, and exit code."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
+    "shim merges environment overrides across invocations",
+)
+def test_shim_merges_env_overrides() -> None:
+    """Shim persists environment overrides between invocations."""
     pass
 
 

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -69,6 +69,18 @@ def stub_command(mox: CmdMox, cmd: str, text: str) -> None:
     mox.stub(cmd).returns(stdout=text)
 
 
+@given(
+    parsers.re(
+        r'the command "(?P<cmd>[^"]+)" is stubbed to return stdout '
+        r'"(?P<stdout>[^"]*)" stderr "(?P<stderr>[^"]*)" exit code (?P<code>\d+)'
+    )
+)
+def stub_command_full(mox: CmdMox, cmd: str, stdout: str, stderr: str, code: str) -> None:
+    """Configure a stubbed command with explicit streams and exit code."""
+
+    mox.stub(cmd).returns(stdout=stdout, stderr=stderr, exit_code=int(code))
+
+
 @given(parsers.cfparse('the command "{cmd}" is mocked to return "{text}"'))
 def mock_command(mox: CmdMox, cmd: str, text: str) -> None:
     """Configure a mocked command."""

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -75,9 +75,10 @@ def stub_command(mox: CmdMox, cmd: str, text: str) -> None:
         r'"(?P<stdout>[^"]*)" stderr "(?P<stderr>[^"]*)" exit code (?P<code>\d+)'
     )
 )
-def stub_command_full(mox: CmdMox, cmd: str, stdout: str, stderr: str, code: str) -> None:
+def stub_command_full(
+    mox: CmdMox, cmd: str, stdout: str, stderr: str, code: str
+) -> None:
     """Configure a stubbed command with explicit streams and exit code."""
-
     mox.stub(cmd).returns(stdout=stdout, stderr=stderr, exit_code=int(code))
 
 

--- a/tests/test_shim_startup.py
+++ b/tests/test_shim_startup.py
@@ -1,0 +1,58 @@
+"""Unit tests for shim startup behaviour."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from typing import Any
+
+import pytest
+
+from cmd_mox.environment import CMOX_IPC_SOCKET_ENV, CMOX_IPC_TIMEOUT_ENV
+from cmd_mox.ipc import Invocation, Response
+
+
+class _FakeInput(io.StringIO):
+    """StringIO that reports itself as a non-tty stream."""
+
+    def isatty(self) -> bool:  # pragma: no cover - trivial
+        return False
+
+
+def test_main_reports_invocation_details(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """``shim.main`` forwards invocation metadata and applies the response."""
+
+    captured: dict[str, Any] = {}
+
+    def fake_invoke(invocation: Invocation, timeout: float) -> Response:
+        captured["invocation"] = invocation
+        captured["timeout"] = timeout
+        return Response(stdout="out", stderr="err", exit_code=7, env={"EXTRA": "42"})
+
+    monkeypatch.setenv(CMOX_IPC_SOCKET_ENV, "/tmp/dummy.sock")
+    monkeypatch.delenv(CMOX_IPC_TIMEOUT_ENV, raising=False)
+    monkeypatch.setenv("SAMPLE", "value")
+    monkeypatch.delenv("EXTRA", raising=False)
+    monkeypatch.setattr(sys, "argv", ["/tmp/shims/git", "status", "--short"])
+    monkeypatch.setattr(sys, "stdin", _FakeInput("payload"))
+    monkeypatch.setattr("cmd_mox.shim.invoke_server", fake_invoke)
+
+    import cmd_mox.shim as shim
+
+    with pytest.raises(SystemExit) as excinfo:
+        shim.main()
+
+    assert excinfo.value.code == 7
+
+    out = capsys.readouterr()
+    assert out.out == "out"
+    assert out.err == "err"
+    assert os.environ["EXTRA"] == "42"
+
+    invocation = captured["invocation"]
+    assert invocation.command == "git"
+    assert invocation.args == ["status", "--short"]
+    assert invocation.stdin == "payload"
+    assert invocation.env.get("SAMPLE") == "value"
+    assert captured["timeout"] == pytest.approx(5.0)

--- a/tests/test_shim_startup.py
+++ b/tests/test_shim_startup.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import io
 import os
 import sys
-from typing import Any
+import typing as t
 
 import pytest
 
 from cmd_mox.environment import CMOX_IPC_SOCKET_ENV, CMOX_IPC_TIMEOUT_ENV
 from cmd_mox.ipc import Invocation, Response
+
+if t.TYPE_CHECKING:  # pragma: no cover - import used only for typing
+    from pathlib import Path
 
 
 class _FakeInput(io.StringIO):
@@ -20,21 +23,26 @@ class _FakeInput(io.StringIO):
         return False
 
 
-def test_main_reports_invocation_details(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+def test_main_reports_invocation_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """``shim.main`` forwards invocation metadata and applies the response."""
-
-    captured: dict[str, Any] = {}
+    captured: dict[str, t.Any] = {}
 
     def fake_invoke(invocation: Invocation, timeout: float) -> Response:
         captured["invocation"] = invocation
         captured["timeout"] = timeout
         return Response(stdout="out", stderr="err", exit_code=7, env={"EXTRA": "42"})
 
-    monkeypatch.setenv(CMOX_IPC_SOCKET_ENV, "/tmp/dummy.sock")
+    socket_path = tmp_path / "dummy.sock"
+    monkeypatch.setenv(CMOX_IPC_SOCKET_ENV, str(socket_path))
     monkeypatch.delenv(CMOX_IPC_TIMEOUT_ENV, raising=False)
     monkeypatch.setenv("SAMPLE", "value")
     monkeypatch.delenv("EXTRA", raising=False)
-    monkeypatch.setattr(sys, "argv", ["/tmp/shims/git", "status", "--short"])
+    shim_path = tmp_path / "shims" / "git"
+    monkeypatch.setattr(sys, "argv", [str(shim_path), "status", "--short"])
     monkeypatch.setattr(sys, "stdin", _FakeInput("payload"))
     monkeypatch.setattr("cmd_mox.shim.invoke_server", fake_invoke)
 
@@ -43,6 +51,7 @@ def test_main_reports_invocation_details(monkeypatch: pytest.MonkeyPatch, capsys
     with pytest.raises(SystemExit) as excinfo:
         shim.main()
 
+    assert isinstance(excinfo.value, SystemExit)
     assert excinfo.value.code == 7
 
     out = capsys.readouterr()


### PR DESCRIPTION
## Summary
- add a focused unit test that verifies the shim forwards invocation metadata and applies IPC responses
- add a behavioural scenario covering shim stdout/stderr/exit code handling and mark the roadmap entry complete
- document shim startup implementation notes in the design document

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d5988a14088322b14fbc7d4da724a4

## Summary by Sourcery

Document shim startup implementation details, complete corresponding roadmap entries, and add both BDD and unit tests to verify invocation forwarding and response handling by the shim

New Features:
- Add unit tests for shim.main to verify invocation metadata forwarding, IPC response application, and environment merging
- Add a BDD scenario in controller.feature to test shim forwarding of stdout, stderr, and exit code

Enhancements:
- Document shim startup implementation notes in the design doc
- Mark shim startup tasks as complete in the roadmap doc

Documentation:
- Add an Implementation Notes section describing shim startup logic in the design document

Tests:
- Add focused unit tests in test_shim_startup.py for shim invocation behaviour
- Add a BDD step definition for configuring stubbed commands with explicit stdout, stderr, and exit code in test_controller_bdd.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Expanded design docs clarifying shim/IPC behavior: command inference, stdin handling, environment merging, timeouts, and response propagation.
  - Updated roadmap checklist to reflect completed shim startup behaviors.
- Tests
  - Added BDD scenario verifying the shim forwards stdout, stderr, and exit code from mocked commands.
  - Introduced a richer step to stub commands with explicit stdout, stderr, and exit code.
  - Added unit tests validating shim startup: invocation metadata, I/O forwarding, exit codes, environment updates, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->