### PR TITLE
Configure Ruff complexity and argument limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,21 @@ select = [
     "D",
     "ANN",
 ]
-per-file-ignores = {"**/test_*.py" = ["S101"]}
+extend-select = [
+    "C90",     # Enforce cyclomatic complexity limits
+    "PLR0913", # Restrict the number of function arguments
+]
 ignore = ["D205"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/test_*.py" = ["S101", "PLR0913"]
+"tests/steps/*.py" = ["PLR0913"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 9
+
+[tool.ruff.lint.pylint]
+max-args = 4
 
 [tool.ruff.lint.flake8-import-conventions]
 # Declare the banned `from` imports.


### PR DESCRIPTION
## Summary
- enforce Ruff complexity and argument count limits with targeted exclusions for test helpers
- simplify the expectation proxy helper to satisfy the tighter complexity threshold

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_6906192919088322b92152f5adc5a59a

## Summary by Sourcery

Enforce new Ruff cyclomatic complexity and argument count rules and adjust the expectation proxy helper to comply with the tighter thresholds.

Enhancements:
- Refactor the expectation proxy helper by separating the typing protocol and runtime placeholder into distinct classes
- Rename and simplify the expectation proxy creation function to reduce code complexity

Build:
- Update pyproject.toml to extend select rules with C90 and PLR0913 lint checks

CI:
- Configure Ruff mccabe max-complexity to 9 and pylint max-args to 4

Documentation:
- Add per-file-ignores for test files to exempt S101 and PLR0913 lint rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal test doubles implementation with enhanced type-checking separation and runtime behavior handling.

* **Chores**
  * Updated linting configuration with new complexity and argument count constraints for stricter code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->