### PR TITLE
Rename auto fail phase literal to uppercase

### DIFF
--- a/cmd_mox/unittests/pytest_plugin_module_utils.py
+++ b/cmd_mox/unittests/pytest_plugin_module_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import textwrap
 import typing as t
 
-PhaseLiteral: t.TypeAlias = t.Literal["RECORD", "REPLAY", "auto_fail"]
+PhaseLiteral: t.TypeAlias = t.Literal["RECORD", "REPLAY", "AUTO_FAIL"]
 
 _UNKNOWN_PHASE_ERR = "Unknown phase: {phase}"
 
@@ -24,7 +24,7 @@ _TEST_BODIES: dict[PhaseLiteral, str] = {
         res = run_subprocess([str(_shim_cmd_path(cmd_mox, "tool"))])
         assert res.stdout.strip() == "ok"
     """,
-    "auto_fail": """
+    "AUTO_FAIL": """
         assert cmd_mox.phase is Phase.REPLAY
         cmd_mox.mock("never-called").returns(stdout="nope")
     """,
@@ -82,19 +82,19 @@ def generate_lifecycle_test_module(
     ``True`` swaps the REPLAY test body for the auto-fail variant and omits the
     subprocess shim helpers; this mirrors how the plugin behaves when a
     lifecycle override expects failure. Passing ``expected_phase`` as
-    ``"auto_fail"`` has the same effect regardless of ``expect_auto_fail``,
+    ``"AUTO_FAIL"`` has the same effect regardless of ``expect_auto_fail``,
     allowing callers to assert the pure auto-fail module layout.
     """
-    if expected_phase not in ("RECORD", "REPLAY", "auto_fail"):
+    if expected_phase not in ("RECORD", "REPLAY", "AUTO_FAIL"):
         raise ValueError(_UNKNOWN_PHASE_ERR.format(phase=expected_phase))
 
     body_key: PhaseLiteral = (
-        "auto_fail"
+        "AUTO_FAIL"
         if expected_phase == "REPLAY" and expect_auto_fail
         else expected_phase
     )
 
-    uses_subprocess_helper = body_key != "auto_fail"
+    uses_subprocess_helper = body_key != "AUTO_FAIL"
     module = _build_module_prefix(include_subprocess_helper=uses_subprocess_helper)
 
     decorator_block = _format_block(decorator) if decorator else ""

--- a/cmd_mox/unittests/test_pytest_plugin.py
+++ b/cmd_mox/unittests/test_pytest_plugin.py
@@ -207,7 +207,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 ini_setting="cmd_mox_auto_lifecycle = false",
                 cli_args=(),
                 test_decorator="@pytest.mark.cmd_mox(auto_lifecycle=True)",
-                expected_phase="auto_fail",
+                expected_phase="AUTO_FAIL",
                 expect_auto_fail=True,
             ),
             id="marker-overrides-ini",

--- a/cmd_mox/unittests/test_pytest_plugin_module_utils_unit.py
+++ b/cmd_mox/unittests/test_pytest_plugin_module_utils_unit.py
@@ -77,7 +77,7 @@ def test_generate_module_overrides_replay_body_when_failures_expected() -> None:
 
 def test_generate_module_forces_auto_fail_body_without_helpers() -> None:
     """Pure auto-fail modules should omit shim helpers and include failure body."""
-    _assert_auto_fail_module_properties("auto_fail", expect_auto_fail=False)
+    _assert_auto_fail_module_properties("AUTO_FAIL", expect_auto_fail=False)
 
 
 def test_generate_module_includes_decorators_with_trailing_newline() -> None:


### PR DESCRIPTION
## Summary
- rename the synthetic module helpers to use the AUTO_FAIL phase literal consistently
- update plugin tests to expect the AUTO_FAIL phase casing
- closes #88

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e7a53a3a308322afdce008d28643b2

## Summary by Sourcery

Use uppercase AUTO_FAIL phase literal consistently across the codebase and tests

Enhancements:
- Rename PhaseLiteral and synthetic module helpers to use uppercase AUTO_FAIL consistently

Tests:
- Update plugin and unit tests to expect the uppercase AUTO_FAIL literal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized the lifecycle constant to uppercase “AUTO_FAIL” for consistency across the tool. No functional changes expected for end-users.
- Tests
  - Updated test cases and expectations to align with the new uppercase “AUTO_FAIL” value.
  - Adjusted validation and internal mappings in tests to recognize “AUTO_FAIL” uniformly.
- Chores
  - Aligned internal utilities with the updated lifecycle value to maintain consistency and reduce ambiguity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->