### PR TITLE
Use StrEnum for phases and command kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ If you've ever mocked `curl` with `cat`, this library is your penance.
 
 For detailed instructions, see [docs/usage-guide.md](docs/usage-guide.md).
 
+## ✅ Requirements
+
+- Python 3.11 or newer (to leverage modern enum.StrEnum support)
+
 ## 🧪 Example: Testing a command-line script with CmdMox
 
 Let’s say your script under test calls `git clone` and `curl`. You want to test

--- a/cmd_mox/expectations.py
+++ b/cmd_mox/expectations.py
@@ -107,7 +107,7 @@ class Expectation:
             try:
                 if not matcher(arg):
                     return False
-            except Exception:  # noqa: BLE001, PERF203
+            except Exception:  # noqa: BLE001
                 return False
         return True
 

--- a/cmd_mox/unittests/test_pytest_plugin.py
+++ b/cmd_mox/unittests/test_pytest_plugin.py
@@ -12,7 +12,7 @@ from cmd_mox.controller import Phase
 from cmd_mox.unittests import pytest_plugin_module_utils as plugin_utils
 from cmd_mox.unittests.test_invocation_journal import _shim_cmd_path
 
-PhaseLiteral = plugin_utils.PhaseLiteral
+LifecyclePhase = plugin_utils.LifecyclePhase
 
 if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
     import subprocess
@@ -28,7 +28,7 @@ class AutoLifecycleTestCase:
     ini_setting: str | None
     cli_args: tuple[str, ...]
     test_decorator: str
-    expected_phase: PhaseLiteral
+    expected_phase: LifecyclePhase
     expect_auto_fail: bool = False
 
 
@@ -185,7 +185,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 ini_setting="cmd_mox_auto_lifecycle = false",
                 cli_args=(),
                 test_decorator="",
-                expected_phase="RECORD",
+                expected_phase=LifecyclePhase.RECORD,
                 expect_auto_fail=False,
             ),
             id="ini-disables",
@@ -196,7 +196,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 ini_setting=None,
                 cli_args=("--no-cmd-mox-auto-lifecycle",),
                 test_decorator="",
-                expected_phase="RECORD",
+                expected_phase=LifecyclePhase.RECORD,
                 expect_auto_fail=False,
             ),
             id="cli-disables",
@@ -207,7 +207,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 ini_setting="cmd_mox_auto_lifecycle = false",
                 cli_args=(),
                 test_decorator="@pytest.mark.cmd_mox(auto_lifecycle=True)",
-                expected_phase="AUTO_FAIL",
+                expected_phase=LifecyclePhase.AUTO_FAIL,
                 expect_auto_fail=True,
             ),
             id="marker-overrides-ini",
@@ -218,7 +218,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 ini_setting=None,
                 cli_args=("--no-cmd-mox-auto-lifecycle",),
                 test_decorator="@pytest.mark.cmd_mox(auto_lifecycle=True)",
-                expected_phase="REPLAY",
+                expected_phase=LifecyclePhase.REPLAY,
                 expect_auto_fail=False,
             ),
             id="marker-overrides-cli",
@@ -231,7 +231,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 test_decorator=(
                     '@pytest.mark.parametrize("cmd_mox", [False], indirect=True)'
                 ),
-                expected_phase="RECORD",
+                expected_phase=LifecyclePhase.RECORD,
                 expect_auto_fail=False,
             ),
             id="fixture-param-bool",
@@ -248,7 +248,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                         ")",
                     ]
                 ),
-                expected_phase="REPLAY",
+                expected_phase=LifecyclePhase.REPLAY,
                 expect_auto_fail=False,
             ),
             id="fixture-param-dict",
@@ -259,7 +259,7 @@ def test_teardown_error_reports_failure(pytester: pytest.Pytester) -> None:
                 ini_setting="cmd_mox_auto_lifecycle = false",
                 cli_args=("--cmd-mox-auto-lifecycle",),
                 test_decorator="",
-                expected_phase="REPLAY",
+                expected_phase=LifecyclePhase.REPLAY,
                 expect_auto_fail=False,
             ),
             id="cli-overrides-ini",

