### PR TITLE
Refine lifecycle module generator formatting

### DIFF
--- a/cmd_mox/unittests/test_pytest_plugin.py
+++ b/cmd_mox/unittests/test_pytest_plugin.py
@@ -29,7 +29,7 @@ class AutoLifecycleTestCase:
     cli_args: tuple[str, ...]
     test_decorator: str
     expected_phase: PhaseLiteral
-    should_fail: bool
+    expect_auto_fail: bool
 
 
 pytest_plugins = ("cmd_mox.pytest_plugin", "pytester")
@@ -186,7 +186,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 cli_args=(),
                 test_decorator="",
                 expected_phase="RECORD",
-                should_fail=False,
+                expect_auto_fail=False,
             ),
             id="ini-disables",
         ),
@@ -197,7 +197,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 cli_args=("--no-cmd-mox-auto-lifecycle",),
                 test_decorator="",
                 expected_phase="RECORD",
-                should_fail=False,
+                expect_auto_fail=False,
             ),
             id="cli-disables",
         ),
@@ -208,7 +208,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 cli_args=(),
                 test_decorator="@pytest.mark.cmd_mox(auto_lifecycle=True)",
                 expected_phase="auto_fail",
-                should_fail=True,
+                expect_auto_fail=True,
             ),
             id="marker-overrides-ini",
         ),
@@ -219,7 +219,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 cli_args=("--no-cmd-mox-auto-lifecycle",),
                 test_decorator="@pytest.mark.cmd_mox(auto_lifecycle=True)",
                 expected_phase="REPLAY",
-                should_fail=False,
+                expect_auto_fail=False,
             ),
             id="marker-overrides-cli",
         ),
@@ -232,7 +232,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                     '@pytest.mark.parametrize("cmd_mox", [False], indirect=True)'
                 ),
                 expected_phase="RECORD",
-                should_fail=False,
+                expect_auto_fail=False,
             ),
             id="fixture-param-bool",
         ),
@@ -249,7 +249,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                     ]
                 ),
                 expected_phase="REPLAY",
-                should_fail=False,
+                expect_auto_fail=False,
             ),
             id="fixture-param-dict",
         ),
@@ -260,7 +260,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 cli_args=("--cmd-mox-auto-lifecycle",),
                 test_decorator="",
                 expected_phase="REPLAY",
-                should_fail=False,
+                expect_auto_fail=False,
             ),
             id="cli-overrides-ini",
         ),
