### PR TITLE
Ensure CmdMox cleans environment after replay interruptions

### DIFF
--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -161,7 +161,7 @@
   - [x] Safe parallel use: unique per-test temp dirs, socket names, no shared
     files
 
-- [x] **Robust Cleanup**
+- [x] **Robust Cleanup** *(done)*
 
   - [x] Always restore env and remove temp dirs/sockets, even on error/interrupt
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -676,6 +676,16 @@ only those variables that changed and removes any that were added. This
 approach avoids disrupting other threads that might rely on the environment
 remaining mostly stable.
 
+Even the setup path defends against leaks. If anything inside `__enter__`
+fails after the shim directory is created—be it an unexpected `OSError`, a
+`KeyboardInterrupt`, or an invalid timeout override—the manager now treats the
+partial setup the same way as a regular teardown. It restores the original
+environment snapshot, clears the active-manager thread-local, deletes the
+temporary directory (and socket) it created, and logs any cleanup issues
+without obscuring the original exception. This guarantees we never leave a
+mutated `PATH` or orphaned shim directory behind, regardless of how the
+context is exited.
+
 This rigorous management ensures that each test runs in a perfectly isolated
 environment and leaves no artifacts behind, a critical requirement for a
 reliable testing framework.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -155,7 +155,9 @@ If replay aborts—whether because your code raised an exception or you hit
 Ctrl+C—`CmdMox` still tears down the environment before surfacing the original
 error. The controller catches interruptions during replay startup, stops the
 IPC server, removes the shim directory (and its socket), and restores `PATH`
-before re-raising so you never leak temporary artefacts between tests.
+before re-raising so you never leak temporary artefacts between tests. The same
+cleanup path also runs if the environment fails to enter successfully, so even
+partial setup never leaves `CMOX_IPC_SOCKET` or shim directories behind.
 
 ## Parallel execution and isolation
 

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -112,6 +112,7 @@ Feature: CmdMox basic functionality
     When I replay the controller expecting an interrupt
     Then the shim directory should be cleaned up after interruption
     And the IPC socket should be cleaned up after interruption
+    And the environment should be restored after interruption
 
   Scenario: stub runs dynamic handler
     Given a CmdMox controller


### PR DESCRIPTION
## Summary
- guard `EnvironmentManager.__enter__` so partial setup is torn down when initialisation fails
- extend unit and behavioural tests to confirm environment, sockets, and shim directories are cleaned after replay interruptions
- document the cleanup guarantees and mark the roadmap item as complete

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68f42eacab508322a7f39b02e92db91f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cleanup handling when environment setup fails or is interrupted to guarantee orphaned files, temporary directories, and environment mutations are properly reverted.

* **Documentation**
  * Updated roadmap marking "Robust Cleanup" as completed.
  * Expanded documentation to describe failure-cleanup behavior during partial environment setup scenarios.

* **Tests**
  * Added comprehensive test coverage for environment setup failures and environment restoration after unexpected interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->