--- a/cmd_mox/unittests/test_verifier_helpers.py
+++ b/cmd_mox/unittests/test_verifier_helpers.py
@@ -7,6 +7,7 @@ import types
 import cmd_mox.verifiers as v
 from cmd_mox.expectations import Expectation
 from cmd_mox.ipc import Invocation
+from cmd_mox.test_doubles import DoubleKind
 
 
 def test_mask_env_value_redacts_sensitive_keys() -> None:
@@ -96,9 +97,9 @@ def test_format_sections_omits_empty_sections() -> None:
 def test_list_expected_commands_excludes_stubs() -> None:
     """Helper lists only commands that can raise unexpected-invocation errors."""
     doubles = {
-        "alpha": types.SimpleNamespace(kind="mock"),
-        "beta": types.SimpleNamespace(kind="stub"),
-        "gamma": types.SimpleNamespace(kind="spy"),
+        "alpha": types.SimpleNamespace(kind=DoubleKind.MOCK),
+        "beta": types.SimpleNamespace(kind=DoubleKind.STUB),
+        "gamma": types.SimpleNamespace(kind=DoubleKind.SPY),
     }
 
     assert v._list_expected_commands(doubles) == "'alpha', 'gamma'"
@@ -107,7 +108,7 @@ def test_list_expected_commands_excludes_stubs() -> None:
 def test_list_expected_commands_reports_when_only_stubs() -> None:
     """When only stubs are registered, the helper documents the omission."""
     doubles = {
-        "alpha": types.SimpleNamespace(kind="stub"),
+        "alpha": types.SimpleNamespace(kind=DoubleKind.STUB),
     }
 
     assert (

--- a/cmd_mox/verifiers.py
+++ b/cmd_mox/verifiers.py
@@ -8,6 +8,7 @@ from textwrap import indent
 
 from .errors import UnexpectedCommandError, UnfulfilledExpectationError
 from .expectations import SENSITIVE_ENV_KEY_TOKENS
+from .test_doubles import DoubleKind
 
 if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
     from .controller import CommandDouble
@@ -141,7 +142,9 @@ def _list_expected_commands(doubles: t.Mapping[str, CommandDouble]) -> str:
     Commands registered as stubs are omitted because they are not validated as
     part of unexpected-invocation checks.
     """
-    names = sorted(name for name, dbl in doubles.items() if dbl.kind != "stub")
+    names = sorted(
+        name for name, dbl in doubles.items() if dbl.kind is not DoubleKind.STUB
+    )
     return (
         "(none: stubs are excluded from expected commands)"
         if not names
@@ -173,7 +176,7 @@ class UnexpectedCommandVerifier:
             self._raise_unregistered_command_error(inv, doubles)
             return
 
-        if dbl.kind == "stub":
+        if dbl.kind is DoubleKind.STUB:
             return
 
         self._validate_expectation_match(inv, dbl, mock_counts)
@@ -189,7 +192,7 @@ class UnexpectedCommandVerifier:
             self._raise_expectation_mismatch_error(exp, inv)
             return
 
-        if dbl.kind == "mock":
+        if dbl.kind is DoubleKind.MOCK:
             self._check_mock_call_count(dbl, exp, inv, mock_counts)
 
     def _check_mock_call_count(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cmd-mox"
 version = "0.1.0"
 description = "cmd-mox package"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = { text = "ISC" }
 authors = [{ name = "Payton McIntosh", email = "pmcintosh@df12.net" }]
 dependencies = []
@@ -20,7 +20,7 @@ dev = [
 
 [tool.ruff]
 line-length = 88
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [[package]]
 name = "cmd-mox"


### PR DESCRIPTION
## Summary
- adopt enum.StrEnum for lifecycle phases and command double kinds and update controller logic
- update pytest plugin module utilities and tests to consume the new LifecyclePhase enum values
- raise the minimum supported Python version to 3.11 and document the requirement

closes #89

## Testing
- make fmt
- make lint
- make test
- make typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e7b1241ac08322a3b1270af865af46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added “Requirements” section noting Python 3.11+ is now required.

- Chores
  - Raised minimum supported Python version to 3.11 and updated tooling targets.

- Refactor
  - Replaced string-based kinds and phases with typed enums for improved clarity and reliability; no functional changes expected.

- Tests
  - Updated test suite to use the new enum-based types and adjusted expectations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->