### PR TITLE
Fix node-aware messaging for teardown failures

### DIFF
--- a/cmd_mox/pytest_plugin.py
+++ b/cmd_mox/pytest_plugin.py
@@ -70,7 +70,10 @@ def _format_single_error(error: tuple[str, Exception], *, nodeid: str | None) ->
         if nodeid:
             base += f" for {nodeid}"
         return f"{base}: {type(err).__name__}: {err}"
-    return f"cmd_mox {stage} {type(err).__name__}: {err}"
+    base = f"cmd_mox {stage}"
+    if nodeid:
+        base += f" for {nodeid}"
+    return f"{base} {type(err).__name__}: {err}"
 
 
 def _format_multiple_errors(

--- a/tests/test_pytest_plugin_formatting.py
+++ b/tests/test_pytest_plugin_formatting.py
@@ -1,0 +1,27 @@
+"""Unit tests covering teardown failure formatting helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from cmd_mox.pytest_plugin import _format_single_error
+
+
+class _BoomError(Exception):
+    """Marker exception for formatting expectations."""
+
+
+@pytest.mark.parametrize(
+    ("nodeid", "expected"),
+    [
+        (None, "cmd_mox verification _BoomError: boom"),
+        ("suite::test", "cmd_mox verification for suite::test _BoomError: boom"),
+    ],
+)
+def test_format_single_error_includes_node_context(
+    nodeid: str | None, expected: str
+) -> None:
+    """Ensure verification failures preserve per-item node context."""
+    message = _format_single_error(("verification", _BoomError("boom")), nodeid=nodeid)
+
+    assert message == expected

--- a/tests/test_pytest_plugin_manager.py
+++ b/tests/test_pytest_plugin_manager.py
@@ -447,7 +447,8 @@ def test_exit_cmd_mox_fails_on_verify_error_when_body_passes(
     with pytest.raises(pytest.fail.Exception) as excinfo:
         manager.exit(body_failed=False)
 
-    assert "cmd_mox verification RuntimeError: verify boom" in str(excinfo.value)
+    expected = f"cmd_mox verification for {node.nodeid} RuntimeError: verify boom"
+    assert expected in str(excinfo.value)
     assert node.sections == [
         ("teardown", "cmd_mox verification", "RuntimeError: verify boom")
     ]


### PR DESCRIPTION
## Summary
- include the node identifier in single-stage teardown failure messages even when only verification fails
- add regression tests covering node-aware formatting for verification-only teardown failures

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d804ba5a548322bdcb1f2e02d6cf1a

## Summary by Sourcery

Ensure teardown failure messages include the node identifier when only verification fails and add regression tests for node-aware formatting

Bug Fixes:
- Include node identifier in cmd_mox teardown failure messages for verification-only failures

Tests:
- Update existing exit test to assert node-aware formatting in failure messages
- Add unit tests for _format_single_error covering both presence and absence of node context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer error messages: standardized prefixes and improved phrasing for fixture cleanup failures; messages now include per-test context when available.
- Tests
  - Added coverage validating error message formatting across stages, with and without per-item context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->