### PR TITLE
Log skipped directory cleanup warnings

### DIFF
--- a/cmd_mox/environment.py
+++ b/cmd_mox/environment.py
@@ -243,6 +243,15 @@ class EnvironmentManager:
     def _cleanup_temporary_directory(self, _cleanup_errors: list[CleanupError]) -> None:
         """Remove the temporary directory created by ``__enter__``."""
         if self._should_skip_directory_removal():
+            created = self._created_dir
+            shim = self.shim_dir
+            if created is not None and shim is not None and shim != created:
+                logger.warning(
+                    "Skipping cleanup for original temporary directory %s because "
+                    "shim_dir now points to %s; leftover directories may remain.",
+                    created,
+                    shim,
+                )
             self._created_dir = None
             return
 

--- a/cmd_mox/environment.py
+++ b/cmd_mox/environment.py
@@ -252,6 +252,11 @@ class EnvironmentManager:
                     created,
                     shim,
                 )
+                # Once ownership of the shim directory diverges from the original
+                # temporary directory, the manager no longer tracks the replacement.
+                # Resetting ``shim_dir`` avoids stale references to directories we did
+                # not create and therefore should not manage.
+                self.shim_dir = None
             self._created_dir = None
             return
 

--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import stat
 import threading
@@ -22,6 +23,8 @@ from cmd_mox.environment import (
     _robust_rmtree,
     temporary_env,
 )
+
+CleanupCallable = t.Callable[[list[envmod.CleanupError]], None]
 
 if t.TYPE_CHECKING:  # pragma: no cover - imported for type hints
     from pathlib import Path
@@ -396,11 +399,8 @@ def test_cleanup_temporary_directory_skips_when_no_directory() -> None:
     mgr = EnvironmentManager()
     cleanup_errors: list[CleanupError] = []
     with patch("cmd_mox.environment._robust_rmtree") as rm:
-        cleanup_dir = t.cast(
-            "t.Callable[[list[CleanupError]], None]",
-            mgr._cleanup_temporary_directory,
-        )
-        cleanup_dir(cleanup_errors)
+        cleanup = t.cast("CleanupCallable", mgr._cleanup_temporary_directory)
+        cleanup(cleanup_errors)
         assert cleanup_errors == []
     rm.assert_not_called()
     assert mgr._created_dir is None
