### PR TITLE
Search dist tree when uploading release wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Upload wheels to release
         run: |
           set -eu
-          find dist/wheels-* -type f -name "*.whl" -print0 | \
+          find dist -type f -name "*.whl" -print0 | \
             xargs -0 -r gh release upload "${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update the release workflow to locate wheel artifacts anywhere under dist before uploading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd9732d0ac8322bd49d0a17495a108

## Summary by Sourcery

Enhancements:
- Update release workflow to search for wheel files recursively under the dist directory before uploading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to expand the search scope for wheel file uploads during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->