### PR TITLE
Add replay() to CommandDouble with eager loading and session accessors

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,5 +1,9 @@
 {
-  "ignores": [".rules/**", "docs/python-native-command-mocking-design.md"],
+  "ignores": [
+    ".rules/**",
+    ".uv-cache/**",
+    "docs/python-native-command-mocking-design.md"
+  ],
   "config": {
     "MD013": false
   }

--- a/cmd_mox/comparators.py
+++ b/cmd_mox/comparators.py
@@ -89,7 +89,8 @@ class StartsWith(_ReprMixin):
 class Predicate(_ReprMixin):
     """Use a custom ``func`` to determine a match."""
 
-    def __init__(self, func: t.Callable[[str], bool]) -> None:
+    def __init__(self, func: t.Callable[[str], t.Any]) -> None:
+        """Create a predicate that evaluates ``func`` and coerces to bool."""
         self.func = func
 
     def __call__(self, value: str) -> bool:

--- a/cmd_mox/expectations.py
+++ b/cmd_mox/expectations.py
@@ -53,7 +53,7 @@ class Expectation:
     name: str
     args: list[str] | None = None
     match_args: list[t.Callable[[str], bool]] | None = None
-    stdin: str | t.Callable[[str], bool] | None = None
+    stdin: str | t.Callable[[str], t.Any] | None = None
     env: dict[str, str] = dc.field(default_factory=dict)
     count: int = 1
     ordered: bool = False

--- a/cmd_mox/expectations.py
+++ b/cmd_mox/expectations.py
@@ -68,8 +68,11 @@ class Expectation:
         self.match_args = list(matchers)
         return self
 
-    def with_stdin(self, data: str | t.Callable[[str], bool]) -> Expectation:
-        """Expect ``stdin`` to equal ``data`` or satisfy a predicate."""
+    def with_stdin(self, data: str | t.Callable[[str], t.Any]) -> Expectation:
+        """Expect ``stdin`` to equal ``data`` or satisfy a predicate.
+
+        The predicate's return value will be coerced to bool.
+        """
         self.stdin = data
         return self
 

--- a/cmd_mox/test_doubles.py
+++ b/cmd_mox/test_doubles.py
@@ -16,6 +16,7 @@ if t.TYPE_CHECKING:  # pragma: no cover - typing-only import
 if t.TYPE_CHECKING:  # pragma: no cover - used only for typing
     from pathlib import Path
 
+    from .record.replay import ReplaySession
     from .record.scrubber import Scrubber
     from .record.session import RecordingSession
 
@@ -76,6 +77,7 @@ class CommandDouble(_ExpectationProxy):  # type: ignore[misc, ty:unsupported-bas
 
     __slots__ = (
         "_recording_session",
+        "_replay_session",
         "controller",
         "expectation",
         "handler",
@@ -95,6 +97,7 @@ class CommandDouble(_ExpectationProxy):  # type: ignore[misc, ty:unsupported-bas
         self.invocations: list[Invocation] = []
         self.passthrough_mode = False
         self.expectation = Expectation(name)
+        self._replay_session: ReplaySession | None = None
         self._recording_session: RecordingSession | None = None
 
     def returns(self, stdout: str = "", stderr: str = "", exit_code: int = 0) -> Self:
@@ -230,6 +233,35 @@ class CommandDouble(_ExpectationProxy):  # type: ignore[misc, ty:unsupported-bas
         self._recording_session.start()
         return self
 
+    def replay(
+        self,
+        fixture_path: str | Path,
+        *,
+        strict: bool = True,
+    ) -> Self:
+        """Attach and eagerly load a replay fixture for a spy."""
+        if self.kind is not DoubleKind.SPY:
+            msg = "replay() is only valid for spies"
+            raise ValueError(msg)
+        if self.passthrough_mode:
+            msg = "replay() cannot be combined with passthrough()"
+            raise ValueError(msg)
+        if self._replay_session is not None:
+            msg = "replay() already called; finalize the existing session first"
+            raise RuntimeError(msg)
+
+        from pathlib import Path as _Path
+
+        from .record.replay import ReplaySession as _ReplaySession
+
+        replay_session = _ReplaySession(
+            fixture_path=_Path(fixture_path),
+            strict_matching=strict,
+        )
+        replay_session.load()
+        self._replay_session = replay_session
+        return self
+
     @property
     def has_recording_session(self) -> bool:
         """Return ``True`` if a recording session is attached."""
@@ -239,6 +271,16 @@ class CommandDouble(_ExpectationProxy):  # type: ignore[misc, ty:unsupported-bas
     def recording_session(self) -> RecordingSession | None:
         """Return the attached recording session, or ``None``."""
         return self._recording_session
+
+    @property
+    def has_replay_session(self) -> bool:
+        """Return ``True`` if a replay session is attached."""
+        return self._replay_session is not None
+
+    @property
+    def replay_session(self) -> ReplaySession | None:
+        """Return the attached replay session, or ``None``."""
+        return self._replay_session
 
     # ------------------------------------------------------------------
     # Matching helpers

--- a/cmd_mox/test_doubles.py
+++ b/cmd_mox/test_doubles.py
@@ -189,6 +189,9 @@ class CommandDouble(_ExpectationProxy):  # type: ignore[misc, ty:unsupported-bas
         if self.kind is not DoubleKind.SPY:
             msg = "passthrough() is only valid for spies"
             raise ValueError(msg)
+        if self._replay_session is not None:
+            msg = "passthrough() cannot be combined with replay()"
+            raise ValueError(msg)
         self.passthrough_mode = True
         return self
 

--- a/cmd_mox/unittests/test_command_double_replay.py
+++ b/cmd_mox/unittests/test_command_double_replay.py
@@ -55,13 +55,18 @@ class TestReplayFluentAPI:
 
         assert result is spy
 
-    @pytest.mark.parametrize(("strict", "expected"), [(True, True), (False, False)])
+    @pytest.mark.parametrize(
+        "mode_case",
+        [(True, True), (False, False)],
+        ids=["strict", "fuzzy"],
+    )
     def test_replay_configures_matching_mode(
-        self, tmp_path: Path, strict: bool, expected: bool
+        self, tmp_path: Path, mode_case: tuple[bool, bool]
     ) -> None:
         """replay() configures strict or fuzzy matching."""
         mox = CmdMox()
         fixture_path = _write_fixture(tmp_path)
+        strict, expected = mode_case
 
         spy = mox.spy("git").replay(fixture_path, strict=strict)
 

--- a/cmd_mox/unittests/test_command_double_replay.py
+++ b/cmd_mox/unittests/test_command_double_replay.py
@@ -68,8 +68,9 @@ class TestReplayFluentAPI:
 
         session = spy.replay_session
         assert session is not None
-        assert session.match(
-            Invocation(command="git", args=["status"], stdin="", env={})
+        assert (
+            session.match(Invocation(command="git", args=["status"], stdin="", env={}))
+            is not None
         )
 
     def test_replay_raises_for_missing_fixture(self, tmp_path: Path) -> None:

--- a/cmd_mox/unittests/test_command_double_replay.py
+++ b/cmd_mox/unittests/test_command_double_replay.py
@@ -55,29 +55,19 @@ class TestReplayFluentAPI:
 
         assert result is spy
 
-    def test_replay_defaults_to_strict_matching(self, tmp_path: Path) -> None:
-        """replay() enables strict matching by default."""
-        mox = CmdMox()
-        fixture_path = _write_fixture(tmp_path)
-
-        spy = mox.spy("git").replay(fixture_path)
-
-        session = spy.replay_session
-        assert session is not None
-        assert session.strict_matching is True
-
-    def test_replay_accepts_strict_false_for_fuzzy_matching(
-        self, tmp_path: Path
+    @pytest.mark.parametrize(("strict", "expected"), [(True, True), (False, False)])
+    def test_replay_configures_matching_mode(
+        self, tmp_path: Path, strict: bool, expected: bool
     ) -> None:
-        """replay(strict=False) configures fuzzy matching."""
+        """replay() configures strict or fuzzy matching."""
         mox = CmdMox()
         fixture_path = _write_fixture(tmp_path)
 
-        spy = mox.spy("git").replay(fixture_path, strict=False)
+        spy = mox.spy("git").replay(fixture_path, strict=strict)
 
         session = spy.replay_session
         assert session is not None
-        assert session.strict_matching is False
+        assert session.strict_matching is expected
 
     def test_replay_accepts_string_path(self, tmp_path: Path) -> None:
         """replay() accepts a string path and converts it to Path."""

--- a/cmd_mox/unittests/test_command_double_replay.py
+++ b/cmd_mox/unittests/test_command_double_replay.py
@@ -9,37 +9,11 @@ import pytest
 
 from cmd_mox.controller import CmdMox
 from cmd_mox.ipc import Invocation
-from cmd_mox.record.fixture import FixtureFile, FixtureMetadata, RecordedInvocation
 from cmd_mox.record.replay import ReplaySession
+from tests.helpers.fixtures import write_minimal_replay_fixture
 
 if t.TYPE_CHECKING:
     from pathlib import Path
-
-
-def _write_fixture(tmp_path: Path, filename: str = "fixture.json") -> Path:
-    """Write a minimal valid replay fixture and return its path."""
-    fixture = FixtureFile(
-        version=FixtureFile.SCHEMA_VERSION,
-        metadata=FixtureMetadata.create(),
-        recordings=[
-            RecordedInvocation(
-                sequence=0,
-                command="git",
-                args=["status"],
-                stdin="",
-                env_subset={},
-                stdout="ok\n",
-                stderr="",
-                exit_code=0,
-                timestamp="2026-01-15T10:30:00+00:00",
-                duration_ms=0,
-            )
-        ],
-        scrubbing_rules=[],
-    )
-    path = tmp_path / filename
-    fixture.save(path)
-    return path
 
 
 class TestReplayFluentAPI:
@@ -48,7 +22,7 @@ class TestReplayFluentAPI:
     def test_replay_returns_self(self, tmp_path: Path) -> None:
         """replay() returns the same CommandDouble instance for chaining."""
         mox = CmdMox()
-        fixture_path = _write_fixture(tmp_path)
+        fixture_path = write_minimal_replay_fixture(tmp_path)
 
         spy = mox.spy("git")
         result = spy.replay(fixture_path)
@@ -65,7 +39,7 @@ class TestReplayFluentAPI:
     ) -> None:
         """replay() configures strict or fuzzy matching."""
         mox = CmdMox()
-        fixture_path = _write_fixture(tmp_path)
+        fixture_path = write_minimal_replay_fixture(tmp_path)
         strict, expected = mode_case
 
         spy = mox.spy("git").replay(fixture_path, strict=strict)
@@ -77,7 +51,7 @@ class TestReplayFluentAPI:
     def test_replay_accepts_string_path(self, tmp_path: Path) -> None:
         """replay() accepts a string path and converts it to Path."""
         mox = CmdMox()
-        fixture_path = _write_fixture(tmp_path)
+        fixture_path = write_minimal_replay_fixture(tmp_path)
 
         spy = mox.spy("git").replay(str(fixture_path))
 
@@ -88,7 +62,7 @@ class TestReplayFluentAPI:
     def test_replay_loads_session_immediately(self, tmp_path: Path) -> None:
         """replay() loads the fixture eagerly during configuration."""
         mox = CmdMox()
-        fixture_path = _write_fixture(tmp_path)
+        fixture_path = write_minimal_replay_fixture(tmp_path)
 
         spy = mox.spy("git").replay(fixture_path)
 
@@ -131,16 +105,24 @@ class TestReplayFluentAPI:
     def test_replay_rejects_passthrough_combination(self, tmp_path: Path) -> None:
         """replay() rejects passthrough because the behaviours conflict."""
         mox = CmdMox()
-        fixture_path = _write_fixture(tmp_path)
+        fixture_path = write_minimal_replay_fixture(tmp_path)
 
         with pytest.raises(ValueError, match=r"replay.*passthrough"):
             mox.spy("git").passthrough().replay(fixture_path)
 
+    def test_passthrough_rejects_replay_combination(self, tmp_path: Path) -> None:
+        """passthrough() rejects replay because the behaviours conflict."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+
+        with pytest.raises(ValueError, match=r"passthrough.*replay"):
+            mox.spy("git").replay(fixture_path).passthrough()
+
     def test_replay_raises_when_session_already_attached(self, tmp_path: Path) -> None:
         """replay() rejects attaching a second replay session."""
         mox = CmdMox()
-        first = _write_fixture(tmp_path, "first.json")
-        second = _write_fixture(tmp_path, "second.json")
+        first = write_minimal_replay_fixture(tmp_path, "first.json")
+        second = write_minimal_replay_fixture(tmp_path, "second.json")
 
         spy = mox.spy("git").replay(first)
 
@@ -151,7 +133,7 @@ class TestReplayFluentAPI:
     def test_replay_is_only_valid_for_spies(self, kind: str, tmp_path: Path) -> None:
         """replay() is limited to spies until controller integration lands."""
         mox = CmdMox()
-        fixture_path = _write_fixture(tmp_path)
+        fixture_path = write_minimal_replay_fixture(tmp_path)
 
         with pytest.raises(ValueError, match=r"replay.*only valid for spies"):
             getattr(mox, kind)("git").replay(fixture_path)
@@ -169,7 +151,7 @@ class TestHasReplaySession:
     def test_true_after_replay(self, tmp_path: Path) -> None:
         """has_replay_session is True after replay() is called."""
         mox = CmdMox()
-        fixture_path = _write_fixture(tmp_path)
+        fixture_path = write_minimal_replay_fixture(tmp_path)
 
         assert mox.spy("git").replay(fixture_path).has_replay_session is True
 
@@ -186,7 +168,7 @@ class TestReplaySessionProperty:
     def test_returns_session_after_replay(self, tmp_path: Path) -> None:
         """replay_session returns the ReplaySession after replay()."""
         mox = CmdMox()
-        fixture_path = _write_fixture(tmp_path)
+        fixture_path = write_minimal_replay_fixture(tmp_path)
 
         session = mox.spy("git").replay(fixture_path).replay_session
 

--- a/cmd_mox/unittests/test_command_double_replay.py
+++ b/cmd_mox/unittests/test_command_double_replay.py
@@ -1,0 +1,199 @@
+"""Unit tests for CommandDouble.replay() fluent API."""
+
+from __future__ import annotations
+
+import json
+import typing as t
+
+import pytest
+
+from cmd_mox.controller import CmdMox
+from cmd_mox.ipc import Invocation
+from cmd_mox.record.fixture import FixtureFile, FixtureMetadata, RecordedInvocation
+from cmd_mox.record.replay import ReplaySession
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_fixture(tmp_path: Path, filename: str = "fixture.json") -> Path:
+    """Write a minimal valid replay fixture and return its path."""
+    fixture = FixtureFile(
+        version=FixtureFile.SCHEMA_VERSION,
+        metadata=FixtureMetadata.create(),
+        recordings=[
+            RecordedInvocation(
+                sequence=0,
+                command="git",
+                args=["status"],
+                stdin="",
+                env_subset={},
+                stdout="ok\n",
+                stderr="",
+                exit_code=0,
+                timestamp="2026-01-15T10:30:00+00:00",
+                duration_ms=0,
+            )
+        ],
+        scrubbing_rules=[],
+    )
+    path = tmp_path / filename
+    fixture.save(path)
+    return path
+
+
+class TestReplayFluentAPI:
+    """Tests for the CommandDouble.replay() fluent method."""
+
+    def test_replay_returns_self(self, tmp_path: Path) -> None:
+        """replay() returns the same CommandDouble instance for chaining."""
+        mox = CmdMox()
+        fixture_path = _write_fixture(tmp_path)
+
+        spy = mox.spy("git")
+        result = spy.replay(fixture_path)
+
+        assert result is spy
+
+    def test_replay_defaults_to_strict_matching(self, tmp_path: Path) -> None:
+        """replay() enables strict matching by default."""
+        mox = CmdMox()
+        fixture_path = _write_fixture(tmp_path)
+
+        spy = mox.spy("git").replay(fixture_path)
+
+        session = spy.replay_session
+        assert session is not None
+        assert session.strict_matching is True
+
+    def test_replay_accepts_strict_false_for_fuzzy_matching(
+        self, tmp_path: Path
+    ) -> None:
+        """replay(strict=False) configures fuzzy matching."""
+        mox = CmdMox()
+        fixture_path = _write_fixture(tmp_path)
+
+        spy = mox.spy("git").replay(fixture_path, strict=False)
+
+        session = spy.replay_session
+        assert session is not None
+        assert session.strict_matching is False
+
+    def test_replay_accepts_string_path(self, tmp_path: Path) -> None:
+        """replay() accepts a string path and converts it to Path."""
+        mox = CmdMox()
+        fixture_path = _write_fixture(tmp_path)
+
+        spy = mox.spy("git").replay(str(fixture_path))
+
+        session = spy.replay_session
+        assert session is not None
+        assert session.fixture_path == fixture_path
+
+    def test_replay_loads_session_immediately(self, tmp_path: Path) -> None:
+        """replay() loads the fixture eagerly during configuration."""
+        mox = CmdMox()
+        fixture_path = _write_fixture(tmp_path)
+
+        spy = mox.spy("git").replay(fixture_path)
+
+        session = spy.replay_session
+        assert session is not None
+        assert session.match(
+            Invocation(command="git", args=["status"], stdin="", env={})
+        )
+
+    def test_replay_raises_for_missing_fixture(self, tmp_path: Path) -> None:
+        """replay() surfaces missing files during setup."""
+        mox = CmdMox()
+
+        with pytest.raises(FileNotFoundError):
+            mox.spy("git").replay(tmp_path / "missing.json")
+
+    def test_replay_raises_for_invalid_fixture_data(self, tmp_path: Path) -> None:
+        """replay() surfaces fixture schema errors during setup."""
+        bad_fixture = tmp_path / "fixture.json"
+        bad_fixture.write_text(
+            json.dumps(
+                {
+                    "version": "99.0",
+                    "metadata": {
+                        "created_at": "2026-01-15T10:30:00Z",
+                        "cmdmox_version": "0.1.0",
+                        "platform": "linux",
+                        "python_version": "3.13.0",
+                    },
+                    "recordings": [],
+                    "scrubbing_rules": [],
+                }
+            )
+        )
+        mox = CmdMox()
+
+        with pytest.raises(ValueError, match=r"99\.0"):
+            mox.spy("git").replay(bad_fixture)
+
+    def test_replay_rejects_passthrough_combination(self, tmp_path: Path) -> None:
+        """replay() rejects passthrough because the behaviours conflict."""
+        mox = CmdMox()
+        fixture_path = _write_fixture(tmp_path)
+
+        with pytest.raises(ValueError, match=r"replay.*passthrough"):
+            mox.spy("git").passthrough().replay(fixture_path)
+
+    def test_replay_raises_when_session_already_attached(self, tmp_path: Path) -> None:
+        """replay() rejects attaching a second replay session."""
+        mox = CmdMox()
+        first = _write_fixture(tmp_path, "first.json")
+        second = _write_fixture(tmp_path, "second.json")
+
+        spy = mox.spy("git").replay(first)
+
+        with pytest.raises(RuntimeError, match="already"):
+            spy.replay(second)
+
+    @pytest.mark.parametrize("kind", ["stub", "mock"])
+    def test_replay_is_only_valid_for_spies(self, kind: str, tmp_path: Path) -> None:
+        """replay() is limited to spies until controller integration lands."""
+        mox = CmdMox()
+        fixture_path = _write_fixture(tmp_path)
+
+        with pytest.raises(ValueError, match=r"replay.*only valid for spies"):
+            getattr(mox, kind)("git").replay(fixture_path)
+
+
+class TestHasReplaySession:
+    """Tests for the has_replay_session property."""
+
+    def test_false_by_default(self) -> None:
+        """has_replay_session is False when no session is attached."""
+        mox = CmdMox()
+
+        assert mox.spy("git").has_replay_session is False
+
+    def test_true_after_replay(self, tmp_path: Path) -> None:
+        """has_replay_session is True after replay() is called."""
+        mox = CmdMox()
+        fixture_path = _write_fixture(tmp_path)
+
+        assert mox.spy("git").replay(fixture_path).has_replay_session is True
+
+
+class TestReplaySessionProperty:
+    """Tests for the replay_session read-only property."""
+
+    def test_none_by_default(self) -> None:
+        """replay_session is None when no session is attached."""
+        mox = CmdMox()
+
+        assert mox.spy("git").replay_session is None
+
+    def test_returns_session_after_replay(self, tmp_path: Path) -> None:
+        """replay_session returns the ReplaySession after replay()."""
+        mox = CmdMox()
+        fixture_path = _write_fixture(tmp_path)
+
+        session = mox.spy("git").replay(fixture_path).replay_session
+
+        assert session is not None
+        assert isinstance(session, ReplaySession)

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -250,7 +250,7 @@ supports deterministic replay without external dependencies. See
   consumed-record tracking, and strict and fuzzy modes.
 - [x] 12.2.2. Implement `InvocationMatcher` with strict matching, fuzzy
   matching, and best-fit score selection.
-- [ ] 12.2.3. Add `.replay()` to `CommandDouble`, including passthrough
+- [x] 12.2.3. Add `.replay()` to `CommandDouble`, including passthrough
   incompatibility validation and strict-mode option.
 - [ ] 12.2.4. Integrate replay into `CmdMox._make_response()` and raise
   `UnexpectedCommandError` for unmatched strict replay invocations.

--- a/docs/execplans/12-2-3-add-replay-to-command-double.md
+++ b/docs/execplans/12-2-3-add-replay-to-command-double.md
@@ -1,0 +1,413 @@
+# Add `.replay()` to `CommandDouble`
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap item `12.2.3` adds the fluent `.replay()` API to
+`cmd_mox.test_doubles.CommandDouble` so recorded fixture files can be attached
+directly to a double during test setup. After this change, a test author can
+write `cmd_mox.spy("git").replay("fixtures/git.json")` and know that the
+fixture is loaded immediately, the strict-versus-fuzzy matching mode is chosen
+explicitly, and invalid configurations such as combining replay with
+passthrough are rejected at configuration time rather than later during command
+execution.
+
+This work is intentionally narrower than roadmap items `12.2.4` and `12.2.5`.
+`12.2.3` establishes the public fluent API and stores a ready-to-use
+`ReplaySession` on the double. It does not yet teach `CmdMox._make_response()`
+to consume replay sessions, and it does not yet extend `CmdMox.verify()` to
+report unconsumed recordings. Those behaviours remain separate follow-on tasks
+and must not be folded into this change unless the user explicitly expands the
+scope.
+
+Observable success after implementation:
+
+1. `CommandDouble` exposes `.replay(fixture_path, *, strict=True) -> Self`.
+2. Calling `.replay()` creates and loads a `ReplaySession` immediately, so
+   missing files and schema errors surface during test setup.
+3. `.replay()` rejects invalid combinations, at minimum replay plus
+   passthrough, with clear error messages.
+4. Unit tests written with `pytest` fail before implementation and pass after
+   it, covering strict defaults, explicit fuzzy mode, validation, duplicate
+   attachment protection, and path handling.
+5. Behavioural tests written with `pytest-bdd` cover the consumer-visible
+   fluent API contract for replay-enabled doubles.
+6. `docs/python-native-command-mocking-design.md` records the final API
+   decisions, `docs/usage-guide.md` explains the consumer-facing behaviour, and
+   `docs/cmd-mox-roadmap.md` marks `12.2.3` done.
+7. The full quality gates pass:
+
+```bash
+set -o pipefail
+make markdownlint 2>&1 | tee /tmp/12-2-3-markdownlint.log
+```
+
+```bash
+set -o pipefail
+make nixie 2>&1 | tee /tmp/12-2-3-nixie.log
+```
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/12-2-3-check-fmt.log
+```
+
+```bash
+set -o pipefail
+make typecheck 2>&1 | tee /tmp/12-2-3-typecheck.log
+```
+
+```bash
+set -o pipefail
+make lint 2>&1 | tee /tmp/12-2-3-lint.log
+```
+
+```bash
+set -o pipefail
+make test 2>&1 | tee /tmp/12-2-3-test.log
+```
+
+## Repository orientation
+
+The current implementation already has the replay infrastructure needed by this
+API:
+
+- `cmd_mox/record/replay.py` contains `ReplaySession`.
+- `cmd_mox/record/matching.py` contains `InvocationMatcher`.
+- `cmd_mox/record/__init__.py` already exports `ReplaySession`.
+
+The missing piece is the fluent attachment point on the double:
+
+- `cmd_mox/test_doubles.py` currently implements `.passthrough()` and
+  `.record()`, carries `_recording_session` in `__slots__`, and exposes
+  `has_recording_session` / `recording_session`.
+- `cmd_mox/controller.py` already finalises recording sessions, but it does not
+  yet consult replay sessions in `_make_response()` or verify replay
+  consumption. That omission is expected at this roadmap stage.
+- Existing tests for the neighbouring feature live in
+  `cmd_mox/unittests/test_command_double_record.py`,
+  `features/command_double_record.feature`,
+  `tests/steps/command_double_record.py`, and
+  `tests/test_command_double_record_bdd.py`. This task should mirror that
+  structure for replay.
+
+The implementation should therefore stay centred on `cmd_mox/test_doubles.py`
+plus replay-specific tests and documentation.
+
+## Constraints
+
+- Follow the repository test-driven development workflow from `AGENTS.md`:
+  write or update tests first, run them to confirm failure, then implement the
+  code, then rerun the focused tests and full quality gates.
+- Keep roadmap boundaries intact. `12.2.3` adds the fluent API only. Do not
+  modify `CmdMox._make_response()` or `CmdMox.verify()` as part of this item.
+- Do not change the public `ReplaySession` API introduced by `12.2.1` and
+  refined by `12.2.2`.
+- Do not change fixture schema semantics, `RecordedInvocation`, or matching
+  rules. Strict versus fuzzy behaviour already belongs to `ReplaySession` and
+  `InvocationMatcher`.
+- Do not add new dependencies.
+- Preserve existing public APIs unless this plan explicitly adds replay-related
+  surface area. Existing `.record()` behaviour must remain unchanged.
+- Keep unit tests under `cmd_mox/unittests/` and behavioural tests under
+  `features/`, `tests/steps/`, and `tests/test_*_bdd.py`.
+- Documentation changes must follow the existing style in `docs/`, including
+  sentence-case headings and British English spellings where the surrounding
+  text already uses them.
+- Quality gates for completion are `make markdownlint`, `make nixie`,
+  `make check-fmt`, `make typecheck`, `make lint`, and `make test`.
+
+## Tolerances
+
+- Scope: stop and escalate if `12.2.3` appears to require touching
+  `cmd_mox/controller.py` beyond comments or imports. That is the clearest sign
+  the work is spilling into `12.2.4` or `12.2.5`.
+- API: stop and escalate if the change seems to require altering the signature
+  of `ReplaySession.__init__()`, `ReplaySession.load()`, or existing
+  `CommandDouble.record()`.
+- Semantics: stop and escalate if replay must be supported on stubs or mocks to
+  satisfy existing tests or documentation. This plan proceeds with the
+  conservative assumption that replay is a spy-oriented fluent API, mirroring
+  the design document examples.
+- Testing: stop and escalate if behavioural coverage cannot be written against
+  observable public behaviour without prematurely implementing controller
+  replay integration.
+- Quality gates: if any required gate still fails after 3 focused fix attempts,
+  capture the failing command and log path in `Surprises & Discoveries` and
+  pause for guidance.
+
+## Risks
+
+- Risk: the design documents show `spy("git").replay(...)`, but they do not
+  state as plainly as they could whether replay is legal on stubs and mocks.
+  Severity: medium. Likelihood: medium. Mitigation: implement the conservative
+  spy-only interpretation, then record that decision explicitly in the design
+  doc when the code lands.
+- Risk: adding `.replay()` without controller integration can produce tests
+  that look superficially incomplete if they expect end-to-end command replay.
+  Severity: medium. Likelihood: high. Mitigation: keep the new tests focused on
+  the fluent API contract and make the roadmap boundary explicit in docs and
+  plan text.
+- Risk: immediate fixture loading means `.replay()` will surface file and
+  schema errors earlier than `.record()`. Severity: low. Likelihood: high.
+  Mitigation: document this as intentional eager validation and cover it with
+  unit tests.
+- Risk: tests may reach into a private `_replay_session` slot if no public
+  accessor exists. Severity: low. Likelihood: high. Mitigation: add read-only
+  public query helpers mirroring recording-session access if that keeps tests
+  and docs off private state.
+
+## Progress
+
+- [x] Reviewed `AGENTS.md`, the execplans skill, the roadmap, the record-mode
+  design sections, and the existing `12.2.1` / `12.2.2` ExecPlans.
+- [x] Inspected the current `CommandDouble`, `ReplaySession`, and neighbouring
+  recording tests to establish the actual implementation seam.
+- [x] Drafted this ExecPlan in
+  `docs/execplans/12-2-3-add-replay-to-command-double.md`.
+- [ ] Obtain explicit user approval for this plan before implementation.
+- [ ] Add or update unit tests for `CommandDouble.replay()` before editing
+  production code.
+- [ ] Add or update `pytest-bdd` scenarios covering the replay fluent API
+  contract before editing production code.
+- [ ] Implement the replay session attachment API on `CommandDouble`.
+- [ ] Update the design doc, usage guide, and roadmap.
+- [ ] Run all required quality gates and capture the results in the plan if it
+  moves into execution.
+
+## Surprises & Discoveries
+
+- `ReplaySession` and `InvocationMatcher` are already fully implemented and
+  exported. The only missing public entrypoint is on `CommandDouble`, which
+  makes this roadmap item a genuine API-wiring task rather than replay-engine
+  work.
+- `CommandDouble` currently mirrors recording state only: it has
+  `_recording_session` in `__slots__`, initializes that slot in `__init__()`,
+  and exposes public read-only recording-session helpers. There is no replay
+  equivalent yet.
+- The design document already contains illustrative code for
+  `CommandDouble.replay()` and a `_replay_session` slot, so the docs are ahead
+  of the shipped code in this area.
+- `docs/usage-guide.md` currently explains `ReplaySession` directly but does
+  not document a fluent `.replay()` method on doubles, which means this task
+  has real user-facing documentation impact.
+
+## Decision Log
+
+- Decision: keep `12.2.3` strictly focused on fluent API attachment. The double
+  will gain replay configuration state, but controller dispatch and replay
+  verification stay for `12.2.4` and `12.2.5`.
+
+- Decision: use eager validation. `CommandDouble.replay()` should construct a
+  `ReplaySession`, call `load()` immediately, and only return `self` once the
+  fixture has been validated successfully. This matches the design document’s
+  illustrative snippet and gives test authors immediate feedback when a fixture
+  path or schema is wrong.
+
+- Decision: reject replay plus passthrough explicitly with a `ValueError`.
+  Replay is a fixture-backed substitute for real command execution, so allowing
+  both at once would create contradictory behaviour.
+
+- Decision: treat replay as a spy-oriented API unless implementation evidence
+  proves otherwise. The design examples use `spy("...").replay(...)`, replayed
+  invocations are still useful to record on spy history, and allowing replay on
+  stubs or mocks would introduce public semantics the roadmap does not yet
+  justify.
+
+- Decision: add replay-session query helpers on `CommandDouble` if that keeps
+  tests and usage documentation off private state. The preferred shape is to
+  mirror the existing recording API with `has_replay_session` and
+  `replay_session`. If the implementation turns out to be cleaner without these
+  helpers, document that reversal here before landing the change.
+
+## Plan of work
+
+### Stage A: Write failing unit tests first
+
+Create `cmd_mox/unittests/test_command_double_replay.py` and model it on the
+existing recording tests. The file should establish the public API contract
+before production code changes.
+
+Write unit tests that cover at least the following behaviours:
+
+1. `.replay()` returns the same `CommandDouble` instance for fluent chaining.
+2. The default `strict` value is `True`.
+3. Passing `strict=False` creates a replay session configured for fuzzy
+   matching.
+4. String paths are accepted and normalised to `Path`.
+5. The attached replay session is loaded eagerly.
+6. Missing fixture files and invalid fixture data raise from `.replay()`
+   immediately.
+7. Replay rejects invalid combinations:
+   `passthrough().replay(...)` must raise `ValueError`.
+8. Replay rejects duplicate attachment on the same double with a clear error.
+9. If public replay-session helpers are added, cover their default and
+   post-attachment values.
+
+Run the focused unit test file before implementation and confirm it fails:
+
+```bash
+set -o pipefail
+pytest cmd_mox/unittests/test_command_double_replay.py -q 2>&1 | tee /tmp/12-2-3-unit-red.log
+```
+
+### Stage B: Write failing behavioural tests first
+
+Add consumer-facing behavioural coverage with:
+
+- `features/command_double_replay.feature`
+- `tests/steps/command_double_replay.py`
+- `tests/test_command_double_replay_bdd.py`
+
+These scenarios should stay at the fluent-API level because controller replay
+dispatch is deliberately out of scope for `12.2.3`.
+
+Minimum scenarios:
+
+1. A spy can attach a replay fixture and the session is loaded with strict mode
+   by default.
+2. A spy can attach a replay fixture with `strict=False` and the replay session
+   reports fuzzy matching.
+3. Combining passthrough and replay raises `ValueError`.
+
+Run the behavioural file before implementation and confirm it fails:
+
+```bash
+set -o pipefail
+pytest tests/test_command_double_replay_bdd.py -q 2>&1 | tee /tmp/12-2-3-bdd-red.log
+```
+
+### Stage C: Implement `CommandDouble.replay()`
+
+Update `cmd_mox/test_doubles.py` only after the red tests are in place.
+
+Implementation steps:
+
+1. Extend the TYPE_CHECKING imports to include `ReplaySession`.
+2. Add `_replay_session` to `CommandDouble.__slots__`.
+3. Initialise `self._replay_session` to `None` in `__init__()`.
+4. Add `replay(self, fixture_path, *, strict=True) -> Self`.
+5. Inside `replay()`, validate the intended constraints:
+   - replay is not allowed when passthrough mode is already enabled
+   - replay is not attached twice to the same double
+   - if replay is kept spy-only, reject non-spy doubles with a clear error
+6. Create `ReplaySession(fixture_path=Path(...), strict_matching=strict)`.
+7. Call `load()` immediately so validation happens during setup.
+8. Store the session on the double and return `self`.
+9. If public query helpers are part of the implementation, add
+   `has_replay_session` and `replay_session` properties mirroring the recording
+   helpers.
+
+After implementation, rerun the focused unit and behavioural tests until they
+both pass.
+
+### Stage D: Update documentation
+
+Update `docs/python-native-command-mocking-design.md` so the normative and
+illustrative sections match the shipped behaviour. At minimum:
+
+1. Confirm Section `9.6.1` and Table `9.6.2` reflect the final `.replay()`
+   signature and validation semantics.
+2. Update Section `9.8.2` if the final implementation adds public replay query
+   helpers or spy-only validation.
+3. Add a new numbered decision under Section `9.10` recording any non-obvious
+   choices made while implementing `.replay()`, especially:
+   eager loading, spy-only scope if retained, and whether public replay-session
+   accessors were added.
+
+Update `docs/usage-guide.md` to describe the consumer-facing behaviour:
+
+1. Add a short subsection near the existing Record Mode material showing
+   `cmd_mox.spy("git").replay("fixtures/git.json")`.
+2. Explain the `strict` flag in terms of strict versus fuzzy replay matching.
+3. Explain that replay validates the fixture eagerly during setup.
+4. Explain that replay cannot be combined with passthrough.
+5. If public replay-session helpers are added, document them only if they are
+   intended for users rather than just tests.
+
+### Stage E: Mark the roadmap item complete
+
+Once the code, tests, and docs are done, update `docs/cmd-mox-roadmap.md` to
+change:
+
+```plaintext
+- [ ] 12.2.3. Add `.replay()` to `CommandDouble`, including passthrough
+  incompatibility validation and strict-mode option.
+```
+
+to:
+
+```plaintext
+- [x] 12.2.3. Add `.replay()` to `CommandDouble`, including passthrough
+  incompatibility validation and strict-mode option.
+```
+
+### Stage F: Run full quality gates
+
+After the focused replay tests pass and all docs are updated, run the complete
+repository gates:
+
+```bash
+set -o pipefail
+make markdownlint 2>&1 | tee /tmp/12-2-3-markdownlint.log
+```
+
+```bash
+set -o pipefail
+make nixie 2>&1 | tee /tmp/12-2-3-nixie.log
+```
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/12-2-3-check-fmt.log
+```
+
+```bash
+set -o pipefail
+make typecheck 2>&1 | tee /tmp/12-2-3-typecheck.log
+```
+
+```bash
+set -o pipefail
+make lint 2>&1 | tee /tmp/12-2-3-lint.log
+```
+
+```bash
+set -o pipefail
+make test 2>&1 | tee /tmp/12-2-3-test.log
+```
+
+If any gate fails, fix the issue and rerun the failed command before rerunning
+the full sequence if necessary.
+
+## Validation and acceptance
+
+The feature is complete when all of the following are true:
+
+1. `cmd_mox.spy("git").replay("fixtures/git.json")` is a supported fluent API.
+2. The attached `ReplaySession` is created and loaded during `.replay()`.
+3. `strict=True` is the default and `strict=False` selects fuzzy replay mode.
+4. Replay plus passthrough is rejected with a clear `ValueError`.
+5. Duplicate replay attachment is rejected with a clear error.
+6. If replay is implemented as spy-only, non-spy doubles are rejected with a
+   clear error and the docs reflect that contract.
+7. New `pytest` unit tests and `pytest-bdd` behavioural tests pass.
+8. `docs/python-native-command-mocking-design.md` captures the final design
+   decisions.
+9. `docs/usage-guide.md` describes the user-visible replay behaviour.
+10. `docs/cmd-mox-roadmap.md` marks `12.2.3` done.
+11. `make markdownlint`, `make nixie`, `make check-fmt`, `make typecheck`,
+    `make lint`, and `make test` all pass.
+
+## Outcomes & Retrospective
+
+This section is intentionally blank during draft phase. When implementation is
+complete, replace this paragraph with a concise record of what shipped, what
+changed from the original plan, which risks materialised, and the final gate
+results.

--- a/docs/execplans/12-2-3-add-replay-to-command-double.md
+++ b/docs/execplans/12-2-3-add-replay-to-command-double.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -171,14 +171,14 @@ plus replay-specific tests and documentation.
   recording tests to establish the actual implementation seam.
 - [x] Drafted this ExecPlan in
   `docs/execplans/12-2-3-add-replay-to-command-double.md`.
-- [ ] Obtain explicit user approval for this plan before implementation.
-- [ ] Add or update unit tests for `CommandDouble.replay()` before editing
+- [x] Obtain explicit user approval for this plan before implementation.
+- [x] Add or update unit tests for `CommandDouble.replay()` before editing
   production code.
-- [ ] Add or update `pytest-bdd` scenarios covering the replay fluent API
+- [x] Add or update `pytest-bdd` scenarios covering the replay fluent API
   contract before editing production code.
-- [ ] Implement the replay session attachment API on `CommandDouble`.
-- [ ] Update the design doc, usage guide, and roadmap.
-- [ ] Run all required quality gates and capture the results in the plan if it
+- [x] Implement the replay session attachment API on `CommandDouble`.
+- [x] Update the design doc, usage guide, and roadmap.
+- [x] Run all required quality gates and capture the results in the plan if it
   moves into execution.
 
 ## Surprises & Discoveries
@@ -197,6 +197,9 @@ plus replay-specific tests and documentation.
 - `docs/usage-guide.md` currently explains `ReplaySession` directly but does
   not document a fluent `.replay()` method on doubles, which means this task
   has real user-facing documentation impact.
+- `make markdownlint` scans `.uv-cache/` by default through the repo-wide
+  `**/*.md` glob, so the markdownlint config needed an explicit `.uv-cache/**`
+  ignore to avoid third-party package READMEs failing the gate.
 
 ## Decision Log
 
@@ -407,7 +410,18 @@ The feature is complete when all of the following are true:
 
 ## Outcomes & Retrospective
 
-This section is intentionally blank during draft phase. When implementation is
-complete, replace this paragraph with a concise record of what shipped, what
-changed from the original plan, which risks materialised, and the final gate
-results.
+- Shipped `CommandDouble.replay(fixture_path, *, strict=True)` with eager
+  `ReplaySession.load()` during configuration, plus public read-only
+  `has_replay_session` and `replay_session` helpers.
+- Landed focused unit and behavioural coverage for fluent chaining, strict vs
+  fuzzy mode, eager fixture validation, duplicate attachment rejection,
+  passthrough incompatibility, and the current spy-only scope.
+- Updated the usage guide, design document, and roadmap so the written contract
+  matches the shipped API.
+- Quality gates:
+  - `make markdownlint`: passed
+  - `make nixie`: passed
+  - `make check-fmt`: passed
+  - `make typecheck`: passed
+  - `make lint`: passed
+  - `make test`: passed (`720 passed, 12 skipped`)

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -2335,8 +2335,8 @@ spy = cmd_mox.spy("aws").passthrough().record(
 # Replaying from a recorded fixture
 spy = cmd_mox.spy("git").replay("fixtures/git_clone.json")
 
-# Strict replay (fail on any unmatched invocation)
-spy = cmd_mox.spy("git").replay("fixtures/git_clone.json", strict=True)
+# Fuzzy replay (match on command + args only)
+spy = cmd_mox.spy("git").replay("fixtures/git_clone.json", strict=False)
 ```
 
 #### 9.6.2 Table 3: Record Mode API Methods
@@ -2346,7 +2346,7 @@ spy = cmd_mox.spy("git").replay("fixtures/git_clone.json", strict=True)
 | Method                                      | Purpose                             | Example                                           |
 | ------------------------------------------- | ----------------------------------- | ------------------------------------------------- |
 | `.record(path, *, scrubber, env_allowlist)` | Enable recording on passthrough spy | `.record("fixtures/git.json")`                    |
-| `.replay(path, *, strict)`                  | Load fixture and replay responses   | `.replay("fixtures/git.json")`                    |
+| `.replay(path, *, strict)`                  | Load fixture and replay responses on a spy | `.replay("fixtures/git.json")`             |
 | `Scrubber()`                                | Create scrubber with default rules  | `Scrubber()`                                      |
 | `Scrubber.add_rule(rule)`                   | Add custom scrubbing rule           | `scrubber.add_rule(rule)`                         |
 | `ScrubbingRule(pattern, replacement)`       | Define a scrubbing pattern          | `ScrubbingRule(r"token=\S+", "token=<REDACTED>")` |
@@ -2488,14 +2488,28 @@ class CommandDouble:
         strict: bool = True,
     ) -> Self:
         """Load a fixture and replay recorded responses."""
+        if self.kind is not DoubleKind.SPY:
+            raise ValueError("replay() is only valid for spies")
         if self.passthrough_mode:
             raise ValueError("replay() cannot be combined with passthrough()")
+        if self._replay_session is not None:
+            raise RuntimeError(
+                "replay() already called; finalize the existing session first"
+            )
         self._replay_session = ReplaySession(
             fixture_path=Path(fixture_path),
             strict_matching=strict,
         )
         self._replay_session.load()
         return self
+
+    @property
+    def has_replay_session(self) -> bool:
+        return self._replay_session is not None
+
+    @property
+    def replay_session(self) -> ReplaySession | None:
+        return self._replay_session
 ```
 
 #### 9.8.3 Controller Integration
@@ -2819,6 +2833,32 @@ the most appropriate recording when multiple candidates qualify.
 - **Exposing InvocationMatcher as a primary API:** Deferred. The class is
   exported from `cmd_mox.record` for advanced use cases, but the primary
   user-facing contract remains `ReplaySession.match()`
+
+#### 9.10.14 `CommandDouble.replay()` scope and eager loading
+
+**Decision:** Implement `CommandDouble.replay()` as a spy-only fluent API that
+constructs and immediately loads a `ReplaySession`, and expose the attached
+session through read-only `has_replay_session` and `replay_session`
+properties.
+
+**Rationale:**
+
+- Eager loading surfaces missing files, malformed fixtures, and schema errors
+  during test setup, which is earlier and easier to diagnose than deferring
+  them until command execution
+- Restricting `.replay()` to spies avoids mixing replay-backed responses with
+  mock and stub semantics before roadmap items `12.2.4` and `12.2.5` complete
+  controller integration and replay verification
+- Mirroring the recording accessors gives tests and documentation a public way
+  to inspect replay attachment without reaching into private slots
+
+**Alternatives considered:**
+
+- **Allow replay on all double kinds:** Deferred because, without controller
+  integration, that broadens the public contract faster than the roadmap stage
+  justifies
+- **Lazy loading on first command invocation:** Rejected because it delays
+  validation and makes fixture problems harder to localise
 
 ### 9.11 Versioning and Forward Compatibility
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -461,7 +461,7 @@ persisted to the fixture file when `verify()` is called. When
 automatically on exit. If `verify_on_exit=False`, fixtures are **not** written
 unless you call `verify()` explicitly.
 
-### Parameters
+### Replay parameters
 
 The `record()` method accepts optional parameters for controlling what is
 recorded:
@@ -493,7 +493,7 @@ spy = cmd_mox.spy("aws").passthrough().record(
 - **`env_allowlist`** (`list[str] | None`): environment variable keys to always
   include in recordings, in addition to the default command-specific prefixes.
 
-### Validation
+### Replay validation
 
 Calling `record()` without first calling `passthrough()` raises `ValueError`:
 
@@ -509,6 +509,45 @@ captures real command interactions to fixture files, replay loads those
 fixtures and uses them to respond to invocations without executing real
 commands. This enables fast, deterministic tests from previously captured
 interactions.
+
+## Automatic replay with `.replay()`
+
+The `CommandDouble.replay()` fluent method attaches a loaded replay fixture to
+a spy during test setup. This keeps fixture validation close to the test code
+that declares the double:
+
+```python
+def test_git_clone(cmd_mox):
+    spy = cmd_mox.spy("git").replay("fixtures/git_clone.json")
+    # ... run code that invokes git ...
+```
+
+Calling `.replay()` loads the fixture immediately. Missing files, malformed
+JSON, and schema-version errors therefore fail the test during setup rather
+than later during command execution.
+
+### Parameters
+
+- **`fixture_path`** (`str | Path`): path to the JSON fixture file to load.
+- **`strict`** (`bool`): when `True` (default), replay uses strict matching.
+  When `False`, replay uses fuzzy matching.
+
+### Validation
+
+The `.replay()` fluent API is currently limited to spies. It also cannot be
+combined with passthrough mode because the two behaviours conflict:
+
+```python
+# This raises ValueError: "replay() is only valid for spies"
+cmd_mox.mock("git").replay("fixtures/git.json")
+
+# This raises ValueError: "replay() cannot be combined with passthrough()"
+cmd_mox.spy("git").passthrough().replay("fixtures/git.json")
+```
+
+Calling `.replay()` more than once on the same double raises `RuntimeError`.
+The attached session is available via the read-only `replay_session` property,
+and `has_replay_session` reports whether a session has been attached.
 
 ### Creating and loading a replay session
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -461,7 +461,7 @@ persisted to the fixture file when `verify()` is called. When
 automatically on exit. If `verify_on_exit=False`, fixtures are **not** written
 unless you call `verify()` explicitly.
 
-### Replay parameters
+### Record parameters
 
 The `record()` method accepts optional parameters for controlling what is
 recorded:
@@ -493,7 +493,7 @@ spy = cmd_mox.spy("aws").passthrough().record(
 - **`env_allowlist`** (`list[str] | None`): environment variable keys to always
   include in recordings, in addition to the default command-specific prefixes.
 
-### Replay validation
+### Record validation
 
 Calling `record()` without first calling `passthrough()` raises `ValueError`:
 

--- a/features/command_double_replay.feature
+++ b/features/command_double_replay.feature
@@ -1,0 +1,25 @@
+Feature: CommandDouble.replay() fluent API
+
+  The .replay() method on CommandDouble attaches a ready-to-use replay fixture
+  to a spy during test setup.
+
+  Scenario: fluent API creates a strict replay session on a spy
+    Given a CmdMox controller
+    And a replay fixture for "git"
+    When replay is called on a "git" spy
+    Then the spy has a replay session attached
+    And the replay session is loaded
+    And the replay session uses strict matching
+
+  Scenario: replay can use fuzzy matching
+    Given a CmdMox controller
+    And a replay fixture for "git"
+    When replay is called on a "git" spy with strict disabled
+    Then the spy has a replay session attached
+    And the replay session uses fuzzy matching
+
+  Scenario: replay cannot be combined with passthrough
+    Given a CmdMox controller
+    And a replay fixture for "git"
+    And a "git" spy with passthrough enabled
+    When replay is combined with passthrough it raises ValueError

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -1,0 +1,56 @@
+"""Shared test fixture utilities for creating minimal valid replay fixtures."""
+
+from __future__ import annotations
+
+import typing as t
+
+from cmd_mox.record.fixture import FixtureFile, FixtureMetadata, RecordedInvocation
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
+
+
+def write_minimal_replay_fixture(
+    tmp_path: Path, filename: str = "fixture.json"
+) -> Path:
+    r"""Write a minimal valid replay fixture and return its path.
+
+    This helper creates a fixture containing a single recorded invocation
+    of ``git status`` that returns ``ok\n`` on stdout. It is intended for
+    tests that need a valid fixture file but don't care about the specific
+    command or response.
+
+    Parameters
+    ----------
+    tmp_path:
+        Temporary directory path (typically from pytest's tmp_path fixture).
+    filename:
+        Name for the fixture file. Defaults to ``"fixture.json"``.
+
+    Returns
+    -------
+    Path
+        The full path to the created fixture file.
+    """
+    fixture = FixtureFile(
+        version=FixtureFile.SCHEMA_VERSION,
+        metadata=FixtureMetadata.create(),
+        recordings=[
+            RecordedInvocation(
+                sequence=0,
+                command="git",
+                args=["status"],
+                stdin="",
+                env_subset={},
+                stdout="ok\n",
+                stderr="",
+                exit_code=0,
+                timestamp="2026-01-15T10:30:00+00:00",
+                duration_ms=0,
+            )
+        ],
+        scrubbing_rules=[],
+    )
+    path = tmp_path / filename
+    fixture.save(path)
+    return path

--- a/tests/steps/command_double_record.py
+++ b/tests/steps/command_double_record.py
@@ -16,9 +16,21 @@ if t.TYPE_CHECKING:
 
 
 @given("a CmdMox controller", target_fixture="mox")
-def create_controller() -> CmdMox:
-    """Create a fresh CmdMox controller."""
-    return CmdMox()
+def create_controller() -> t.Generator[CmdMox, None, None]:
+    """Create a fresh CmdMox controller with proper cleanup.
+
+    Yields
+    ------
+    CmdMox
+        A fresh controller instance that will be cleaned up after the test.
+    """
+    mox = CmdMox()
+    try:
+        yield mox
+    finally:
+        # Ensure cleanup even if the test raises
+        if mox._entered:
+            mox.__exit__(None, None, None)
 
 
 @given('a spy for "git" with passthrough enabled', target_fixture="spy")

--- a/tests/steps/command_double_replay.py
+++ b/tests/steps/command_double_replay.py
@@ -1,0 +1,116 @@
+"""Step definitions for CommandDouble.replay() BDD scenarios."""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+from pytest_bdd import given, then, when
+
+from cmd_mox.controller import CmdMox
+from cmd_mox.ipc import Invocation
+from cmd_mox.record.fixture import FixtureFile, FixtureMetadata, RecordedInvocation
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
+
+    from cmd_mox.test_doubles import CommandDouble
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    """Write a minimal valid replay fixture and return its path."""
+    fixture = FixtureFile(
+        version=FixtureFile.SCHEMA_VERSION,
+        metadata=FixtureMetadata.create(),
+        recordings=[
+            RecordedInvocation(
+                sequence=0,
+                command="git",
+                args=["status"],
+                stdin="",
+                env_subset={},
+                stdout="ok\n",
+                stderr="",
+                exit_code=0,
+                timestamp="2026-01-15T10:30:00+00:00",
+                duration_ms=0,
+            )
+        ],
+        scrubbing_rules=[],
+    )
+    path = tmp_path / "fixture.json"
+    fixture.save(path)
+    return path
+
+
+@given("a CmdMox controller", target_fixture="mox")
+def create_controller() -> CmdMox:
+    """Create a fresh CmdMox controller."""
+    return CmdMox()
+
+
+@given('a replay fixture for "git"', target_fixture="fixture_path")
+def replay_fixture(tmp_path: Path) -> Path:
+    """Create a replay fixture file for the git command."""
+    return _write_fixture(tmp_path)
+
+
+@given('a "git" spy with passthrough enabled', target_fixture="spy")
+def spy_with_passthrough(mox: CmdMox) -> CommandDouble:
+    """Create a spy configured for passthrough mode."""
+    return mox.spy("git").passthrough()
+
+
+@when('replay is called on a "git" spy', target_fixture="spy_after_replay")
+def call_replay(mox: CmdMox, fixture_path: Path) -> CommandDouble:
+    """Attach a strict replay session to a spy."""
+    return mox.spy("git").replay(fixture_path)
+
+
+@when(
+    'replay is called on a "git" spy with strict disabled',
+    target_fixture="spy_after_replay",
+)
+def call_replay_fuzzy(mox: CmdMox, fixture_path: Path) -> CommandDouble:
+    """Attach a fuzzy replay session to a spy."""
+    return mox.spy("git").replay(fixture_path, strict=False)
+
+
+@when("replay is combined with passthrough it raises ValueError")
+def call_replay_with_passthrough_raises(spy: CommandDouble, fixture_path: Path) -> None:
+    """Attempt to combine replay with passthrough and assert rejection."""
+    with pytest.raises(ValueError, match=r"replay.*passthrough"):
+        spy.replay(fixture_path)
+
+
+@then("the spy has a replay session attached")
+def spy_has_replay_session(spy_after_replay: CommandDouble) -> None:
+    """Assert a replay session has been attached."""
+    assert spy_after_replay.has_replay_session is True
+
+
+@then("the replay session is loaded")
+def replay_session_is_loaded(spy_after_replay: CommandDouble) -> None:
+    """Assert the session is immediately usable after replay()."""
+    session = spy_after_replay.replay_session
+    assert session is not None
+    assert (
+        session.match(Invocation(command="git", args=["status"], stdin="", env={}))
+        is not None
+    )
+
+
+@then("the replay session uses strict matching")
+def replay_session_uses_strict_matching(spy_after_replay: CommandDouble) -> None:
+    """Assert strict matching is enabled by default."""
+    session = spy_after_replay.replay_session
+    assert session is not None
+    assert session.strict_matching is True
+
+
+@then("the replay session uses fuzzy matching")
+def replay_session_uses_fuzzy_matching(spy_after_replay: CommandDouble) -> None:
+    """Assert fuzzy matching is enabled when strict=False."""
+    session = spy_after_replay.replay_session
+    assert session is not None
+    assert session.strict_matching is False

--- a/tests/steps/command_double_replay.py
+++ b/tests/steps/command_double_replay.py
@@ -69,23 +69,24 @@ def spy_with_passthrough(mox: CmdMox) -> CommandDouble:
     return mox.spy("git").passthrough()
 
 
+def _call_replay_with_strict(
+    mox: CmdMox, fixture_path: Path, *, strict: bool
+) -> CommandDouble:
+    """Attach a replay session to a git spy with the specified strict mode."""
+    return mox.spy("git").replay(fixture_path, strict=strict)
+
+
+def _assert_strict_matching(spy_after_replay: CommandDouble, *, expected: bool) -> None:
+    """Assert that the replay session has the expected strict_matching setting."""
+    session = spy_after_replay.replay_session
+    assert session is not None
+    assert session.strict_matching is expected
+
+
 @when('replay is called on a "git" spy', target_fixture="spy_after_replay")
 def call_replay(mox: CmdMox, fixture_path: Path) -> CommandDouble:
-    """Attach a strict replay session to a spy.
-
-    Parameters
-    ----------
-    mox : CmdMox
-        The controller instance to create the spy from.
-    fixture_path : Path
-        Path to the replay fixture file.
-
-    Returns
-    -------
-    CommandDouble
-        A git spy with a strict replay session attached.
-    """
-    return mox.spy("git").replay(fixture_path)
+    """Attach a strict replay session to a spy."""
+    return _call_replay_with_strict(mox, fixture_path, strict=True)
 
 
 @when(
@@ -93,21 +94,8 @@ def call_replay(mox: CmdMox, fixture_path: Path) -> CommandDouble:
     target_fixture="spy_after_replay",
 )
 def call_replay_fuzzy(mox: CmdMox, fixture_path: Path) -> CommandDouble:
-    """Attach a fuzzy replay session to a spy.
-
-    Parameters
-    ----------
-    mox : CmdMox
-        The controller instance to create the spy from.
-    fixture_path : Path
-        Path to the replay fixture file.
-
-    Returns
-    -------
-    CommandDouble
-        A git spy with a fuzzy replay session attached.
-    """
-    return mox.spy("git").replay(fixture_path, strict=False)
+    """Attach a fuzzy replay session to a spy."""
+    return _call_replay_with_strict(mox, fixture_path, strict=False)
 
 
 @when("replay is combined with passthrough it raises ValueError")
@@ -161,27 +149,11 @@ def replay_session_is_loaded(spy_after_replay: CommandDouble) -> None:
 
 @then("the replay session uses strict matching")
 def replay_session_uses_strict_matching(spy_after_replay: CommandDouble) -> None:
-    """Assert strict matching is enabled by default.
-
-    Parameters
-    ----------
-    spy_after_replay : CommandDouble
-        A spy with a replay session.
-    """
-    session = spy_after_replay.replay_session
-    assert session is not None
-    assert session.strict_matching is True
+    """Assert strict matching is enabled by default."""
+    _assert_strict_matching(spy_after_replay, expected=True)
 
 
 @then("the replay session uses fuzzy matching")
 def replay_session_uses_fuzzy_matching(spy_after_replay: CommandDouble) -> None:
-    """Assert fuzzy matching is enabled when strict=False.
-
-    Parameters
-    ----------
-    spy_after_replay : CommandDouble
-        A spy with a replay session configured for fuzzy matching.
-    """
-    session = spy_after_replay.replay_session
-    assert session is not None
-    assert session.strict_matching is False
+    """Assert fuzzy matching is enabled when strict=False."""
+    _assert_strict_matching(spy_after_replay, expected=False)

--- a/tests/steps/command_double_replay.py
+++ b/tests/steps/command_double_replay.py
@@ -9,38 +9,12 @@ from pytest_bdd import given, then, when
 
 from cmd_mox.controller import CmdMox
 from cmd_mox.ipc import Invocation
-from cmd_mox.record.fixture import FixtureFile, FixtureMetadata, RecordedInvocation
+from tests.helpers.fixtures import write_minimal_replay_fixture
 
 if t.TYPE_CHECKING:
     from pathlib import Path
 
     from cmd_mox.test_doubles import CommandDouble
-
-
-def _write_fixture(tmp_path: Path) -> Path:
-    """Write a minimal valid replay fixture and return its path."""
-    fixture = FixtureFile(
-        version=FixtureFile.SCHEMA_VERSION,
-        metadata=FixtureMetadata.create(),
-        recordings=[
-            RecordedInvocation(
-                sequence=0,
-                command="git",
-                args=["status"],
-                stdin="",
-                env_subset={},
-                stdout="ok\n",
-                stderr="",
-                exit_code=0,
-                timestamp="2026-01-15T10:30:00+00:00",
-                duration_ms=0,
-            )
-        ],
-        scrubbing_rules=[],
-    )
-    path = tmp_path / "fixture.json"
-    fixture.save(path)
-    return path
 
 
 @given("a CmdMox controller", target_fixture="mox")
@@ -52,7 +26,7 @@ def create_controller() -> CmdMox:
 @given('a replay fixture for "git"', target_fixture="fixture_path")
 def replay_fixture(tmp_path: Path) -> Path:
     """Create a replay fixture file for the git command."""
-    return _write_fixture(tmp_path)
+    return write_minimal_replay_fixture(tmp_path)
 
 
 @given('a "git" spy with passthrough enabled', target_fixture="spy")

--- a/tests/steps/command_double_replay.py
+++ b/tests/steps/command_double_replay.py
@@ -18,26 +18,73 @@ if t.TYPE_CHECKING:
 
 
 @given("a CmdMox controller", target_fixture="mox")
-def create_controller() -> CmdMox:
-    """Create a fresh CmdMox controller."""
-    return CmdMox()
+def create_controller() -> t.Generator[CmdMox, None, None]:
+    """Create a fresh CmdMox controller with proper cleanup.
+
+    Yields
+    ------
+    CmdMox
+        A fresh controller instance that will be cleaned up after the test.
+    """
+    mox = CmdMox()
+    try:
+        yield mox
+    finally:
+        # Ensure cleanup even if the test raises
+        if mox._entered:
+            mox.__exit__(None, None, None)
 
 
 @given('a replay fixture for "git"', target_fixture="fixture_path")
 def replay_fixture(tmp_path: Path) -> Path:
-    """Create a replay fixture file for the git command."""
+    """Create a replay fixture file for the git command.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory path provided by pytest.
+
+    Returns
+    -------
+    Path
+        Path to the created fixture file.
+    """
     return write_minimal_replay_fixture(tmp_path)
 
 
 @given('a "git" spy with passthrough enabled', target_fixture="spy")
 def spy_with_passthrough(mox: CmdMox) -> CommandDouble:
-    """Create a spy configured for passthrough mode."""
+    """Create a spy configured for passthrough mode.
+
+    Parameters
+    ----------
+    mox : CmdMox
+        The controller instance to create the spy from.
+
+    Returns
+    -------
+    CommandDouble
+        A git spy with passthrough enabled.
+    """
     return mox.spy("git").passthrough()
 
 
 @when('replay is called on a "git" spy', target_fixture="spy_after_replay")
 def call_replay(mox: CmdMox, fixture_path: Path) -> CommandDouble:
-    """Attach a strict replay session to a spy."""
+    """Attach a strict replay session to a spy.
+
+    Parameters
+    ----------
+    mox : CmdMox
+        The controller instance to create the spy from.
+    fixture_path : Path
+        Path to the replay fixture file.
+
+    Returns
+    -------
+    CommandDouble
+        A git spy with a strict replay session attached.
+    """
     return mox.spy("git").replay(fixture_path)
 
 
@@ -46,26 +93,64 @@ def call_replay(mox: CmdMox, fixture_path: Path) -> CommandDouble:
     target_fixture="spy_after_replay",
 )
 def call_replay_fuzzy(mox: CmdMox, fixture_path: Path) -> CommandDouble:
-    """Attach a fuzzy replay session to a spy."""
+    """Attach a fuzzy replay session to a spy.
+
+    Parameters
+    ----------
+    mox : CmdMox
+        The controller instance to create the spy from.
+    fixture_path : Path
+        Path to the replay fixture file.
+
+    Returns
+    -------
+    CommandDouble
+        A git spy with a fuzzy replay session attached.
+    """
     return mox.spy("git").replay(fixture_path, strict=False)
 
 
 @when("replay is combined with passthrough it raises ValueError")
 def call_replay_with_passthrough_raises(spy: CommandDouble, fixture_path: Path) -> None:
-    """Attempt to combine replay with passthrough and assert rejection."""
+    """Attempt to combine replay with passthrough and assert rejection.
+
+    Parameters
+    ----------
+    spy : CommandDouble
+        A spy with passthrough already enabled.
+    fixture_path : Path
+        Path to the replay fixture file.
+
+    Raises
+    ------
+    ValueError
+        When replay is called on a spy with passthrough enabled.
+    """
     with pytest.raises(ValueError, match=r"replay.*passthrough"):
         spy.replay(fixture_path)
 
 
 @then("the spy has a replay session attached")
 def spy_has_replay_session(spy_after_replay: CommandDouble) -> None:
-    """Assert a replay session has been attached."""
+    """Assert a replay session has been attached.
+
+    Parameters
+    ----------
+    spy_after_replay : CommandDouble
+        A spy with a replay session.
+    """
     assert spy_after_replay.has_replay_session is True
 
 
 @then("the replay session is loaded")
 def replay_session_is_loaded(spy_after_replay: CommandDouble) -> None:
-    """Assert the session is immediately usable after replay()."""
+    """Assert the session is immediately usable after replay().
+
+    Parameters
+    ----------
+    spy_after_replay : CommandDouble
+        A spy with a replay session.
+    """
     session = spy_after_replay.replay_session
     assert session is not None
     assert (
@@ -76,7 +161,13 @@ def replay_session_is_loaded(spy_after_replay: CommandDouble) -> None:
 
 @then("the replay session uses strict matching")
 def replay_session_uses_strict_matching(spy_after_replay: CommandDouble) -> None:
-    """Assert strict matching is enabled by default."""
+    """Assert strict matching is enabled by default.
+
+    Parameters
+    ----------
+    spy_after_replay : CommandDouble
+        A spy with a replay session.
+    """
     session = spy_after_replay.replay_session
     assert session is not None
     assert session.strict_matching is True
@@ -84,7 +175,13 @@ def replay_session_uses_strict_matching(spy_after_replay: CommandDouble) -> None
 
 @then("the replay session uses fuzzy matching")
 def replay_session_uses_fuzzy_matching(spy_after_replay: CommandDouble) -> None:
-    """Assert fuzzy matching is enabled when strict=False."""
+    """Assert fuzzy matching is enabled when strict=False.
+
+    Parameters
+    ----------
+    spy_after_replay : CommandDouble
+        A spy with a replay session configured for fuzzy matching.
+    """
     session = spy_after_replay.replay_session
     assert session is not None
     assert session.strict_matching is False

--- a/tests/steps/controller_setup.py
+++ b/tests/steps/controller_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import typing as t
 from pathlib import Path
 
 import pytest
@@ -28,18 +29,47 @@ _ERROR_TYPES: dict[str, type[VerificationError]] = {
 
 
 @given("a CmdMox controller", target_fixture="mox")
-def create_controller() -> CmdMox:
-    """Create a fresh CmdMox instance."""
-    return CmdMox()
+def create_controller() -> t.Generator[CmdMox, None, None]:
+    """Create a fresh CmdMox instance with proper cleanup.
+
+    Yields
+    ------
+    CmdMox
+        A fresh controller instance that will be cleaned up after the test.
+    """
+    mox = CmdMox()
+    try:
+        yield mox
+    finally:
+        # Ensure cleanup even if the test raises
+        if mox._entered:
+            mox.__exit__(None, None, None)
 
 
 @given(
     parsers.cfparse("a CmdMox controller with max journal size {size:d}"),
     target_fixture="mox",
 )
-def create_controller_with_limit(size: int) -> CmdMox:
-    """Create a CmdMox instance with bounded journal."""
-    return CmdMox(max_journal_entries=size)
+def create_controller_with_limit(size: int) -> t.Generator[CmdMox, None, None]:
+    """Create a CmdMox instance with bounded journal and proper cleanup.
+
+    Parameters
+    ----------
+    size : int
+        Maximum number of journal entries to retain.
+
+    Yields
+    ------
+    CmdMox
+        A controller instance with the specified journal size limit.
+    """
+    mox = CmdMox(max_journal_entries=size)
+    try:
+        yield mox
+    finally:
+        # Ensure cleanup even if the test raises
+        if mox._entered:
+            mox.__exit__(None, None, None)
 
 
 @given(

--- a/tests/test_command_double_replay_bdd.py
+++ b/tests/test_command_double_replay_bdd.py
@@ -1,0 +1,35 @@
+"""Behavioural tests for CommandDouble.replay() using pytest-bdd."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest_bdd import scenario
+
+from tests.steps.command_double_replay import *  # noqa: F403
+
+FEATURES_DIR = Path(__file__).resolve().parent.parent / "features"
+
+
+@scenario(
+    str(FEATURES_DIR / "command_double_replay.feature"),
+    "fluent API creates a strict replay session on a spy",
+)
+def test_replay_creates_strict_session() -> None:
+    """Calling replay() attaches a loaded strict replay session."""
+
+
+@scenario(
+    str(FEATURES_DIR / "command_double_replay.feature"),
+    "replay can use fuzzy matching",
+)
+def test_replay_can_use_fuzzy_matching() -> None:
+    """Calling replay(strict=False) attaches a loaded fuzzy replay session."""
+
+
+@scenario(
+    str(FEATURES_DIR / "command_double_replay.feature"),
+    "replay cannot be combined with passthrough",
+)
+def test_replay_with_passthrough_raises() -> None:
+    """Calling replay() after passthrough raises ValueError."""


### PR DESCRIPTION
## Summary
- Consolidates the test fixture helper into `tests/helpers/fixtures.py` and related scaffolding for replay fixtures.
- Adds a public fluent API on `CommandDouble` to attach a replay fixture via `.replay(fixture_path, *, strict=True)` with eager loading and validation of a `ReplaySession`. Default is strict matching; path is normalised to a `Path`; stores the session on the double and returns `self` for fluent chaining. Enforces exclusivity with `passthrough()` and prevents attaching replay more than once. Introduces read-only accessors `has_replay_session` and `replay_session` to mirror the existing recording API. Adds test scaffolding, BDD steps, a test fixture helper, and associated documentation and execplan updates.

## Changes

### Public API
- Add `CommandDouble.replay(self, fixture_path, *, strict=True) -> Self`.
- Default `strict=True`; normalises the path to a `Path` and creates/loads a `ReplaySession` eagerly.
- Return `self` for fluent chaining.

### Internal state
- Extend `CommandDouble` to hold a `_replay_session` slot (initialised to `None`).
- Enforce that replay cannot be attached when passthrough is active and cannot be attached twice.
- Optional public query helpers: `has_replay_session` and `replay_session` mirror the recording API.

### Replay wiring
- Create a `ReplaySession` with `fixture_path=Path(...)` and `strict_matching=strict`.
- Call `load()` immediately to perform fixture validation during test setup.
- Store the session on the double and return `self`.

### Testing surface
- New unit tests mirroring the recording tests for the replay API (structure introduced in this branch).
- Behavioural tests scaffolded under `features/`, `tests/steps/`, and `tests/test_command_double_replay_bdd.py`.
- New test helper: `tests/helpers/fixtures.py` to write minimal replay fixtures for tests.

### Documentation and roadmap
- Add an ExecPlan at `docs/execplans/12-2-3-add-replay-to-command-double.md` describing the design, constraints and outcomes.
- Update `docs/cmd-mox-roadmap.md` to mark 12.2.3 as done.
- Update usage/design docs to reflect the final API and eager loading semantics.

### API surface
- Public: `CommandDouble.replay(fixture_path, *, strict=True) -> Self`.
- Public query helpers: `has_replay_session` and `replay_session`.
- Enforces that replay is for spies only (until controller integration lands) and cannot be combined with passthrough.

## Why this change
- Eager validation of replay fixtures during setup provides immediate feedback to test authors.
- Constraining replay to spies and disallowing passthrough+replay keeps scope aligned with the roadmap and avoids ambiguous behaviours.
- Public accessors for replay state mirror the existing recording API for consistency in tests and docs.

## How to test locally
- Unit tests for the replay API (new/growing surface) and path handling:
  - `pytest cmd_mox/unittests/test_command_double_replay.py -q`
- Behavioural tests (BDD) once wired:
  - `pytest tests/test_command_double_replay_bdd.py -q`
- Full quality gates as per project requirements:
  - `make markdownlint` / `make nixie` / `make check-fmt` / `make typecheck` / `make lint` / `make test`

## Notes
- This PR wires the replay API surface and its test scaffolding. End-to-end controller integration and replay verification in `CmdMox._make_response()` remain out of scope for this item and are tracked for future roadmap steps.
- The new fixture helper in `tests/helpers/fixtures.py` is used to generate minimal replay fixtures for tests.
- Public docs reflect the final API and eager loading semantics, and the execplan documents the rationale and decisions.


📎 **Task**: https://www.devboxer.com/task/ad75b9f7-e51f-4e25-bb01-efea70d109a2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `.replay(fixture_path, *, strict=True)` fluent API to spy doubles for automatic response replay from fixtures
  * Control response matching behavior with strict and fuzzy modes
  * New `has_replay_session` and `replay_session` properties to inspect attached session state

* **Documentation**
  * Updated usage guide and design documentation with `.replay()` setup, parameters, and behavior details
  * Marked roadmap item 12.2.3 as complete

* **Chores**
  * Updated type annotations for predicate compatibility
  * Enhanced BDD fixture cleanup procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->