### PR TITLE
Add environment injection to canned responses

### DIFF
--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -151,9 +151,9 @@
 
 ## **VII. Advanced Features & Edge Cases**
 
-- [ ] **Environment Variable Injection**
+- [x] **Environment Variable Injection**
 
-  - [ ] `.with_env()` applies mock-specific env before executing the handler or
+  - [x] `.with_env()` applies mock-specific env before executing the handler or
     canned response
 
 - [ ] **Concurrency Support**

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1392,7 +1392,9 @@ held by each `CommandDouble`. Builder methods such as `with_args()` and
 `with_stdin()` delegate to this object. During replay the IPC handler
 temporarily applies any `with_env()` variables using `temporary_env` so the
 mock's handler executes with the expected environment yet leaves the process
-state untouched.
+state untouched. Static responses created via `.returns()` run through the same
+path so the canned response is prepared while the environment overrides are
+active and the shim receives the merged environment payload.
 
 Verification is split into focused components. `UnexpectedCommandVerifier`
 checks that every journal entry matches a registered expectation.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -50,10 +50,9 @@ boolean instead. Advanced tests can override the detected platform by setting
 the `CMD_MOX_PLATFORM_OVERRIDE` environment variable, which is primarily useful
 for simulating Windows behaviour inside CI pipelines.
 
-The cmd-mox test suite also uses the
-`pytest.mark.requires_unix_sockets` marker for scenarios that need to bind a
-Unix domain socket. Marking these tests keeps them green on platforms (or CI
-sandboxes) that disallow Unix sockets entirely.
+The cmd-mox test suite also uses the `pytest.mark.requires_unix_sockets` marker
+for scenarios that need to bind a Unix domain socket. Marking these tests keeps
+them green on platforms (or CI sandboxes) that disallow Unix sockets entirely.
 
 ## Basic workflow
 
@@ -246,8 +245,9 @@ few common ones are:
 - `with_matching_args(*matchers)` – match arguments using comparators.
 - `with_stdin(data_or_matcher)` – expect specific standard input (`str`) or
   validate it with a predicate `Callable[[str], bool]`.
-- `with_env(mapping)` – set additional environment variables for the invocation
-  and apply them when custom handlers run.
+- `with_env(mapping)` – set additional environment variables for the invocation.
+  CmdMox injects them while handlers execute **and** when serving canned
+  responses so shim processes update their environment before producing output.
 - `returns(stdout="", stderr="", exit_code=0)` – static response using text
   values; CmdMox operates in text mode—pass `str` (bytes are not supported).
   Note: For binary payloads, prefer `passthrough()` or encode/decode at the

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -144,6 +144,17 @@ Feature: CmdMox basic functionality
     When I verify the controller
     Then the journal should contain 1 invocation of "envcmd"
 
+  Scenario: expectation env applies to canned responses
+    Given a CmdMox controller
+    And the command "seedstatic" is stubbed to return "seeded" with env var "ALPHA"="one"
+    And the command "checkstatic" records shim env var "ALPHA"="one"
+    When I replay the controller
+    And I run the shim sequence "seedstatic checkstatic"
+    Then the output should be "one"
+    When I verify the controller
+    Then the journal should contain 1 invocation of "seedstatic"
+    And the journal should contain 1 invocation of "checkstatic"
+
   Scenario: passthrough spy executes real command
     Given a CmdMox controller
     And the command "echo" is spied to passthrough

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -188,6 +188,16 @@ def stub_with_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
     mox.stub(cmd).with_env({var: val}).runs(handler)
 
 
+@given(
+    parsers.cfparse(
+        'the command "{cmd}" is stubbed to return "{text}" with env var "{var}"="{val}"'
+    )
+)
+def stub_returns_with_env(mox: CmdMox, cmd: str, text: str, var: str, val: str) -> None:
+    """Stub command returning static output while seeding shim environment."""
+    mox.stub(cmd).with_env({var: val}).returns(stdout=text)
+
+
 @given(parsers.cfparse('the command "{cmd}" seeds shim env var "{var}"="{val}"'))
 def stub_seeds_shim_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
     """Stub command that injects an environment override for future shims."""
@@ -217,6 +227,20 @@ def stub_expect_and_seed_env(
             )
             raise AssertionError(msg)
         return Response(env={var: val})
+
+    mox.stub(cmd).runs(handler)
+
+
+@given(parsers.cfparse('the command "{cmd}" records shim env var "{var}"="{val}"'))
+def stub_records_single_env(mox: CmdMox, cmd: str, var: str, val: str) -> None:
+    """Stub that asserts a single shim environment value."""
+
+    def handler(invocation: Invocation) -> tuple[str, str, int]:
+        actual = invocation.env.get(var)
+        if actual != val:
+            msg = f"expected shim env {var!r} to equal {val!r} but got {actual!r}"
+            raise AssertionError(msg)
+        return (actual or "", "", 0)
 
     mox.stub(cmd).runs(handler)
 


### PR DESCRIPTION
## Summary
- ensure `_invoke_handler` wraps static responses in the expectation environment so `.with_env()` affects canned behaviour
- cover the new behaviour with targeted unit and pytest-bdd scenarios while updating the roadmap and design notes
- document environment injection for canned responses in the usage guide

## Testing
- `make check-fmt`
- `make typecheck`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68e983ed5780832289a1209a3bd91358

## Summary by Sourcery

Ensure with_env applies to both dynamic handlers and canned responses by wrapping static responses in the expectation environment, and update tests and documentation to cover the new behavior

New Features:
- Apply with_env overrides to canned (static) responses

Enhancements:
- Unify static and dynamic handler execution by wrapping both in the expectation environment

Documentation:
- Document environment injection for canned responses in the usage guide
- Mark environment variable injection as completed in the roadmap
- Clarify design documentation to reflect unified environment handling for static responses

Tests:
- Add unit test for environment injection in canned responses
- Add pytest-bdd steps and scenarios covering environment overrides on static responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Environment variable injection now applies to canned/static responses, matching handler behavior. Shim processes receive the merged environment during replay without persisting changes afterward.
- Bug Fixes
  - Ensures environment overrides are correctly observed during canned responses and cleared after execution.
- Documentation
  - Updated guides and design docs to clarify with_env behavior for both handlers and canned responses; roadmap marked as implemented; minor formatting improvements.
- Tests
  - Added unit, BDD, and feature scenarios to verify environment application and non-leakage.
- Refactor
  - Simplified internal handler invocation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->