### PR TITLE
Tighten cleanup skip tests

### DIFF
--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -337,9 +337,10 @@ def test_should_skip_directory_removal_returns_false(tmp_path: Path) -> None:
 def test_cleanup_temporary_directory_skips_when_no_directory() -> None:
     """Skip directory removal when no directory was created or it's gone."""
     mgr = EnvironmentManager()
+    cleanup_errors: list[envmod.CleanupError] = []
     with patch("cmd_mox.environment._robust_rmtree") as rm:
-        cleanup_errors: list[envmod.CleanupError] = []
-        EnvironmentManager._cleanup_temporary_directory(mgr, cleanup_errors)
+        mgr._cleanup_temporary_directory(cleanup_errors)
+        assert cleanup_errors == []
     rm.assert_not_called()
     assert mgr._created_dir is None
 
@@ -354,9 +355,10 @@ def test_cleanup_temporary_directory_skips_when_shim_dir_missing(
     mgr._created_dir = path
     mgr.shim_dir = path
     path.rmdir()
+    cleanup_errors: list[envmod.CleanupError] = []
     with patch("cmd_mox.environment._robust_rmtree") as rm:
-        cleanup_errors: list[envmod.CleanupError] = []
-        EnvironmentManager._cleanup_temporary_directory(mgr, cleanup_errors)
+        mgr._cleanup_temporary_directory(cleanup_errors)
+        assert cleanup_errors == []
     rm.assert_not_called()
     assert mgr._created_dir is None
 


### PR DESCRIPTION
## Summary
- call the bound `_cleanup_temporary_directory` helper in skip-focused tests and assert the cleanup error list stays empty
- confirm cleanup skips leave the tracked directory unset
- closes #65

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e052d773388322930ce4965dc7ebfa