@@ -418,18 +418,15 @@ def test_cleanup_temporary_directory_skips_when_shim_dir_missing(
     path.rmdir()
     cleanup_errors: list[CleanupError] = []
     with patch("cmd_mox.environment._robust_rmtree") as rm:
-        cleanup_dir = t.cast(
-            "t.Callable[[list[CleanupError]], None]",
-            mgr._cleanup_temporary_directory,
-        )
-        cleanup_dir(cleanup_errors)
+        cleanup = t.cast("CleanupCallable", mgr._cleanup_temporary_directory)
+        cleanup(cleanup_errors)
         assert cleanup_errors == []
     rm.assert_not_called()
     assert mgr._created_dir is None
 
 
 def test_cleanup_temporary_directory_skips_when_shim_dir_replaced(
-    tmp_path: Path,
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Skip directory removal when ``shim_dir`` differs from ``_created_dir``."""
     mgr = EnvironmentManager()
@@ -440,17 +437,20 @@ def test_cleanup_temporary_directory_skips_when_shim_dir_replaced(
     mgr._created_dir = original
     mgr.shim_dir = replacement
     cleanup_errors: list[CleanupError] = []
-    with patch("cmd_mox.environment._robust_rmtree") as rm:
-        cleanup_dir = t.cast(
-            "t.Callable[[list[CleanupError]], None]",
-            mgr._cleanup_temporary_directory,
-        )
-        cleanup_dir(cleanup_errors)
+    with caplog.at_level(logging.WARNING), patch(
+        "cmd_mox.environment._robust_rmtree"
+    ) as rm:
+        cleanup = t.cast("CleanupCallable", mgr._cleanup_temporary_directory)
+        cleanup(cleanup_errors)
         assert cleanup_errors == []
     rm.assert_not_called()
     assert mgr._created_dir is None
     assert original.exists()
     assert replacement.exists()
+    assert any(
+        record.message.startswith("Skipping cleanup for original temporary directory")
+        for record in caplog.records
+    ), caplog.text
 
 
 def test_environment_manager_readonly_file_cleanup(tmp_path: Path) -> None:

--- a/cmd_mox/unittests/test_environment.py
+++ b/cmd_mox/unittests/test_environment.py
@@ -401,7 +401,7 @@ def test_cleanup_temporary_directory_skips_when_no_directory() -> None:
             mgr._cleanup_temporary_directory,
         )
         cleanup_dir(cleanup_errors)
-        assert not cleanup_errors
+        assert cleanup_errors == []
     rm.assert_not_called()
     assert mgr._created_dir is None
 
@@ -423,7 +423,7 @@ def test_cleanup_temporary_directory_skips_when_shim_dir_missing(
             mgr._cleanup_temporary_directory,
         )
         cleanup_dir(cleanup_errors)
-        assert not cleanup_errors
+        assert cleanup_errors == []
     rm.assert_not_called()
     assert mgr._created_dir is None
 
@@ -446,7 +446,7 @@ def test_cleanup_temporary_directory_skips_when_shim_dir_replaced(
             mgr._cleanup_temporary_directory,
         )
         cleanup_dir(cleanup_errors)
-        assert not cleanup_errors
+        assert cleanup_errors == []
     rm.assert_not_called()
     assert mgr._created_dir is None
     assert original.exists()

--- a/tests/test_ipc_behaviour.py
+++ b/tests/test_ipc_behaviour.py
@@ -6,7 +6,6 @@ import logging
 import os
 import subprocess
 import typing as t
-from pathlib import Path
 
 import pytest
 
@@ -15,6 +14,8 @@ from cmd_mox.environment import CMOX_IPC_SOCKET_ENV, CMOX_IPC_TIMEOUT_ENV
 from cmd_mox.unittests.test_invocation_journal import _shim_cmd_path
 
 if t.TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from pathlib import Path
+
     import pytest
 
 

--- a/tests/test_ipc_behaviour.py
+++ b/tests/test_ipc_behaviour.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import typing as t
+from pathlib import Path
+
+import pytest
 
 from cmd_mox import EnvironmentManager, IPCServer, create_shim_symlinks
 from cmd_mox.environment import CMOX_IPC_SOCKET_ENV, CMOX_IPC_TIMEOUT_ENV
@@ -99,3 +103,33 @@ def test_shim_errors_on_invalid_timeout(monkeypatch: pytest.MonkeyPatch) -> None
         assert result.stdout == ""
         assert "invalid timeout: 'nan'" in result.stderr
         assert result.returncode == 1
+
+
+def test_environment_manager_warns_when_shim_replaced(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Replacing ``shim_dir`` leaves both directories and emits a warning."""
+    replacement = tmp_path / "replacement"
+    replacement.mkdir()
+
+    original: Path | None = None
+    with (
+        caplog.at_level(logging.WARNING, logger="cmd_mox.environment"),
+        EnvironmentManager() as env,
+    ):
+        assert env.shim_dir is not None
+        original = env.shim_dir
+        env.shim_dir = replacement
+
+    assert original is not None
+    assert original.exists()
+    assert replacement.exists()
+    # The manager should drop ownership of the replacement directory when skipping.
+    assert env.shim_dir is None
+    assert any(
+        record.levelno == logging.WARNING
+        and record.message.startswith(
+            "Skipping cleanup for original temporary directory"
+        )
+        for record in caplog.records
+    ), caplog.text


### PR DESCRIPTION
## Summary
- add a warning when temporary directory cleanup is skipped due to a shim directory mismatch
- assert cleanup errors remain empty and use the bound helper in the skip tests
- closes #66

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e052e7d98c8322891112628ba0fd73

## Summary by Sourcery

Add a warning for skipped directory cleanup when shim_dir no longer matches the original temporary directory, and update tests to call the instance cleanup helper and assert that no cleanup errors are registered.

New Features:
- Log warning when skipping cleanup of the original temporary directory due to shim_dir mismatch

Enhancements:
- Ensure cleanup_errors list stays empty when cleanup is skipped and switch tests to use the instance method

Tests:
- Add assertions in skip tests to verify no cleanup errors are recorded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved temporary directory cleanup to avoid removing unrelated directories if the shim path was replaced.
  - Added a clear warning when cleanup is skipped due to a mismatched directory, reducing confusion and aiding troubleshooting.
  - Ensures internal tracking is reset to prevent future mis-cleanups.

- Tests
  - Added coverage to verify warnings are logged and state is reset when the shim directory is replaced.
  - Updated tests to reflect instance-based cleanup invocation and validate no residual errors after cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->