### PR TITLE
Export IPC timeout from EnvironmentManager

### DIFF
--- a/cmd_mox/_validators.py
+++ b/cmd_mox/_validators.py
@@ -1,0 +1,16 @@
+"""Shared validation helpers."""
+
+from __future__ import annotations
+
+import math
+
+
+def validate_positive_finite_timeout(timeout: float) -> None:
+    """Ensure *timeout* represents a usable IPC timeout value."""
+    if isinstance(timeout, bool):
+        msg = "timeout must be a real number"
+        raise TypeError(msg)
+
+    if not (timeout > 0 and math.isfinite(timeout)):
+        msg = "timeout must be > 0 and finite"
+        raise ValueError(msg)

--- a/cmd_mox/environment.py
+++ b/cmd_mox/environment.py
@@ -276,9 +276,16 @@ class EnvironmentManager:
             raise RuntimeError(msg)
 
         os.environ[CMOX_IPC_SOCKET_ENV] = str(self.socket_path)
+
         if timeout is not None:
             self.ipc_timeout = timeout
-            os.environ[CMOX_IPC_TIMEOUT_ENV] = str(timeout)
+        elif self.ipc_timeout is not None:
+            timeout = self.ipc_timeout
+        else:
+            os.environ.pop(CMOX_IPC_TIMEOUT_ENV, None)
+            return
+
+        os.environ[CMOX_IPC_TIMEOUT_ENV] = str(timeout)
 
 
 @contextlib.contextmanager

--- a/cmd_mox/environment.py
+++ b/cmd_mox/environment.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import contextlib
 import functools
 import logging
+import math
+import numbers
 import os
 import shutil
 import tempfile
@@ -278,6 +280,12 @@ class EnvironmentManager:
         os.environ[CMOX_IPC_SOCKET_ENV] = str(self.socket_path)
 
         if timeout is not None:
+            if isinstance(timeout, bool) or not isinstance(timeout, numbers.Real):
+                msg = "IPC timeout must be a positive number"
+                raise ValueError(msg)
+            if timeout <= 0 or not math.isfinite(timeout):
+                msg = "IPC timeout must be a positive number"
+                raise ValueError(msg)
             self.ipc_timeout = timeout
         elif self.ipc_timeout is not None:
             timeout = self.ipc_timeout

--- a/cmd_mox/ipc.py
+++ b/cmd_mox/ipc.py
@@ -17,6 +17,7 @@ import time
 import typing as t
 from pathlib import Path
 
+from ._validators import validate_positive_finite_timeout
 from .environment import CMOX_IPC_SOCKET_ENV, EnvironmentManager
 from .expectations import SENSITIVE_ENV_KEY_TOKENS
 
@@ -336,9 +337,7 @@ def _validate_retries(retries: int) -> None:
 
 def _validate_timeout(timeout: float) -> None:
     """Validate overall timeout value."""
-    if not (timeout > 0 and math.isfinite(timeout)):
-        msg = "timeout must be > 0 and finite"
-        raise ValueError(msg)
+    validate_positive_finite_timeout(timeout)
 
 
 def _validate_backoff(backoff: float) -> None:

--- a/cmd_mox/ipc.py
+++ b/cmd_mox/ipc.py
@@ -17,7 +17,7 @@ import time
 import typing as t
 from pathlib import Path
 
-from .environment import CMOX_IPC_SOCKET_ENV
+from .environment import CMOX_IPC_SOCKET_ENV, EnvironmentManager
 from .expectations import SENSITIVE_ENV_KEY_TOKENS
 
 # Pre-normalize tokens once for case-insensitive checks
@@ -558,6 +558,10 @@ class IPCServer:
             raise RuntimeError(msg)
 
         _cleanup_stale_socket(self.socket_path)
+
+        env_mgr = EnvironmentManager.get_active_manager()
+        if env_mgr is not None:
+            env_mgr.export_ipc_environment(timeout=self.timeout)
 
         self._server = _InnerServer(self.socket_path, self)
         self._server.timeout = self.accept_timeout

--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -49,15 +49,23 @@ def test_export_ipc_environment_sets_timeout() -> None:
         assert env.ipc_timeout == 2.5
 
 
-@pytest.mark.parametrize(
-    "invalid", [0, -1, -0.1, float("nan"), float("inf"), True, "five"]
-)
-def test_export_ipc_environment_rejects_invalid_timeout(invalid: object) -> None:
+@pytest.mark.parametrize("invalid", [0, -1, -0.1, float("nan"), float("inf")])
+def test_export_ipc_environment_rejects_invalid_timeout(invalid: float) -> None:
     """Invalid timeout overrides should raise ValueError."""
     with EnvironmentManager() as env:
-        msg = "IPC timeout must be a positive number"
+        msg = "timeout must be > 0 and finite"
         with pytest.raises(ValueError, match=msg):
-            env.export_ipc_environment(timeout=t.cast("float", invalid))
+            env.export_ipc_environment(timeout=invalid)
+
+
+@pytest.mark.parametrize(
+    "invalid_type",
+    [None, True, [], {}, "five", complex(1, 1)],
+)
+def test_export_ipc_environment_invalid_timeout_type(invalid_type: object) -> None:
+    """Invalid timeout types should propagate TypeError."""
+    with EnvironmentManager() as env, pytest.raises(TypeError):
+        env.export_ipc_environment(timeout=t.cast("float", invalid_type))
 
 
 def test_export_ipc_environment_reuses_previous_timeout() -> None:

--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -49,6 +49,18 @@ def test_export_ipc_environment_sets_timeout() -> None:
         assert env.ipc_timeout == 2.5
 
 
+def test_export_ipc_environment_clears_missing_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """export_ipc_environment removes stale timeout variables."""
+    monkeypatch.setenv(CMOX_IPC_TIMEOUT_ENV, "9.0")
+
+    with EnvironmentManager() as env:
+        # __enter__ calls export_ipc_environment() without a timeout override.
+        assert CMOX_IPC_TIMEOUT_ENV not in os.environ
+        assert env.ipc_timeout is None
+
+
 def test_export_ipc_environment_rejects_inactive_manager() -> None:
     """Calling export_ipc_environment before entering raises."""
     mgr = EnvironmentManager()

