### PR TITLE
Ensure replay cleanup handles interrupts

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -257,10 +257,13 @@ class CmdMox:
         self._check_replay_preconditions()
         try:
             self._start_ipc_server()
-            self._phase = Phase.REPLAY
-        except Exception:  # pragma: no cover - cleanup only
+        except BaseException:
+            # ``KeyboardInterrupt`` and friends should not leak shims or PATH
+            # mutations. Clean up before re-raising so the caller sees the
+            # original failure.
             self._cleanup_after_replay_error()
             raise
+        self._phase = Phase.REPLAY
 
     def verify(self) -> None:
         """Stop the server and finalise the verification phase."""

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -161,9 +161,9 @@
   - [x] Safe parallel use: unique per-test temp dirs, socket names, no shared
     files
 
-- [ ] **Robust Cleanup**
+- [x] **Robust Cleanup**
 
-  - [ ] Always restore env and remove temp dirs/sockets, even on error/interrupt
+  - [x] Always restore env and remove temp dirs/sockets, even on error/interrupt
 
 ## **VIII. Documentation, Examples & Usability**
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -680,6 +680,15 @@ This rigorous management ensures that each test runs in a perfectly isolated
 environment and leaves no artifacts behind, a critical requirement for a
 reliable testing framework.
 
+`CmdMox` enforces this guarantee even when replay aborts unexpectedly. The
+controller treats any failure while starting the IPC server—including
+``KeyboardInterrupt`` and ``SystemExit``—as a signal to immediately invoke the
+environment manager's teardown routine before re-raising the error. Capturing
+``BaseException`` in :meth:`CmdMox.replay` ensures that shim directories,
+socket files, and `PATH` mutations are reversed deterministically so users
+never have to remember to manually call :meth:`CmdMox.__exit__` after an
+interrupt.
+
 ### 3.4 The Invocation Journal
 
 The Invocation Journal is a simple but crucial in-memory data structure within

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -151,6 +151,12 @@ with CmdMox() as mox:
     subprocess.run(["ls"], check=True)
 ```
 
+If replay aborts—whether because your code raised an exception or you hit
+Ctrl+C—`CmdMox` still tears down the environment before surfacing the original
+error. The controller catches interruptions during replay startup, stops the
+IPC server, removes the shim directory (and its socket), and restores `PATH`
+before re-raising so you never leak temporary artefacts between tests.
+
 ## Parallel execution and isolation
 
 CmdMox test runs are isolated even when executed in parallel with

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -106,6 +106,13 @@ Feature: CmdMox basic functionality
     Then the output should be "hello"
     Then the journal should contain 1 invocation of "hi"
 
+  Scenario: replay cleanup handles interrupts
+    Given a CmdMox controller
+    And replay startup is interrupted by KeyboardInterrupt
+    When I replay the controller expecting an interrupt
+    Then the shim directory should be cleaned up after interruption
+    And the IPC socket should be cleaned up after interruption
+
   Scenario: stub runs dynamic handler
     Given a CmdMox controller
     And the command "dyn" is stubbed to run a handler


### PR DESCRIPTION
## Summary
- ensure `CmdMox.replay()` cleans up the environment even when replay startup raises `BaseException`
- add regression coverage (unit + pytest-bdd scenario) that asserts environment teardown and shim removal on interrupts
- document the cleanup guarantee for users, update the roadmap, and keep behavioural docs aligned

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68f41346bcec8322943ec231f733fe1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interrupt handling: CmdMox now guarantees environment cleanup (shim directories, IPC sockets, PATH restoration) even when replay is interrupted by KeyboardInterrupt or other signals, preventing temporary artifacts from leaking between test runs.

* **Documentation**
  * Updated design and usage documentation to detail robust teardown behavior during replay interruptions and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->