### PR TITLE
Add callback registration to IPCServer

### DIFF
--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -554,7 +554,9 @@ The initial implementation ships with a lightweight `IPCServer` class. It uses
 Python's `socketserver.ThreadingUnixStreamServer` to listen on a Unix domain
 socket path provided by the `EnvironmentManager`. Incoming JSON messages are
 parsed into `Invocation` objects and processed in background threads with
-reasonable timeouts (default: 5.0s). The server attaches the corresponding
+reasonable timeouts (default: 5.0s). Callers may now provide their own
+invocation and passthrough callbacks when constructing the server, removing the
+need to subclass for custom behaviour. The server attaches the corresponding
 response data (`stdout`, `stderr`, `exit_code`) to the `Invocation` before
 appending it to the journal. The server cleans up the socket on shutdown to
 prevent stale sockets from interfering with subsequent tests. The timeout is

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -274,6 +274,27 @@ few common ones are:
 Refer to the [design document](./python-native-command-mocking-design.md) for
 the full table of methods and examples.
 
+## Using the IPC server directly
+
+Most projects interact with the IPC server through `CmdMox`, but advanced
+scenarios can instantiate `cmd_mox.ipc.IPCServer` themselves. The server
+accepts optional callbacks so you can customise invocation handling without
+subclassing:
+
+```python
+from cmd_mox.ipc import IPCServer, Response
+
+def handle(invocation):
+    return Response(stdout="custom output")
+
+with IPCServer(socket_path, handler=handle):
+    ...
+```
+
+Provide `passthrough_handler=` to intercept passthrough completions in the same
+fashion. When no callbacks are supplied the server keeps its default echo
+behaviour, so existing code continues to work unchanged.
+
 ## Environment variables
 
 CmdMox exposes two environment variables to coordinate shims with the IPC

--- a/tests/test_ipc_server_callbacks.py
+++ b/tests/test_ipc_server_callbacks.py
@@ -1,0 +1,82 @@
+"""Tests covering :class:`cmd_mox.ipc.IPCServer` callback behaviour."""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from cmd_mox.environment import CMOX_IPC_SOCKET_ENV
+from cmd_mox.ipc import (
+    Invocation,
+    IPCServer,
+    PassthroughResult,
+    Response,
+    invoke_server,
+    report_passthrough_result,
+)
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.usefixtures("tmp_path")
+def test_ipcserver_invocation_handler(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IPCServer should delegate invocations to the configured handler."""
+    socket_path = tmp_path / "ipc.sock"
+    seen: list[Invocation] = []
+
+    def handler(invocation: Invocation) -> Response:
+        """Record invocations and return a distinctive response."""
+        seen.append(invocation)
+        return Response(stdout="handled", stderr="err", exit_code=2)
+
+    with IPCServer(socket_path, handler=handler):
+        monkeypatch.setenv(CMOX_IPC_SOCKET_ENV, str(socket_path))
+        invocation = Invocation(command="cmd", args=["--flag"], stdin="", env={})
+        response = invoke_server(invocation, timeout=1.0)
+
+    assert seen
+    assert seen[0].command == "cmd"
+    assert response.stdout == "handled"
+    assert response.stderr == "err"
+    assert response.exit_code == 2
+
+
+@pytest.mark.usefixtures("tmp_path")
+def test_ipcserver_passthrough_handler(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IPCServer should delegate passthrough results when a handler is provided."""
+    socket_path = tmp_path / "ipc.sock"
+    seen: list[PassthroughResult] = []
+
+    def handler(invocation: Invocation) -> Response:
+        """Return a simple echo to keep the invocation path exercised."""
+        return Response(stdout=invocation.command)
+
+    def passthrough_handler(result: PassthroughResult) -> Response:
+        """Capture passthrough results and return a custom response."""
+        seen.append(result)
+        return Response(stdout="passthrough", exit_code=5)
+
+    with IPCServer(
+        socket_path,
+        handler=handler,
+        passthrough_handler=passthrough_handler,
+    ):
+        monkeypatch.setenv(CMOX_IPC_SOCKET_ENV, str(socket_path))
+        result = PassthroughResult(
+            invocation_id="123",
+            stdout="out",
+            stderr="err",
+            exit_code=0,
+        )
+        response = report_passthrough_result(result, timeout=1.0)
+
+    assert seen
+    assert seen[0].invocation_id == "123"
+    assert response.stdout == "passthrough"
+    assert response.exit_code == 5


### PR DESCRIPTION
## Summary
- allow `IPCServer` to accept optional invocation and passthrough handlers so callers can register callbacks without subclassing (closes #10)
- document the callback-enabled API in the design and usage guides
- add coverage verifying invocation and passthrough callbacks work through the IPC server

## Testing
- make fmt
- make lint
- make typecheck
- make test


------
https://chatgpt.com/codex/tasks/task_e_68e051f9ed648322ab9c61fc6c59e0a5