--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -15,6 +15,7 @@ import pytest
 import cmd_mox.environment as envmod
 from cmd_mox.environment import (
     CMOX_IPC_SOCKET_ENV,
+    CMOX_IPC_TIMEOUT_ENV,
     CleanupError,
     EnvironmentManager,
     RobustRmtreeError,
@@ -38,6 +39,21 @@ def test_environment_manager_modifies_and_restores() -> None:
     assert os.environ == original_env
     assert env.shim_dir is not None
     assert not env.shim_dir.exists()
+
+
+def test_export_ipc_environment_sets_timeout() -> None:
+    """export_ipc_environment exposes timeout overrides when provided."""
+    with EnvironmentManager() as env:
+        env.export_ipc_environment(timeout=2.5)
+        assert os.environ[CMOX_IPC_TIMEOUT_ENV] == "2.5"
+        assert env.ipc_timeout == 2.5
+
+
+def test_export_ipc_environment_rejects_inactive_manager() -> None:
+    """Calling export_ipc_environment before entering raises."""
+    mgr = EnvironmentManager()
+    with pytest.raises(RuntimeError, match="Cannot export IPC settings"):
+        mgr.export_ipc_environment(timeout=1.0)
 
 
 def test_environment_restores_modified_vars() -> None:

--- a/cmd_mox/unittests/test_shim_generation.py
+++ b/cmd_mox/unittests/test_shim_generation.py
@@ -9,7 +9,11 @@ import typing as t
 
 import pytest
 
-from cmd_mox.environment import CMOX_IPC_SOCKET_ENV, EnvironmentManager
+from cmd_mox.environment import (
+    CMOX_IPC_SOCKET_ENV,
+    CMOX_IPC_TIMEOUT_ENV,
+    EnvironmentManager,
+)
 from cmd_mox.ipc import IPCServer
 from cmd_mox.shimgen import (
     SHIM_PATH,
@@ -32,7 +36,8 @@ def test_create_shim_symlinks_and_execution(
         with IPCServer(env.socket_path):
             mapping = create_shim_symlinks(env.shim_dir, commands)
             assert set(mapping) == set(commands)
-            os.environ[CMOX_IPC_SOCKET_ENV] = str(env.socket_path)
+            assert os.environ[CMOX_IPC_SOCKET_ENV] == str(env.socket_path)
+            assert os.environ[CMOX_IPC_TIMEOUT_ENV] == "5.0"
             for cmd in commands:
                 link = mapping[cmd]
                 assert link.is_symlink()

--- a/cmd_mox/unittests/test_validators.py
+++ b/cmd_mox/unittests/test_validators.py
@@ -1,0 +1,33 @@
+"""Unit tests for :mod:`cmd_mox._validators`."""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from cmd_mox._validators import validate_positive_finite_timeout
+
+
+@pytest.mark.parametrize("value", [0.1, 1, 5.5])
+def test_validate_positive_finite_timeout_accepts_positive_finite(value: float) -> None:
+    """Positive finite values should pass validation."""
+    validate_positive_finite_timeout(value)
+
+
+@pytest.mark.parametrize("value", [0, -1, -0.5, float("nan"), float("inf")])
+def test_validate_positive_finite_timeout_rejects_invalid_values(value: float) -> None:
+    """Non-positive or non-finite values should raise ValueError."""
+    msg = "timeout must be > 0 and finite"
+    with pytest.raises(ValueError, match=msg):
+        validate_positive_finite_timeout(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, True, [], {}, "5", complex(1, 2)],
+)
+def test_validate_positive_finite_timeout_rejects_invalid_types(value: object) -> None:
+    """Non-real inputs should raise TypeError before numeric checks."""
+    with pytest.raises(TypeError):
+        validate_positive_finite_timeout(t.cast("float", value))

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -563,8 +563,8 @@ configurable via :data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` (seconds).
 When `IPCServer.start()` executes inside an active
 :class:`~cmd_mox.environment.EnvironmentManager`, the manager exports both the
 socket and timeout environment variables automatically. This keeps tests and
-shim workflows from having to patch :mod:`os.environ` manually when they rely on
-the higher-level context manager.
+shim workflows from having to patch :mod:`os.environ` manually when they rely
+on the higher-level context manager.
 
 To avoid races and corrupted state, `IPCServer.start()` first checks if an
 existing socket is in use before unlinking it. After launching the background

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -560,6 +560,12 @@ appending it to the journal. The server cleans up the socket on shutdown to
 prevent stale sockets from interfering with subsequent tests. The timeout is
 configurable via :data:`cmd_mox.environment.CMOX_IPC_TIMEOUT_ENV` (seconds).
 
+When `IPCServer.start()` executes inside an active
+:class:`~cmd_mox.environment.EnvironmentManager`, the manager exports both the
+socket and timeout environment variables automatically. This keeps tests and
+shim workflows from having to patch :mod:`os.environ` manually when they rely on
+the higher-level context manager.
+
 To avoid races and corrupted state, `IPCServer.start()` first checks if an
 existing socket is in use before unlinking it. After launching the background
 thread, the server polls for the socket path using an exponential backoff to

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -279,10 +279,13 @@ the full table of methods and examples.
 CmdMox exposes two environment variables to coordinate shims with the IPC
 server.
 
-- `CMOX_IPC_SOCKET` – path to the Unix domain socket used by shims. The
-  `CmdMox` fixture sets this automatically when the server starts. Shims exit
-  with an error if the variable is missing.
-- `CMOX_IPC_TIMEOUT` – communication timeout in seconds. Override this to tune
-  connection waits. When unset, the default is `5.0` seconds.
+- `CMOX_IPC_SOCKET` – path to the Unix domain socket used by shims. Entering an
+  `EnvironmentManager` sets this automatically and `IPCServer.start()` refreshes
+  it, so manual overrides are rarely needed. Shims exit with an error if the
+  variable is missing.
+- `CMOX_IPC_TIMEOUT` – communication timeout in seconds. When the IPC server
+  starts under an active `EnvironmentManager`, the configured timeout is
+  exported automatically (default `5.0`). Override this to tune connection
+  waits.
 
 Most tests should rely on the fixture to manage these variables.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -280,9 +280,9 @@ CmdMox exposes two environment variables to coordinate shims with the IPC
 server.
 
 - `CMOX_IPC_SOCKET` – path to the Unix domain socket used by shims. Entering an
-  `EnvironmentManager` sets this automatically and `IPCServer.start()` refreshes
-  it, so manual overrides are rarely needed. Shims exit with an error if the
-  variable is missing.
+  `EnvironmentManager` sets this automatically and `IPCServer.start()`
+  refreshes it, so manual overrides are rarely needed. Shims exit with an error
+  if the variable is missing.
 - `CMOX_IPC_TIMEOUT` – communication timeout in seconds. When the IPC server
   starts under an active `EnvironmentManager`, the configured timeout is
   exported automatically (default `5.0`). Override this to tune connection

--- a/tests/test_ipc_behaviour.py
+++ b/tests/test_ipc_behaviour.py
@@ -1,36 +1,69 @@
-"""Behavioural test for the shim and IPC server."""
+"""Behavioural tests for shim execution through the IPC server."""
+
+from __future__ import annotations
 
 import os
 import subprocess
-
-import pytest
+import typing as t
 
 from cmd_mox import EnvironmentManager, IPCServer, create_shim_symlinks
 from cmd_mox.environment import CMOX_IPC_SOCKET_ENV, CMOX_IPC_TIMEOUT_ENV
 from cmd_mox.unittests.test_invocation_journal import _shim_cmd_path
 
+if t.TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    import pytest
+
+
+def _run_shim(
+    env: EnvironmentManager, command: str
+) -> subprocess.CompletedProcess[str]:
+    """Execute *command* through its generated shim."""
+    shim_path = _shim_cmd_path(env, command)
+    return subprocess.run(  # noqa: S603
+        [str(shim_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _invoke_command_via_ipc(
+    env: EnvironmentManager,
+    command: str,
+    *,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Start an IPC server and run *command* through its shim."""
+    assert env.shim_dir is not None
+    socket_path = env.socket_path
+    assert socket_path is not None
+    server_timeout = timeout if timeout is not None else 5.0
+
+    with IPCServer(socket_path, timeout=server_timeout):
+        create_shim_symlinks(env.shim_dir, [command])
+
+        expected_timeout = str(server_timeout)
+        assert os.environ[CMOX_IPC_SOCKET_ENV] == str(socket_path)
+        assert os.environ[CMOX_IPC_TIMEOUT_ENV] == expected_timeout
+
+        return _run_shim(env, command)
+
 
 def test_shim_invokes_via_ipc() -> None:
     """End-to-end shim invocation using the IPC server."""
-    commands = ["foo"]
     with EnvironmentManager() as env:
-        assert env.shim_dir is not None
-        socket_path = env.socket_path
-        assert socket_path is not None
-        with IPCServer(socket_path):
-            create_shim_symlinks(env.shim_dir, commands)
+        result = _invoke_command_via_ipc(env, "foo")
+        assert result.stdout.strip() == "foo"
+        assert result.stderr == ""
+        assert result.returncode == 0
 
-            assert os.environ[CMOX_IPC_SOCKET_ENV] == str(socket_path)
-            assert os.environ[CMOX_IPC_TIMEOUT_ENV] == "5.0"
-            result = subprocess.run(  # noqa: S603
-                [str(_shim_cmd_path(env, "foo"))],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            assert result.stdout.strip() == "foo"
-            assert result.stderr == ""
-            assert result.returncode == 0
+
+def test_ipc_server_exports_custom_timeout() -> None:
+    """Starting the server with a custom timeout updates the environment."""
+    with EnvironmentManager() as env:
+        result = _invoke_command_via_ipc(env, "qux", timeout=1.25)
+        assert os.environ[CMOX_IPC_TIMEOUT_ENV] == "1.25"
+        assert result.stdout.strip() == "qux"
 
 
 def test_shim_errors_when_socket_unset() -> None:

--- a/tests/test_ipc_behaviour.py
+++ b/tests/test_ipc_behaviour.py
@@ -20,7 +20,8 @@ def test_shim_invokes_via_ipc() -> None:
         with IPCServer(socket_path):
             create_shim_symlinks(env.shim_dir, commands)
 
-            os.environ[CMOX_IPC_SOCKET_ENV] = str(socket_path)
+            assert os.environ[CMOX_IPC_SOCKET_ENV] == str(socket_path)
+            assert os.environ[CMOX_IPC_TIMEOUT_ENV] == "5.0"
             result = subprocess.run(  # noqa: S603
                 [str(_shim_cmd_path(env, "foo"))],
                 capture_output=True,


### PR DESCRIPTION
## Summary
- teach `EnvironmentManager` to expose IPC settings, including the server timeout, and have `IPCServer` refresh them when it starts
- update tests and documentation to rely on the automatic socket/timeout export instead of manual environment manipulation
- closes #11

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68e052ab95a883229359068630b98410

## Summary by Sourcery

Enable automated export of IPC timeout from the EnvironmentManager and ensure IPCServer refreshes both socket path and timeout environment variables on startup, with corresponding test and documentation updates.

New Features:
- Add export_ipc_environment in EnvironmentManager to expose IPC socket and optional timeout environment variables
- Have IPCServer.start automatically refresh IPC socket and timeout variables when running under an active EnvironmentManager

Enhancements:
- EnvironmentManager now automatically exports the IPC socket on context entry

Documentation:
- Update usage guide and design documentation to describe automatic export of CMOX_IPC_TIMEOUT_ENV

Tests:
- Add unit tests for export_ipc_environment behavior and IPCServer environment export
- Update existing tests to assert automatic setting of CMOX_IPC_TIMEOUT_ENV alongside the socket variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IPC server now automatically exports both socket path and IPC timeout when started inside a managed environment; timeouts can be set, reused, or cleared.

* **Documentation**
  * Guides updated to describe automatic IPC environment management, default timeout, and how to override it.

* **Tests**
  * Added tests covering timeout export, validation, reuse/clearing, and error cases when the environment manager is inactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->