@@ -284,7 +284,7 @@ def test_auto_lifecycle_configuration(
     module = plugin_utils.generate_lifecycle_test_module(
         test_case.test_decorator,
         test_case.expected_phase,
-        should_fail=test_case.should_fail,
+        expect_auto_fail=test_case.expect_auto_fail,
     )
     module = f"# scenario: {test_case.config_method}\n" + module
     test_file = pytester.makepyfile(**{f"test_{test_case.config_method}.py": module})
@@ -292,7 +292,7 @@ def test_auto_lifecycle_configuration(
     plugins: tuple[str, ...] = ("cmd_mox.pytest_plugin",) if test_case.cli_args else ()
     result = pytester.runpytest(*test_case.cli_args, str(test_file), plugins=plugins)
 
-    if test_case.should_fail:
+    if test_case.expect_auto_fail:
         result.assert_outcomes(passed=1, errors=1)
         result.stdout.fnmatch_lines(["*UnfulfilledExpectationError*"])
     else:

--- a/cmd_mox/unittests/test_pytest_plugin.py
+++ b/cmd_mox/unittests/test_pytest_plugin.py
@@ -29,7 +29,7 @@ class AutoLifecycleTestCase:
     cli_args: tuple[str, ...]
     test_decorator: str
     expected_phase: PhaseLiteral
-    expect_auto_fail: bool
+    expect_auto_fail: bool = False
 
 
 pytest_plugins = ("cmd_mox.pytest_plugin", "pytester")

--- a/cmd_mox/unittests/test_pytest_plugin_module_utils_unit.py
+++ b/cmd_mox/unittests/test_pytest_plugin_module_utils_unit.py
@@ -100,6 +100,23 @@ def test_generate_module_includes_decorators_with_trailing_newline() -> None:
     assert expected_block in module_text
 
 
+def test_generate_module_includes_decorators_with_leading_trailing_whitespace() -> None:
+    """Decorator formatting should be resilient to surrounding whitespace."""
+    module_text = plugin_utils.generate_lifecycle_test_module(
+        decorator="   @pytest.mark.some_marker   ",
+        expected_phase="RECORD",
+        expect_auto_fail=False,
+    )
+    assert "@pytest.mark.some_marker" in module_text
+
+    module_text = plugin_utils.generate_lifecycle_test_module(
+        decorator="\n@pytest.mark.some_marker\n",
+        expected_phase="RECORD",
+        expect_auto_fail=False,
+    )
+    assert "@pytest.mark.some_marker" in module_text
+
+
 def test_generate_module_preserves_multiline_decorators() -> None:
     """Multi-line decorators should be dedented and placed flush with the test."""
     decorator = """
@@ -134,7 +151,7 @@ def test_generate_module_preserves_multiline_decorators() -> None:
 
 def test_generate_module_rejects_unknown_phases() -> None:
     """An invalid phase should raise an explicit error for callers."""
-    with pytest.raises(ValueError, match="Unknown phase"):
+    with pytest.raises(ValueError, match=r"Unknown phase: INVALID"):
         plugin_utils.generate_lifecycle_test_module(
             decorator="",
             expected_phase=t.cast("plugin_utils.PhaseLiteral", "INVALID"),

--- a/cmd_mox/unittests/test_pytest_plugin_module_utils_unit.py
+++ b/cmd_mox/unittests/test_pytest_plugin_module_utils_unit.py
@@ -56,30 +56,28 @@ def test_generate_module_includes_expected_snippets(case: CaseType) -> None:
         assert snippet in module_text
 
 
-def test_generate_module_overrides_replay_body_when_failures_expected() -> None:
-    """REPLAY scenarios expecting failure should use the auto-fail body."""
+def _assert_auto_fail_module_properties(
+    expected_phase: plugin_utils.PhaseLiteral, *, expect_auto_fail: bool
+) -> None:
     module_text = plugin_utils.generate_lifecycle_test_module(
         decorator="",
-        expected_phase="REPLAY",
-        expect_auto_fail=True,
+        expected_phase=expected_phase,
+        expect_auto_fail=expect_auto_fail,
     )
 
     assert 'cmd_mox.mock("never-called").returns(stdout="nope")' in module_text
     assert "from cmd_mox.unittests.conftest import run_subprocess" not in module_text
     assert "def _shim_cmd_path" not in module_text
+
+
+def test_generate_module_overrides_replay_body_when_failures_expected() -> None:
+    """REPLAY scenarios expecting failure should use the auto-fail body."""
+    _assert_auto_fail_module_properties("REPLAY", expect_auto_fail=True)
 
 
 def test_generate_module_forces_auto_fail_body_without_helpers() -> None:
     """Pure auto-fail modules should omit shim helpers and include failure body."""
-    module_text = plugin_utils.generate_lifecycle_test_module(
-        decorator="",
-        expected_phase="auto_fail",
-        expect_auto_fail=False,
-    )
-
-    assert 'cmd_mox.mock("never-called").returns(stdout="nope")' in module_text
-    assert "from cmd_mox.unittests.conftest import run_subprocess" not in module_text
-    assert "def _shim_cmd_path" not in module_text
+    _assert_auto_fail_module_properties("auto_fail", expect_auto_fail=False)
 
 
 def test_generate_module_includes_decorators_with_trailing_newline() -> None:


### PR DESCRIPTION
## Summary
- refactor the lifecycle test generator to build modules from a shared body map while conditionally injecting helper imports, decorators, and rejecting unknown phases
- ensure auto-fail modules omit subprocess helpers and support multi-line decorators through explicit formatting logic
- extend the unit suite with negative phase coverage and decorator assertions to lock in the regenerated module layout

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d81ec556c88322aadbee30e293153c

## Summary by Sourcery

Refine the pytest lifecycle module generator by consolidating its templating logic, improving decorator and import handling, renaming the failure flag, and adding explicit phase validation

New Features:
- Add support for pure auto-fail modules that omit subprocess helpers via an explicit expect_auto_fail parameter
- Validate lifecycle phases by raising a ValueError for unknown phases
- Preserve and dedent multi-line decorators when injecting them into generated test modules

Enhancements:
- Refactor the lifecycle test generator to build modules from a shared body map with conditional header and shim code insertion
- Rename the failure flag from should_fail to expect_auto_fail and expand the generate_lifecycle_test_module docstring for clarity

Tests:
- Add unit tests for negative phase validation, pure auto-fail modules, multi-line decorators, and unknown phase errors
- Update existing tests to use the expect_auto_fail parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Tests now generate modules with more flexible assembly and improved decorator formatting (preserves whitespace and multi-line decorators).
- Bug Fixes
  - Validation added with a clearer error when an unknown phase is provided.
- Refactor
  - Public parameter renamed to expect_auto_fail; all call sites updated to match.
- Tests
  - Expanded coverage for auto-fail scenarios, omission of helpers, multiline decorator handling, and invalid phases.
- Documentation
  - Updated inline descriptions to reflect the renamed parameter and adjusted behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->