### PR TITLE
Parametrize cleanup skip logic test

### DIFF
--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -355,7 +355,7 @@ def test_environment_manager_cleanup_error_handling(
     _test_environment_cleanup_error(test_case)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CleanupScenario:
     """Describe a temporary-directory cleanup scenario."""
 
@@ -393,7 +393,8 @@ def _prepare_cleanup_scenario(
             mgr.shim_dir = created
             return created, None
         case _:
-            raise AssertionError(f"Unknown scenario: {scenario.name}")
+            msg = f"Unknown scenario: {scenario.name}"
+            raise AssertionError(msg)
 
 
 @pytest.mark.parametrize(

--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -430,6 +430,7 @@ def test_cleanup_temporary_directory_skip_logic(
     match scenario.name:
         case "present":
             assert created is not None
+            # A matching shim directory should be removed by cleanup.
             assert not created.exists()
         case "missing":
             assert created is not None

--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -426,9 +426,7 @@ def test_cleanup_temporary_directory_skip_logic(
 
         if scenario.name == "replaced":
             with caplog.at_level(logging.WARNING):
-                EnvironmentManager._cleanup_temporary_directory(
-                    mgr, cleanup_errors
-                )
+                EnvironmentManager._cleanup_temporary_directory(mgr, cleanup_errors)
         else:
             EnvironmentManager._cleanup_temporary_directory(mgr, cleanup_errors)
 
@@ -450,8 +448,10 @@ def test_cleanup_temporary_directory_skip_logic(
                 assert created is not None
                 assert not created.exists()
             case "replaced":
-                assert created is not None and created.exists()
-                assert replacement is not None and replacement.exists()
+                assert created is not None
+                assert created.exists()
+                assert replacement is not None
+                assert replacement.exists()
                 assert mgr.shim_dir is None
                 assert any(
                     record.levelno == logging.WARNING
@@ -465,8 +465,8 @@ def test_cleanup_temporary_directory_skip_logic(
                 assert replacement is None
                 assert mgr.shim_dir is None
             case _:
-                raise AssertionError(f"Unhandled scenario: {scenario.name}")
-
+                msg = f"Unhandled scenario: {scenario.name}"
+                raise AssertionError(msg)
 
 
 def test_environment_manager_readonly_file_cleanup(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- collapse the skip-directory-removal scenarios into a single parametrized test using the cleanup API
- assert EnvironmentManager leaves the created directory state consistent across scenarios

closes #64

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e05280385c832296c674381c35d8b2

## Summary by Sourcery

Refactor EnvironmentManager cleanup tests to use a single parametrized pytest test that covers skip and execution logic for various directory scenarios.

Tests:
- Consolidated multiple directory cleanup skip logic tests into a single parametrized pytest test covering absence, missing, replaced, and present scenarios
- Assert correct invocation of _robust_rmtree and consistent EnvironmentManager state across scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Consolidated several discrete directory-cleanup tests into a single parameterized, scenario-driven test, expanding coverage and centralizing assertions about cleanup outcomes.
- Refactor
  - Introduced scenario-based test inputs and helper setup to simplify and clarify test scaffolding, reducing duplication and improving maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->