### PR TITLE
Complete: Integrate replay into CmdMox._make_response() (12.2.4)

### DIFF
--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -414,6 +414,27 @@ class CmdMox:
             double.invocations.append(invocation)
         return resp
 
+    def _response_for_replay(
+        self, double: CommandDouble, invocation: Invocation
+    ) -> Response:
+        """Handle a replay-backed invocation before normal spy behaviour."""
+        replay_session = double.replay_session
+        if replay_session is None:
+            msg = "Replay response requested without an attached replay session"
+            raise RuntimeError(msg)
+
+        if matched := replay_session.match(invocation):
+            if double.is_recording:
+                double.invocations.append(invocation)
+            return matched
+
+        if replay_session.strict_matching:
+            invocation_text = " ".join([invocation.command, *invocation.args]).strip()
+            msg = f"No fixture recording matches: {invocation_text}"
+            raise UnexpectedCommandError(msg)
+
+        return self._response_for_regular(double, invocation)
+
     def _select_response_strategy(
         self, double: CommandDouble | None
     ) -> _ResponseStrategy:
@@ -427,6 +448,12 @@ class CmdMox:
     def _make_response(self, invocation: Invocation) -> Response:
         """Build the response for an invocation using the appropriate strategy."""
         double = self._doubles.get(invocation.command)
+
+        if double is not None and double.replay_session is not None:
+            resp = self._response_for_replay(double, invocation)
+            invocation.apply(resp)
+            return resp
+
         strategy = self._select_response_strategy(double)
 
         if strategy is _ResponseStrategy.MISSING_DOUBLE:

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -359,6 +359,15 @@ class CmdMox:
     ) -> Response:
         """Run ``double``'s handler within its expectation environment."""
         overrides = self._apply_expectation_env(double, invocation)
+        return self._invoke_handler_with_overrides(double, invocation, overrides)
+
+    def _invoke_handler_with_overrides(
+        self,
+        double: CommandDouble,
+        invocation: Invocation,
+        overrides: dict[str, str],
+    ) -> Response:
+        """Run ``double``'s handler with prevalidated expectation overrides."""
         resp = self._execute_handler(double, invocation, overrides)
         self._finalize_response_env(resp, overrides)
         return resp
@@ -406,10 +415,20 @@ class CmdMox:
         return Response(stdout=invocation.command)
 
     def _response_for_regular(
-        self, double: CommandDouble, invocation: Invocation
+        self,
+        double: CommandDouble,
+        invocation: Invocation,
+        overrides: dict[str, str] | None = None,
     ) -> Response:
         """Handle a non-passthrough invocation with optional recording."""
-        resp = self._invoke_handler(double, invocation)
+        applied_overrides = (
+            self._apply_expectation_env(double, invocation)
+            if overrides is None
+            else overrides
+        )
+        resp = self._invoke_handler_with_overrides(
+            double, invocation, applied_overrides
+        )
         if double.is_recording:
             double.invocations.append(invocation)
         return resp
@@ -423,9 +442,11 @@ class CmdMox:
             msg = "Replay response requested without an attached replay session"
             raise RuntimeError(msg)
 
+        overrides = self._apply_expectation_env(double, invocation)
+
         if matched := replay_session.match(invocation):
-            if double.is_recording:
-                double.invocations.append(invocation)
+            self._finalize_response_env(matched, overrides)
+            double.invocations.append(invocation)
             return matched
 
         if replay_session.strict_matching:
@@ -433,7 +454,7 @@ class CmdMox:
             msg = f"No fixture recording matches: {invocation_text}"
             raise UnexpectedCommandError(msg)
 
-        return self._response_for_regular(double, invocation)
+        return self._response_for_regular(double, invocation, overrides)
 
     def _select_response_strategy(
         self, double: CommandDouble | None
@@ -451,25 +472,23 @@ class CmdMox:
 
         if double is not None and double.replay_session is not None:
             resp = self._response_for_replay(double, invocation)
-            invocation.apply(resp)
-            return resp
-
-        strategy = self._select_response_strategy(double)
-
-        if strategy is _ResponseStrategy.MISSING_DOUBLE:
-            resp = self._response_for_missing_double(invocation)
         else:
-            if double is None:
-                msg = "Unexpected response strategy/double combination"
-                raise RuntimeError(msg)
-            match strategy:
-                case _ResponseStrategy.PASSTHROUGH:
-                    resp = self._prepare_passthrough(double, invocation)
-                case _ResponseStrategy.REGULAR:
-                    resp = self._response_for_regular(double, invocation)
-                case _:
-                    msg = f"Unhandled response strategy: {strategy}"
+            strategy = self._select_response_strategy(double)
+
+            if strategy is _ResponseStrategy.MISSING_DOUBLE:
+                resp = self._response_for_missing_double(invocation)
+            else:
+                if double is None:
+                    msg = "Unexpected response strategy/double combination"
                     raise RuntimeError(msg)
+                match strategy:
+                    case _ResponseStrategy.PASSTHROUGH:
+                        resp = self._prepare_passthrough(double, invocation)
+                    case _ResponseStrategy.REGULAR:
+                        resp = self._response_for_regular(double, invocation)
+                    case _:
+                        msg = f"Unhandled response strategy: {strategy}"
+                        raise RuntimeError(msg)
 
         invocation.apply(resp)
         return resp

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -466,6 +466,23 @@ class CmdMox:
             return _ResponseStrategy.PASSTHROUGH
         return _ResponseStrategy.REGULAR
 
+    def _resolve_response(
+        self, double: CommandDouble | None, invocation: Invocation
+    ) -> Response:
+        """Resolve the response for non-replay invocation paths."""
+        if double is None:
+            return self._response_for_missing_double(invocation)
+
+        strategy = self._select_response_strategy(double)
+        match strategy:
+            case _ResponseStrategy.PASSTHROUGH:
+                return self._prepare_passthrough(double, invocation)
+            case _ResponseStrategy.REGULAR:
+                return self._response_for_regular(double, invocation)
+            case _:
+                msg = f"Unhandled response strategy: {strategy}"
+                raise RuntimeError(msg)
+
     def _make_response(self, invocation: Invocation) -> Response:
         """Build the response for an invocation using the appropriate strategy."""
         double = self._doubles.get(invocation.command)
@@ -473,22 +490,7 @@ class CmdMox:
         if double is not None and double.replay_session is not None:
             resp = self._response_for_replay(double, invocation)
         else:
-            strategy = self._select_response_strategy(double)
-
-            if strategy is _ResponseStrategy.MISSING_DOUBLE:
-                resp = self._response_for_missing_double(invocation)
-            else:
-                if double is None:
-                    msg = "Unexpected response strategy/double combination"
-                    raise RuntimeError(msg)
-                match strategy:
-                    case _ResponseStrategy.PASSTHROUGH:
-                        resp = self._prepare_passthrough(double, invocation)
-                    case _ResponseStrategy.REGULAR:
-                        resp = self._response_for_regular(double, invocation)
-                    case _:
-                        msg = f"Unhandled response strategy: {strategy}"
-                        raise RuntimeError(msg)
+            resp = self._resolve_response(double, invocation)
 
         invocation.apply(resp)
         return resp

--- a/cmd_mox/unittests/test_controller_replay.py
+++ b/cmd_mox/unittests/test_controller_replay.py
@@ -51,6 +51,43 @@ class TestControllerReplayIntegration:
         assert response.stdout == "ok\n"
         assert handler_calls == []
 
+    def test_replay_match_applies_expectation_env_to_invocation_and_response(
+        self, tmp_path: Path
+    ) -> None:
+        """Replay matches should still apply expectation env semantics."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        spy = mox.spy("git").with_env({"EXPECT_ENV": "VALUE"}).replay(fixture_path)
+        invocation = Invocation(command="git", args=["status"], stdin="", env={})
+
+        response = mox._handle_invocation(invocation)
+
+        assert response.stdout == "ok\n"
+        assert response.env["EXPECT_ENV"] == "VALUE"
+        assert invocation.env["EXPECT_ENV"] == "VALUE"
+        assert spy.invocations == [invocation]
+        assert list(mox.journal) == [invocation]
+
+    def test_replay_match_rejects_conflicting_expectation_env(
+        self, tmp_path: Path
+    ) -> None:
+        """Replay matches should reject conflicting invocation environment."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        spy = mox.spy("git").with_env({"EXPECT_ENV": "VALUE"}).replay(fixture_path)
+        invocation = Invocation(
+            command="git",
+            args=["status"],
+            stdin="",
+            env={"EXPECT_ENV": "DIFF"},
+        )
+
+        with pytest.raises(UnexpectedCommandError, match="conflicting environment"):
+            mox._handle_invocation(invocation)
+
+        assert spy.invocations == []
+        assert len(mox.journal) == 0
+
     def test_handle_invocation_records_replay_match_in_spy_and_journal(
         self, tmp_path: Path
     ) -> None:
@@ -96,5 +133,27 @@ class TestControllerReplayIntegration:
         response = mox._handle_invocation(invocation)
 
         assert response.stdout == "fallback"
+        assert spy.invocations == [invocation]
+        assert list(mox.journal) == [invocation]
+
+    def test_fuzzy_replay_mismatch_falls_back_to_dynamic_handler(
+        self, tmp_path: Path
+    ) -> None:
+        """Fuzzy replay should fall back to the spy handler when no match exists."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        handler_calls: list[Invocation] = []
+
+        def handler(invocation: Invocation) -> Response:
+            handler_calls.append(invocation)
+            return Response(stdout="handler-fallback", stderr="", exit_code=0)
+
+        spy = mox.spy("git").runs(handler).replay(fixture_path, strict=False)
+        invocation = Invocation(command="git", args=["commit"], stdin="", env={})
+
+        response = mox._handle_invocation(invocation)
+
+        assert handler_calls == [invocation]
+        assert response.stdout == "handler-fallback"
         assert spy.invocations == [invocation]
         assert list(mox.journal) == [invocation]

--- a/cmd_mox/unittests/test_controller_replay.py
+++ b/cmd_mox/unittests/test_controller_replay.py
@@ -1,0 +1,100 @@
+"""Unit tests for controller replay integration in ``_make_response()``."""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from cmd_mox.controller import CmdMox
+from cmd_mox.errors import UnexpectedCommandError
+from cmd_mox.ipc import Invocation, Response
+from tests.helpers.fixtures import write_minimal_replay_fixture
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestControllerReplayIntegration:
+    """Replay-backed controller dispatch should use fixture responses."""
+
+    def test_replay_match_uses_fixture_response_before_static_fallback(
+        self, tmp_path: Path
+    ) -> None:
+        """A replay match should win over a spy's configured static response."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        spy = mox.spy("git").returns(stdout="fallback").replay(fixture_path)
+        invocation = Invocation(command="git", args=["status"], stdin="", env={})
+
+        response = mox._make_response(invocation)
+
+        assert response.stdout == "ok\n"
+        assert invocation.stdout == "ok\n"
+        assert spy.invocations == [invocation]
+
+    def test_replay_match_bypasses_dynamic_handler(self, tmp_path: Path) -> None:
+        """A replay match should not call the spy's dynamic handler."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        handler_calls: list[Invocation] = []
+
+        def handler(invocation: Invocation) -> Response:
+            handler_calls.append(invocation)
+            return Response(stdout="handler", stderr="", exit_code=0)
+
+        mox.spy("git").runs(handler).replay(fixture_path)
+        invocation = Invocation(command="git", args=["status"], stdin="", env={})
+
+        response = mox._make_response(invocation)
+
+        assert response.stdout == "ok\n"
+        assert handler_calls == []
+
+    def test_handle_invocation_records_replay_match_in_spy_and_journal(
+        self, tmp_path: Path
+    ) -> None:
+        """Replay-backed responses should still update spy history and journal."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        spy = mox.spy("git").replay(fixture_path)
+        invocation = Invocation(command="git", args=["status"], stdin="", env={})
+
+        response = mox._handle_invocation(invocation)
+
+        assert response.stdout == "ok\n"
+        assert spy.invocations == [invocation]
+        assert list(mox.journal) == [invocation]
+        assert spy.call_count == 1
+
+    def test_strict_replay_mismatch_raises_without_recording(
+        self, tmp_path: Path
+    ) -> None:
+        """Strict replay should fail immediately when no fixture entry matches."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        spy = mox.spy("git").returns(stdout="fallback").replay(fixture_path)
+        invocation = Invocation(command="git", args=["commit"], stdin="", env={})
+
+        with pytest.raises(UnexpectedCommandError, match="No fixture recording"):
+            mox._handle_invocation(invocation)
+
+        assert spy.invocations == []
+        assert len(mox.journal) == 0
+
+    def test_fuzzy_replay_mismatch_falls_back_to_spy_response(
+        self, tmp_path: Path
+    ) -> None:
+        """Fuzzy replay should fall back to the spy response when no match exists."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        spy = (
+            mox.spy("git").returns(stdout="fallback").replay(fixture_path, strict=False)
+        )
+        invocation = Invocation(command="git", args=["commit"], stdin="", env={})
+
+        response = mox._handle_invocation(invocation)
+
+        assert response.stdout == "fallback"
+        assert spy.invocations == [invocation]
+        assert list(mox.journal) == [invocation]

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -252,7 +252,7 @@ supports deterministic replay without external dependencies. See
   matching, and best-fit score selection.
 - [x] 12.2.3. Add `.replay()` to `CommandDouble`, including passthrough
   incompatibility validation and strict-mode option.
-- [ ] 12.2.4. Integrate replay into `CmdMox._make_response()` and raise
+- [x] 12.2.4. Integrate replay into `CmdMox._make_response()` and raise
   `UnexpectedCommandError` for unmatched strict replay invocations.
 - [ ] 12.2.5. Extend `CmdMox.verify()` to report unconsumed recordings.
 - [ ] 12.2.6. Add unit tests for fixture loading, matcher behaviour, and

--- a/docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md
+++ b/docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md
@@ -1,0 +1,435 @@
+# Integrate replay into `CmdMox._make_response()`
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap item `12.2.4` is the first point where replay fixtures stop being
+configuration-only and start affecting live command execution. `12.2.3`
+already lets a test author write
+`cmd_mox.spy("git").replay("fixtures/git_clone.json")`, but the controller
+still ignores the attached `ReplaySession` and continues using the spy's normal
+response or handler. This task wires replay into
+`cmd_mox.controller.CmdMox._make_response()` so replay-enabled spies actually
+serve recorded responses during the replay phase.
+
+The user-visible behaviour after implementation is:
+
+1. A replay-enabled spy consults its attached `ReplaySession` before the normal
+   spy response or handler path.
+2. When the fixture contains a matching recording, the recorded
+   `stdout` / `stderr` / exit code are returned and the invocation is still
+   visible in the spy's history and the controller journal.
+3. When strict replay is enabled and no recording matches, the invocation fails
+   immediately with `UnexpectedCommandError` instead of silently falling
+   through and only failing later during `verify()`.
+4. When fuzzy replay is enabled and no recording matches, the controller falls
+   back to the spy's existing response/handler behaviour.
+5. Unit tests written with `pytest` fail before the code change and pass after
+   it.
+6. Behavioural tests written with `pytest-bdd` demonstrate the consumer-facing
+   replay flow.
+7. `docs/python-native-command-mocking-design.md` records the final controller
+   integration decision, `docs/usage-guide.md` explains the new runtime
+   behaviour, and `docs/cmd-mox-roadmap.md` marks `12.2.4` done.
+8. The full quality gates pass:
+
+```bash
+set -o pipefail
+make markdownlint 2>&1 | tee /tmp/12-2-4-markdownlint.log
+```
+
+```bash
+set -o pipefail
+make nixie 2>&1 | tee /tmp/12-2-4-nixie.log
+```
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/12-2-4-check-fmt.log
+```
+
+```bash
+set -o pipefail
+make typecheck 2>&1 | tee /tmp/12-2-4-typecheck.log
+```
+
+```bash
+set -o pipefail
+make lint 2>&1 | tee /tmp/12-2-4-lint.log
+```
+
+```bash
+set -o pipefail
+make test 2>&1 | tee /tmp/12-2-4-test.log
+```
+
+This plan is draft-only. Implementation must not begin until the user
+explicitly approves it.
+
+## Repository orientation
+
+The implementation seam is concentrated in the controller, but the surrounding
+pieces already exist:
+
+- `cmd_mox/test_doubles.py` already provides the spy-only fluent
+  `.replay(fixture_path, *, strict=True)` API and stores a loaded
+  `ReplaySession` on `CommandDouble._replay_session`.
+- `cmd_mox/record/replay.py` already loads fixtures, delegates matching to
+  `InvocationMatcher`, marks recordings as consumed, and returns
+  `Response | None` from `ReplaySession.match()`.
+- `cmd_mox/controller.py` currently has no replay-aware branch in
+  `_make_response()`. Its existing strategies are "missing double",
+  "passthrough", and "regular". Spy invocation history is only updated inside
+  `_response_for_regular()` and `_handle_passthrough_result()`.
+- `docs/usage-guide.md` already documents `.replay()` setup, but it does not
+  yet describe the controller's runtime replay behaviour because that behaviour
+  is not implemented.
+- `docs/python-native-command-mocking-design.md` already contains a draft
+  controller integration sketch in section `9.8.3`, so this task should align
+  the shipped code with that design and record any final clarifications.
+- Existing behavioural controller coverage lives in
+  `features/controller.feature`, `tests/steps/controller_setup.py`,
+  `tests/steps/command_execution.py`, and `tests/test_controller_bdd.py`.
+- Existing replay fixture helpers live in `tests/helpers/fixtures.py`.
+
+The follow-on roadmap item `12.2.5` extends `CmdMox.verify()` to check for
+unconsumed recordings. That verification work is explicitly out of scope here.
+
+## Constraints
+
+- Follow the repository test-driven development workflow from `AGENTS.md`:
+  update tests first, confirm they fail, then implement the production change,
+  then rerun focused tests and the full quality gates.
+- Keep roadmap boundaries intact. `12.2.4` only integrates replay into
+  `CmdMox._make_response()` and introduces the strict-unmatched failure path.
+  Do not add replay-consumption verification to `CmdMox.verify()` in this
+  change.
+- Preserve the public APIs already shipped in `ReplaySession`,
+  `InvocationMatcher`, and `CommandDouble.replay()`.
+- Do not change fixture schema semantics, matching rules, or the meaning of
+  strict versus fuzzy replay. Those were established by `12.2.1` through
+  `12.2.3`.
+- Replay-backed invocations must still populate the spy's `invocations` list
+  and the controller journal so existing spy assertions remain meaningful.
+- Strict replay misses must raise `UnexpectedCommandError` during invocation
+  handling. Fuzzy replay misses must not raise solely because the fixture did
+  not match; they must fall through to the spy's normal response/handler path.
+- No new dependencies.
+- Keep unit tests under `cmd_mox/unittests/` and behavioural tests under
+  `features/`, `tests/steps/`, and `tests/test_*_bdd.py`.
+- Update consumer-facing docs in `docs/usage-guide.md` and record any final
+  design decisions in `docs/python-native-command-mocking-design.md`.
+- Mark roadmap item `12.2.4` done only after the implementation and all
+  quality gates succeed.
+- Required gates for completion are `make markdownlint`, `make nixie`,
+  `make check-fmt`, `make typecheck`, `make lint`, and `make test`.
+
+## Tolerances
+
+- Scope tolerance: stop and escalate if `12.2.4` appears to require extending
+  `CmdMox.verify()` beyond comments or helper extraction. That is `12.2.5`.
+- Controller tolerance: stop and escalate if replay integration cannot be
+  implemented with a focused controller change plus tests and docs. If the work
+  starts pulling in IPC protocol changes, shim protocol changes, or fixture
+  schema changes, confirm direction before proceeding.
+- Error-surface tolerance: unit tests should assert the exact
+  `UnexpectedCommandError` type in-process. Behavioural tests should verify the
+  user-visible failure mode exposed by the current transport. If surfacing the
+  raw exception class through subprocess execution would require a protocol
+  redesign, do not expand the scope to do that here.
+- File-count tolerance: stop and escalate if the implementation needs more than
+  10 touched files of Python code or more than 450 net new Python lines outside
+  tests. This item should be controller wiring, not replay architecture churn.
+- Quality-gate tolerance: if any required gate still fails after 3 focused fix
+  attempts, capture the failing command and log file path in
+  `Surprises & Discoveries` and pause for guidance.
+
+## Risks
+
+- Risk: the current controller strategy split does not include replay, so a
+  naive early return can bypass spy bookkeeping. Mitigation: test and implement
+  replay through a helper that appends to `double.invocations` before returning
+  the matched `Response`.
+- Risk: strict replay mismatch now fails at invocation time, which shifts one
+  class of failure earlier than the rest of CmdMox's verification model.
+  Mitigation: document that this is intentional and cover it in both unit tests
+  and the usage guide.
+- Risk: fuzzy replay mismatch semantics are easy to leave ambiguous. Mitigation:
+  add a test that proves fuzzy replay falls back to the configured spy
+  response/handler instead of raising.
+- Risk: behavioural tests that go through the shim may observe a transport-level
+  error string rather than a raw Python exception type. Mitigation: keep the
+  exact exception-type assertions in unit tests and keep BDD expectations at
+  the user-visible behaviour level.
+- Risk: `12.2.5` will later add `verify_all_consumed()` calls. Mitigation:
+  avoid any implementation shortcuts in `12.2.4` that would make replay
+  sessions look "consumed" without actually going through `ReplaySession.match()`.
+
+## Progress
+
+- [x] Review `AGENTS.md`, the `execplans` skill, the record-mode roadmap
+  entries, and the existing `12.2.1` to `12.2.3` ExecPlans.
+- [x] Inspect the current controller, replay session, double API, usage guide,
+  and controller BDD scaffolding.
+- [x] Draft this ExecPlan in
+  `docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md`.
+- [ ] Obtain explicit user approval for this plan before implementation.
+- [ ] Add or update unit tests for controller replay integration before
+  touching production code.
+- [ ] Add or update `pytest-bdd` scenarios that exercise replay-backed command
+  execution behaviour.
+- [ ] Implement replay-aware response selection in `cmd_mox/controller.py`.
+- [ ] Update the design doc, usage guide, and roadmap.
+- [ ] Run all required quality gates and record the results in this document if
+  the plan moves into execution.
+
+## Surprises & Discoveries
+
+- `CommandDouble.replay()` is already shipped and eagerly loads fixtures, so
+  the missing work here is purely controller dispatch and its test coverage.
+- `CmdMox._make_response()` currently handles only three cases: no double,
+  passthrough spy, and regular stub/mock/spy handling. Replay is not modelled
+  anywhere in that control flow.
+- Spy bookkeeping is split across two places today:
+  `_response_for_regular()` appends invocations for non-passthrough doubles,
+  while `_handle_passthrough_result()` appends invocations and journal entries
+  after real-command execution. A replay path must preserve equivalent
+  bookkeeping.
+- The controller journal is populated in `_handle_invocation()` after
+  `_make_response()` returns. A strict replay mismatch that raises inside
+  `_make_response()` will therefore leave no journal entry, which is the
+  correct behaviour for an immediately-failed invocation.
+- The design doc already sketches the desired `_make_response()` replay branch,
+  but it does not explicitly call out spy invocation-history bookkeeping. This
+  plan makes that requirement explicit.
+
+## Decision Log
+
+- Decision: implement replay as an explicit controller branch ahead of the
+  existing "regular" response logic. The controller should check whether the
+  resolved double has an attached replay session before selecting the normal
+  response strategy.
+
+- Decision: keep `ReplaySession.match()` as the single source of truth for
+  replay matching and consumption. The controller must not duplicate matching
+  logic or mutate replay-consumption state directly.
+
+- Decision: when `ReplaySession.match()` returns a `Response`, treat the
+  invocation as a normal spy call for bookkeeping purposes by appending the
+  invocation to `double.invocations`. Journal appending can remain in
+  `_handle_invocation()` because that path already runs for non-passthrough
+  responses.
+
+- Decision: when `ReplaySession.match()` returns `None` and the session is in
+  strict mode, raise `UnexpectedCommandError` immediately with a message that
+  includes the command and arguments. This makes strict replay mismatches fail
+  at the actual invocation site rather than later during verification.
+
+- Decision: when `ReplaySession.match()` returns `None` and the session is in
+  fuzzy mode, fall through to the existing spy response/handler path. This
+  keeps fuzzy replay additive rather than making it all-or-nothing.
+
+- Decision: keep `CmdMox.verify()` unchanged in this roadmap item, aside from
+  any comment updates needed to clarify that replay-consumption verification is
+  still pending in `12.2.5`.
+
+## Plan of work
+
+### Stage A: Write failing unit tests first
+
+Create or extend a controller-focused unit test file under
+`cmd_mox/unittests/`. The cleanest option is a dedicated file such as
+`cmd_mox/unittests/test_controller_replay.py` so replay integration stays easy
+to find and does not get buried in unrelated handler or passthrough tests.
+
+Write tests that cover at least these behaviours:
+
+1. A replay-enabled spy returns the fixture-backed `Response` for a matching
+   invocation.
+2. A matched replay invocation is appended to `spy.invocations`.
+3. A matched replay invocation reaches the journal when driven through
+   `_handle_invocation()`.
+4. Strict replay mismatch raises `UnexpectedCommandError` immediately.
+5. A strict replay mismatch does not append to `spy.invocations` or the
+   journal.
+6. Fuzzy replay mismatch falls back to the configured spy response or handler
+   instead of raising.
+7. A replay-backed match takes precedence over a configured spy
+   `.returns(...)` or `.runs(...)` response.
+8. A double without replay continues using the existing behaviour unchanged.
+
+Use `tests/helpers/fixtures.py` where possible for valid fixture creation. Add a
+small purpose-built fixture helper only if the existing `git status` fixture is
+too narrow for the new controller cases.
+
+Run the focused unit tests before implementation and confirm they fail:
+
+```bash
+set -o pipefail
+pytest cmd_mox/unittests/test_controller_replay.py -q 2>&1 | tee /tmp/12-2-4-unit-red.log
+```
+
+If the tests live in an existing file instead, adjust the command accordingly
+and record that change in `Decision Log`.
+
+### Stage B: Write failing behavioural tests
+
+Extend the consumer-visible controller behaviour through `pytest-bdd`. The
+lowest-friction location is the existing controller feature suite:
+
+- add replay scenarios to `features/controller.feature`;
+- add any new step definitions in a focused file such as
+  `tests/steps/controller_replay.py` or extend the existing controller step
+  modules only where the new steps clearly belong;
+- register the new scenarios in `tests/test_controller_bdd.py`.
+
+Cover at least these scenarios:
+
+1. A replay-enabled spy serves the recorded response during command execution.
+2. A replay-backed invocation is visible through the spy's recorded call count
+   or the controller journal after verification.
+3. A strict replay mismatch fails during invocation handling rather than only
+   during `verify()`.
+
+Keep the BDD assertions consumer-facing. For example, a success-path scenario
+should drive a real shimmed command and assert on its stdout and the spy/journal
+state. For the strict-mismatch scenario, it is acceptable for the step to
+exercise the controller directly if that is the most stable way to assert the
+timing and error type without expanding the IPC protocol.
+
+Run the focused behavioural coverage before implementation and confirm failure:
+
+```bash
+set -o pipefail
+pytest tests/test_controller_bdd.py -k replay -q 2>&1 | tee /tmp/12-2-4-bdd-red.log
+```
+
+### Stage C: Implement replay-aware controller dispatch
+
+Update `cmd_mox/controller.py` with the smallest change that makes the tests
+pass cleanly and keeps the controller easy to read.
+
+The recommended implementation shape is:
+
+1. Add a small helper such as `_response_for_replay(...)` or equivalent inline
+   logic in `_make_response()`.
+2. Resolve the double from `self._doubles` as today.
+3. If no double exists, keep the existing missing-double path unchanged.
+4. If the double has an attached replay session:
+   - call `double.replay_session.match(invocation)`;
+   - when a `Response` is returned, append the invocation to
+     `double.invocations` and return that response;
+   - when `None` is returned and `strict_matching` is `True`, raise
+     `UnexpectedCommandError` with a message that includes enough invocation
+     detail to debug the mismatch;
+   - when `None` is returned and `strict_matching` is `False`, fall through to
+     the existing response logic.
+5. Preserve the current passthrough and regular paths for all non-replay
+   doubles.
+6. Do not add `verify_all_consumed()` calls here.
+
+After the code change, rerun the focused unit and behavioural tests:
+
+```bash
+set -o pipefail
+pytest cmd_mox/unittests/test_controller_replay.py -q 2>&1 | tee /tmp/12-2-4-unit-green.log
+```
+
+```bash
+set -o pipefail
+pytest tests/test_controller_bdd.py -k replay -q 2>&1 | tee /tmp/12-2-4-bdd-green.log
+```
+
+### Stage D: Update documentation and roadmap
+
+Update the docs in the same change so the shipped behaviour and the written
+contract stay aligned.
+
+In `docs/python-native-command-mocking-design.md`:
+
+1. Confirm section `9.8.3` matches the final controller code shape.
+2. Add a new decision entry after `9.10.14` capturing the final strict-miss and
+   spy-bookkeeping rules if those details are not already covered elsewhere.
+
+In `docs/usage-guide.md`:
+
+1. Extend the `.replay()` section to explain that attached replay sessions are
+   now consulted during live command execution.
+2. Document the strict mismatch behaviour explicitly.
+3. Document the fuzzy fallback behaviour explicitly so consumers know replay is
+   best-effort in fuzzy mode.
+
+In `docs/cmd-mox-roadmap.md`:
+
+1. Change `12.2.4` from `[ ]` to `[x]` only after the implementation and all
+   gates succeed.
+
+### Stage E: Run the full quality gates
+
+After the code and documentation changes are complete, run the full required
+gates with `tee` logging:
+
+```bash
+set -o pipefail
+make markdownlint 2>&1 | tee /tmp/12-2-4-markdownlint.log
+```
+
+```bash
+set -o pipefail
+make nixie 2>&1 | tee /tmp/12-2-4-nixie.log
+```
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/12-2-4-check-fmt.log
+```
+
+```bash
+set -o pipefail
+make typecheck 2>&1 | tee /tmp/12-2-4-typecheck.log
+```
+
+```bash
+set -o pipefail
+make lint 2>&1 | tee /tmp/12-2-4-lint.log
+```
+
+```bash
+set -o pipefail
+make test 2>&1 | tee /tmp/12-2-4-test.log
+```
+
+If any gate fails, fix the regression and rerun the affected command until all
+six pass. Record noteworthy failures in `Surprises & Discoveries`.
+
+## Validation and acceptance
+
+The implementation is complete when all of the following are true:
+
+1. `cmd_mox.spy("git").replay("fixture.json")` actually replays the fixture
+   during command execution.
+2. A strict replay mismatch raises `UnexpectedCommandError` at invocation time.
+3. A fuzzy replay mismatch falls back to the configured spy response/handler.
+4. Replay-backed spy calls are reflected in `spy.invocations` and in the
+   controller journal.
+5. Unit tests and behavioural tests covering the new behaviour pass.
+6. `docs/usage-guide.md` describes the runtime replay behaviour for library
+   consumers.
+7. `docs/python-native-command-mocking-design.md` records the final controller
+   integration decision.
+8. `docs/cmd-mox-roadmap.md` marks `12.2.4` done.
+9. `make markdownlint`, `make nixie`, `make check-fmt`, `make typecheck`,
+   `make lint`, and `make test` all pass.
+
+## Outcomes & Retrospective
+
+This section is intentionally blank during the draft phase. When implementation
+completes, replace this note with a concise summary of what shipped, which tests
+proved it, which quality gates passed, and what follow-on work remains for
+`12.2.5`.

--- a/docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md
+++ b/docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md
@@ -5,13 +5,13 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
 Roadmap item `12.2.4` is the first point where replay fixtures stop being
-configuration-only and start affecting live command execution. `12.2.3`
-already lets a test author write
+configuration-only and start affecting live command execution. `12.2.3` already
+lets a test author write
 `cmd_mox.spy("git").replay("fixtures/git_clone.json")`, but the controller
 still ignores the attached `ReplaySession` and continues using the spy's normal
 response or handler. This task wires replay into
@@ -169,7 +169,8 @@ unconsumed recordings. That verification work is explicitly out of scope here.
   the user-visible behaviour level.
 - Risk: `12.2.5` will later add `verify_all_consumed()` calls. Mitigation:
   avoid any implementation shortcuts in `12.2.4` that would make replay
-  sessions look "consumed" without actually going through `ReplaySession.match()`.
+  sessions look "consumed" without actually going through
+  `ReplaySession.match()`.
 
 ## Progress
 
@@ -179,14 +180,14 @@ unconsumed recordings. That verification work is explicitly out of scope here.
   and controller BDD scaffolding.
 - [x] Draft this ExecPlan in
   `docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md`.
-- [ ] Obtain explicit user approval for this plan before implementation.
-- [ ] Add or update unit tests for controller replay integration before
+- [x] Obtain explicit user approval for this plan before implementation.
+- [x] Add or update unit tests for controller replay integration before
   touching production code.
-- [ ] Add or update `pytest-bdd` scenarios that exercise replay-backed command
+- [x] Add or update `pytest-bdd` scenarios that exercise replay-backed command
   execution behaviour.
-- [ ] Implement replay-aware response selection in `cmd_mox/controller.py`.
-- [ ] Update the design doc, usage guide, and roadmap.
-- [ ] Run all required quality gates and record the results in this document if
+- [x] Implement replay-aware response selection in `cmd_mox/controller.py`.
+- [x] Update the design doc, usage guide, and roadmap.
+- [x] Run all required quality gates and record the results in this document if
   the plan moves into execution.
 
 ## Surprises & Discoveries
@@ -208,6 +209,10 @@ unconsumed recordings. That verification work is explicitly out of scope here.
 - The design doc already sketches the desired `_make_response()` replay branch,
   but it does not explicitly call out spy invocation-history bookkeeping. This
   plan makes that requirement explicit.
+- Focused red-phase test runs need
+  `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools`
+  `uv run pytest ...` rather than plain `pytest`, because the repo does not put
+  the virtualenv binaries directly on `PATH`.
 
 ## Decision Log
 
@@ -239,6 +244,11 @@ unconsumed recordings. That verification work is explicitly out of scope here.
   any comment updates needed to clarify that replay-consumption verification is
   still pending in `12.2.5`.
 
+- Decision: keep replay handling as a dedicated helper branch in
+  `cmd_mox/controller.py` rather than extending `_ResponseStrategy`. Replay is
+  an overlay on top of the existing regular path, and the helper keeps the diff
+  small while still making the precedence rules explicit.
+
 ## Plan of work
 
 ### Stage A: Write failing unit tests first
@@ -264,9 +274,9 @@ Write tests that cover at least these behaviours:
    `.returns(...)` or `.runs(...)` response.
 8. A double without replay continues using the existing behaviour unchanged.
 
-Use `tests/helpers/fixtures.py` where possible for valid fixture creation. Add a
-small purpose-built fixture helper only if the existing `git status` fixture is
-too narrow for the new controller cases.
+Use `tests/helpers/fixtures.py` where possible for valid fixture creation. Add
+a small purpose-built fixture helper only if the existing `git status` fixture
+is too narrow for the new controller cases.
 
 Run the focused unit tests before implementation and confirm they fail:
 
@@ -298,10 +308,10 @@ Cover at least these scenarios:
    during `verify()`.
 
 Keep the BDD assertions consumer-facing. For example, a success-path scenario
-should drive a real shimmed command and assert on its stdout and the spy/journal
-state. For the strict-mismatch scenario, it is acceptable for the step to
-exercise the controller directly if that is the most stable way to assert the
-timing and error type without expanding the IPC protocol.
+should drive a real shimmed command and assert on its stdout and the
+spy/journal state. For the strict-mismatch scenario, it is acceptable for the
+step to exercise the controller directly if that is the most stable way to
+assert the timing and error type without expanding the IPC protocol.
 
 Run the focused behavioural coverage before implementation and confirm failure:
 
@@ -429,7 +439,57 @@ The implementation is complete when all of the following are true:
 
 ## Outcomes & Retrospective
 
-This section is intentionally blank during the draft phase. When implementation
-completes, replace this note with a concise summary of what shipped, which tests
-proved it, which quality gates passed, and what follow-on work remains for
-`12.2.5`.
+Implementation completed successfully.
+
+What shipped:
+
+1. `CmdMox._make_response()` now consults an attached replay session before the
+   normal spy response/handler path.
+2. Matched replay invocations are recorded in `double.invocations`, and
+   `_handle_invocation()` continues to record them in the controller journal.
+3. Strict replay mismatches now raise `UnexpectedCommandError` immediately with
+   a `"No fixture recording matches: ..."` message.
+4. Fuzzy replay mismatches now fall back to the spy's configured
+   response/handler path instead of raising.
+5. The usage guide, design doc, roadmap, and this ExecPlan were updated to
+   reflect the final behaviour.
+
+Evidence:
+
+- New unit coverage in `cmd_mox/unittests/test_controller_replay.py`
+  exercises replay precedence, handler bypass, spy/journal bookkeeping, strict
+  mismatch failure, and fuzzy fallback.
+- New behavioural scenarios in `features/controller.feature` and
+  `tests/steps/controller_replay.py` exercise replay-backed command execution,
+  strict invocation-time failure, and fuzzy fallback behaviour.
+- Focused green runs:
+
+  ```plaintext
+  5 passed in 0.04s
+  6 passed, 28 deselected in 1.89s
+  ```
+
+- Full quality gates passed:
+
+  ```plaintext
+  make markdownlint
+  Summary: 0 error(s)
+
+  make nixie
+  All diagrams validated successfully
+
+  make check-fmt
+  133 files already formatted
+
+  make typecheck
+  All checks passed!
+
+  make lint
+  All checks passed!
+
+  make test
+  729 passed, 12 skipped
+  ```
+
+Follow-on work remains in roadmap item `12.2.5`, which will extend
+`CmdMox.verify()` to report unconsumed replay recordings.

--- a/docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md
+++ b/docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md
@@ -69,9 +69,6 @@ set -o pipefail
 make test 2>&1 | tee /tmp/12-2-4-test.log
 ```
 
-This plan is draft-only. Implementation must not begin until the user
-explicitly approves it.
-
 ## Repository orientation
 
 The implementation seam is concentrated in the controller, but the surrounding
@@ -136,8 +133,9 @@ unconsumed recordings. That verification work is explicitly out of scope here.
   `CmdMox.verify()` beyond comments or helper extraction. That is `12.2.5`.
 - Controller tolerance: stop and escalate if replay integration cannot be
   implemented with a focused controller change plus tests and docs. If the work
-  starts pulling in IPC protocol changes, shim protocol changes, or fixture
-  schema changes, confirm direction before proceeding.
+  starts pulling in inter-process communication (IPC) protocol changes, shim
+  protocol changes, or fixture schema changes, confirm direction before
+  proceeding.
 - Error-surface tolerance: unit tests should assert the exact
   `UnexpectedCommandError` type in-process. Behavioural tests should verify the
   user-visible failure mode exposed by the current transport. If surfacing the

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -2194,10 +2194,11 @@ Matching modes:
 
 Best-fit scoring:
 
-The matcher computes a stats tuple `(stdin_match, matching_env_pairs,
-env_subset_size)` for each compatible recording and selects the highest-scoring
-candidate. When two candidates have identical stats, the one with the lower
-`sequence` value wins. This ensures deterministic selection that prioritises:
+The matcher computes a stats tuple
+`(stdin_match, matching_env_pairs, env_subset_size)` for each compatible
+recording and selects the highest-scoring candidate. When two candidates have
+identical stats, the one with the lower `sequence` value wins. This ensures
+deterministic selection that prioritises:
 
 1. Exact stdin match (True > False)
 2. Number of matching environment pairs (higher is better)
@@ -2343,13 +2344,13 @@ spy = cmd_mox.spy("git").replay("fixtures/git_clone.json", strict=False)
 
 <!-- markdownlint-disable MD013 -->
 
-| Method                                      | Purpose                             | Example                                           |
-| ------------------------------------------- | ----------------------------------- | ------------------------------------------------- |
-| `.record(path, *, scrubber, env_allowlist)` | Enable recording on passthrough spy | `.record("fixtures/git.json")`                    |
-| `.replay(path, *, strict)`                  | Load fixture and replay responses on a spy | `.replay("fixtures/git.json")`             |
-| `Scrubber()`                                | Create scrubber with default rules  | `Scrubber()`                                      |
-| `Scrubber.add_rule(rule)`                   | Add custom scrubbing rule           | `scrubber.add_rule(rule)`                         |
-| `ScrubbingRule(pattern, replacement)`       | Define a scrubbing pattern          | `ScrubbingRule(r"token=\S+", "token=<REDACTED>")` |
+| Method                                      | Purpose                                    | Example                                           |
+| ------------------------------------------- | ------------------------------------------ | ------------------------------------------------- |
+| `.record(path, *, scrubber, env_allowlist)` | Enable recording on passthrough spy        | `.record("fixtures/git.json")`                    |
+| `.replay(path, *, strict)`                  | Load fixture and replay responses on a spy | `.replay("fixtures/git.json")`                    |
+| `Scrubber()`                                | Create scrubber with default rules         | `Scrubber()`                                      |
+| `Scrubber.add_rule(rule)`                   | Add custom scrubbing rule                  | `scrubber.add_rule(rule)`                         |
+| `ScrubbingRule(pattern, replacement)`       | Define a scrubbing pattern                 | `ScrubbingRule(r"token=\S+", "token=<REDACTED>")` |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -2523,32 +2524,24 @@ class CmdMox:
         double = self._doubles.get(invocation.command)
 
         # Check for replay session before other strategies
-        if double and double._replay_session:
-            matched = double._replay_session.match(invocation)
+        if double and double.replay_session:
+            matched = double.replay_session.match(invocation)
             if matched:
+                double.invocations.append(invocation)
                 return matched
-            if double._replay_session.strict_matching:
+            if double.replay_session.strict_matching:
                 raise UnexpectedCommandError(
-                    f"No fixture recording matches: {invocation}"
+                    f"No fixture recording matches: {invocation.command}"
                 )
+            return self._response_for_regular(double, invocation)
 
         # Fall through to existing logic
         return self._make_response_original(invocation)
-
-    def verify(self) -> None:
-        """Extended verification including replay consumption checks."""
-        # ... existing verification ...
-
-        # Verify all replay recordings were consumed
-        for name, double in self._doubles.items():
-            if double._replay_session:
-                double._replay_session.verify_all_consumed()
-
-        # Finalize any active recording sessions
-        for name, double in self._doubles.items():
-            if double._recording_session and not double._recording_session._finalized:
-                double._recording_session.finalize()
 ```
+
+Replay integration in `_make_response()` is intentionally separate from replay
+consumption verification in `verify()`. The former is roadmap item `12.2.4`;
+the latter remains `12.2.5`.
 
 ### 9.9 Security Considerations
 
@@ -2838,8 +2831,7 @@ the most appropriate recording when multiple candidates qualify.
 
 **Decision:** Implement `CommandDouble.replay()` as a spy-only fluent API that
 constructs and immediately loads a `ReplaySession`, and expose the attached
-session through read-only `has_replay_session` and `replay_session`
-properties.
+session through read-only `has_replay_session` and `replay_session` properties.
 
 **Rationale:**
 
@@ -2859,6 +2851,35 @@ properties.
   justifies
 - **Lazy loading on first command invocation:** Rejected because it delays
   validation and makes fixture problems harder to localise
+
+#### 9.10.15 Replay-backed controller dispatch and strict-miss handling
+
+**Decision:** When a spy has an attached replay session,
+`CmdMox._make_response()` consults that replay session before the spy's normal
+response or handler path. Matched replay invocations are recorded in the spy
+history, strict misses raise `UnexpectedCommandError` immediately, and fuzzy
+misses fall back to the spy's configured behaviour.
+
+**Rationale:**
+
+- Replay fixtures are intended to drive live command execution, not merely to
+  be attached as inert configuration on the double
+- Recording matched replay invocations in `spy.invocations` keeps spy
+  assertions and journal inspection consistent with the existing non-replay spy
+  behaviour
+- Raising immediately on strict mismatches surfaces the failure at the exact
+  invocation that violated the fixture contract
+- Allowing fuzzy mismatches to fall back keeps fuzzy replay additive and useful
+  for partial-fixture scenarios
+
+**Alternatives considered:**
+
+- **Delay strict replay failures until `verify()`:** Rejected because that
+  hides the failing invocation behind later verification work and weakens the
+  strict replay contract
+- **Treat fuzzy replay as all-or-nothing:** Rejected because it makes fuzzy
+  replay much less useful for tests that only fixture a subset of command
+  variants
 
 ### 9.11 Versioning and Forward Compatibility
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -526,6 +526,12 @@ Calling `.replay()` loads the fixture immediately. Missing files, malformed
 JSON, and schema-version errors therefore fail the test during setup rather
 than later during command execution.
 
+Once replay mode is active on the controller, CmdMox consults the attached
+replay session before the spy's normal `.returns(...)` or `.runs(...)`
+behaviour. When a fixture recording matches, the recorded `stdout`, `stderr`,
+and exit code are returned, and the invocation still appears in both
+`spy.invocations` and `cmd_mox.journal`.
+
 ### Parameters
 
 - **`fixture_path`** (`str | Path`): path to the JSON fixture file to load.
@@ -548,6 +554,11 @@ cmd_mox.spy("git").passthrough().replay("fixtures/git.json")
 Calling `.replay()` more than once on the same double raises `RuntimeError`.
 The attached session is available via the read-only `replay_session` property,
 and `has_replay_session` reports whether a session has been attached.
+
+If strict replay is enabled and no fixture recording matches the live
+invocation, CmdMox raises `UnexpectedCommandError` immediately during command
+handling. If fuzzy replay is enabled and no fixture recording matches, CmdMox
+falls back to the spy's configured response or handler instead of raising.
 
 ### Creating and loading a replay session
 
@@ -583,11 +594,11 @@ if response is not None:
     print(response.stdout)  # the recorded stdout
 ```
 
-`match()` searches the loaded recordings and returns a `Response` built from the
-best-fit unconsumed recording. When multiple recordings qualify, the matcher
-selects the most appropriate one deterministically based on stdin exactness and
-environment specificity. Each matched recording is marked as consumed and will
-not match again.
+`match()` searches the loaded recordings and returns a `Response` built from
+the best-fit unconsumed recording. When multiple recordings qualify, the
+matcher selects the most appropriate one deterministically based on stdin
+exactness and environment specificity. Each matched recording is marked as
+consumed and will not match again.
 
 ### Matching modes
 
@@ -615,8 +626,9 @@ session.load()
 
 ### Best-fit selection
 
-When a fixture contains multiple recordings with the same command and arguments,
-the replay session selects the most appropriate match deterministically:
+When a fixture contains multiple recordings with the same command and
+arguments, the replay session selects the most appropriate match
+deterministically:
 
 **In strict mode**, all recordings must fully match (command, args, stdin, and
 env_subset). When multiple recordings qualify, the matcher prefers the one with:
@@ -633,10 +645,10 @@ recordings, the matcher prefers the one with:
 3. Larger `env_subset`
 4. Lower recording `sequence` value (if scores tie)
 
-This ensures that when the same command is recorded with different contexts (for
-example, `git status` with and without environment variables), replay selects
-the recording that best matches the live invocation rather than always consuming
-the first compatible entry.
+This ensures that when the same command is recorded with different contexts
+(for example, `git status` with and without environment variables), replay
+selects the recording that best matches the live invocation rather than always
+consuming the first compatible entry.
 
 ### Consumed-record tracking
 

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -83,6 +83,17 @@ Feature: CmdMox basic functionality
     Then the spy "git" should record 1 invocation
     And the journal should contain 1 invocation of "git"
 
+  Scenario: replay-backed spy applies expectation environment
+    Given a CmdMox controller
+    And a git replay fixture exists
+    And the command "git" is spied with that replay fixture
+    And the command "git" requires env var "EXPECT_ENV"="VALUE"
+    When I replay the controller
+    And I run the command "git" with arguments "status"
+    Then the output should be "ok"
+    When I verify the controller
+    Then the journal entry for "git" should record arguments "status" stdin "<empty>" env var "EXPECT_ENV"="VALUE"
+
   Scenario: strict replay mismatch fails during invocation handling
     Given a CmdMox controller
     And a git replay fixture exists

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -72,6 +72,37 @@ Feature: CmdMox basic functionality
     When I verify the controller
     Then the spy "hi" should record 1 invocation
 
+  Scenario: replay-backed spy serves recorded response
+    Given a CmdMox controller
+    And a git replay fixture exists
+    And the command "git" is spied with that replay fixture
+    When I replay the controller
+    And I run the command "git" with arguments "status"
+    Then the output should be "ok"
+    When I verify the controller
+    Then the spy "git" should record 1 invocation
+    And the journal should contain 1 invocation of "git"
+
+  Scenario: strict replay mismatch fails during invocation handling
+    Given a CmdMox controller
+    And a git replay fixture exists
+    And the command "git" is spied with that replay fixture
+    When the controller handles the invocation for "git" with arguments "commit" expecting UnexpectedCommandError
+    Then the invocation error message should contain "No fixture recording matches"
+    And the spy "git" should record 0 invocation
+    And the journal should contain 0 invocation of "git"
+
+  Scenario: fuzzy replay mismatch falls back to spy response
+    Given a CmdMox controller
+    And a git replay fixture exists
+    And the command "git" is spied with fuzzy replay and fallback "fallback"
+    When I replay the controller
+    And I run the command "git" with arguments "commit"
+    Then the output should be "fallback"
+    When I verify the controller
+    Then the spy "git" should record 1 invocation
+    And the journal should contain 1 invocation of "git"
+
   Scenario: spy assertion helpers
     Given a CmdMox controller
     And the command "hi" is spied to return "hello"

--- a/tests/steps/__init__.py
+++ b/tests/steps/__init__.py
@@ -3,6 +3,7 @@
 from .assertions import *  # noqa: F403
 from .command_config import *  # noqa: F403
 from .command_execution import *  # noqa: F403
+from .controller_replay import *  # noqa: F403
 from .controller_setup import *  # noqa: F403
 from .documentation import *  # noqa: F403
 from .environment import *  # noqa: F403

--- a/tests/steps/controller_replay.py
+++ b/tests/steps/controller_replay.py
@@ -1,0 +1,71 @@
+"""pytest-bdd steps for controller replay integration scenarios."""
+
+from __future__ import annotations
+
+import shlex
+import typing as t
+
+import pytest
+from pytest_bdd import given, parsers, then, when
+
+from cmd_mox.errors import UnexpectedCommandError
+from cmd_mox.ipc import Invocation
+from tests.helpers.fixtures import write_minimal_replay_fixture
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
+
+    from cmd_mox.controller import CmdMox
+
+
+@given("a git replay fixture exists", target_fixture="git_replay_fixture_path")
+def git_replay_fixture(tmp_path: Path) -> Path:
+    """Create a replay fixture containing ``git status`` -> ``ok``."""
+    return write_minimal_replay_fixture(tmp_path)
+
+
+@given(parsers.cfparse('the command "{cmd}" is spied with that replay fixture'))
+def spy_with_replay_fixture(
+    mox: CmdMox, cmd: str, git_replay_fixture_path: Path
+) -> None:
+    """Attach a strict replay fixture to a spy."""
+    mox.spy(cmd).replay(git_replay_fixture_path)
+
+
+@given(
+    parsers.cfparse(
+        'the command "{cmd}" is spied with fuzzy replay and fallback "{text}"'
+    )
+)
+def spy_with_fuzzy_replay_and_fallback(
+    mox: CmdMox, cmd: str, text: str, git_replay_fixture_path: Path
+) -> None:
+    """Attach a fuzzy replay fixture and canned fallback response to a spy."""
+    mox.spy(cmd).returns(stdout=text).replay(git_replay_fixture_path, strict=False)
+
+
+@when(
+    parsers.cfparse(
+        'the controller handles the invocation for "{cmd}" with arguments "{args}" '
+        "expecting UnexpectedCommandError"
+    ),
+    target_fixture="invocation_error",
+)
+def handle_invocation_expect_error(
+    mox: CmdMox, cmd: str, args: str
+) -> UnexpectedCommandError:
+    """Call ``_handle_invocation()`` directly and capture the strict replay error."""
+    invocation = Invocation(command=cmd, args=shlex.split(args), stdin="", env={})
+
+    with pytest.raises(UnexpectedCommandError) as excinfo:
+        mox._handle_invocation(invocation)
+
+    return excinfo.value
+
+
+@then(parsers.cfparse('the invocation error message should contain "{text}"'))
+def invocation_error_contains(
+    invocation_error: UnexpectedCommandError, text: str
+) -> None:
+    """Assert the captured invocation error contains *text*."""
+    assert text in str(invocation_error)

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -96,6 +96,15 @@ def test_replay_backed_spy_serves_recorded_response() -> None:
 
 @scenario(
     str(FEATURES_DIR / "controller.feature"),
+    "replay-backed spy applies expectation environment",
+)
+def test_replay_backed_spy_applies_expectation_environment() -> None:
+    """Replay-backed spies should still enforce and record expectation env."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
     "strict replay mismatch fails during invocation handling",
 )
 def test_strict_replay_mismatch_fails_during_invocation_handling() -> None:

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -85,6 +85,33 @@ def test_spy_records_invocation() -> None:
     pass
 
 
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
+    "replay-backed spy serves recorded response",
+)
+def test_replay_backed_spy_serves_recorded_response() -> None:
+    """Replay-backed spies should return fixture responses at runtime."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
+    "strict replay mismatch fails during invocation handling",
+)
+def test_strict_replay_mismatch_fails_during_invocation_handling() -> None:
+    """Strict replay mismatches should fail at invocation time."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
+    "fuzzy replay mismatch falls back to spy response",
+)
+def test_fuzzy_replay_mismatch_falls_back_to_spy_response() -> None:
+    """Fuzzy replay should fall back to the spy's configured response."""
+    pass
+
+
 @scenario(str(FEATURES_DIR / "controller.feature"), "spy assertion helpers")
 def test_spy_assertion_helpers() -> None:
     """Spy exposes assert_called helpers."""


### PR DESCRIPTION
## Summary
Implements runtime replay integration in CmdMox._make_response(), including strict and fuzzy replay handling, unit tests, behavioural tests, and updated documentation. This change completes roadmap item 12.2.4 and updates supporting docs and tests accordingly.

## Changes
- Production code
  - Added CmdMox._response_for_replay(double, invocation) to handle replay-backed invocations using the attached ReplaySession.
  - Updated CmdMox._make_response() to consult an attached replay session before the existing spy paths. If a match is found, the invocation is recorded and the fixture-derived Response is returned. If no match and strict_matching is True, raise UnexpectedCommandError; if no match and fuzzy, fall through to the regular path.
  - Ensured replay-backed invocations are reflected in spy.invocations and the controller journal where applicable.
- Tests
  - New unit tests: cmd_mox/unittests/test_controller_replay.py exercising replay precedence, handler bypass, strict misses, and fuzzy fallback.
  - Expanded behavioural coverage scaffolding:
    - features/controller.feature with replay-backed scenarios.
    - tests/steps/controller_replay.py implementing replay-focused step definitions.
    - tests/steps/__init__.py updated to include replay steps.
- Documentation and design artifacts
  - New ExecPlan: docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md detailing constraints, decisions, and plan.
  - Roadmap and user-facing docs adjusted:
    - docs/cmd-mox-roadmap.md marks 12.2.4 as done.
    - docs/usage-guide.md explains runtime replay behavior, strict/fuzzy rules, and journal propagation.
    - docs/python-native-command-mocking-design.md updated to reflect final controller integration approach.
- Verification and gating
  - Update aligns with the new implementation and tests; quality gates should be re-run to confirm coverage.

## Rationale
- This completes the integration of replay into live command execution by wiring the replay path into the controller's decision flow, ensuring deterministic fixture-based responses take precedence when available and that strict vs fuzzy replay semantics are enforced at invocation time.
- Keeps existing spy bookkeeping intact while adding replay-specific behaviour, so tests and user assertions continue to behave consistently.
- Provides a clear, test-driven path to validate runtime replay behavior before proceeding with broader verification changes (12.2.5).

## Validation and acceptance criteria
- Replay-enabled spy returns fixture-backed Response during command execution.
- A strict replay mismatch raises UnexpectedCommandError at invocation time.
- A fuzzy replay mismatch falls back to the configured spy response/handler.
- Replay-backed invocations appear in spy.invocations and in the controller journal.
- Unit tests and behavioural tests cover the new behavior and pass.
- Documentation reflects the runtime replay behavior and design decisions.
- All required quality gates pass (markdownlint, nixie, check-fmt, typecheck, lint, test).

## Testing plan
- Unit tests:
  - pytest cmd_mox/unittests/test_controller_replay.py -q
- Behavioural tests:
  - pytest tests/test_controller_bdd.py -k replay -q
- Quality gates:
  - make markdownlint, make nixie, make check-fmt, make typecheck, make lint, make test

## Risks and mitigations
- Risk: replay path changes could bypass spy bookkeeping. Mitigation: ensure replay path appends to double.invocations before returning the Response.
- Risk: strict mismatch timing could affect verify flow. Mitigation: document behavior and harden tests.
- Risk: fuzzy semantics could become ambiguous. Mitigation: include explicit tests demonstrating fallback behavior.
- No new dependencies or fixture schema changes planned for this stage.

## Notes
- This PR moves from planning-only to actual implementation and testing for 12.2.4. The ExecPlan document is a living artifact and will be updated as work progresses or scope shifts.
- Task/issue link remains for traceability: https://www.devboxer.com/task/6316551f-1785-4707-bfeb-76e1fe7e0d05

## Summary by Sourcery

Integrate replay sessions into CmdMox controller response handling so replay-backed spies serve fixture responses with strict and fuzzy semantics, and document and test the new behaviour.

New Features:
- Add replay-aware dispatch in CmdMox._make_response() so spies with attached replay sessions return fixture-backed responses with strict and fuzzy matching behaviour.

Enhancements:
- Record replay-backed invocations in spy history and the controller journal to keep bookkeeping consistent with non-replay spies.
- Clarify design decisions and security considerations around replay-backed controller dispatch and strict-miss handling in the design documentation.
- Update roadmap to mark replay integration into CmdMox._make_response() as complete.

Documentation:
- Expand the usage guide and design docs to describe runtime replay behaviour, strict versus fuzzy mismatch handling, and controller integration details.
- Add an execution plan document detailing the constraints, decisions, and outcomes for integrating replay into CmdMox._make_response().

Tests:
- Add unit tests for controller replay integration covering replay precedence, handler bypass, strict mismatch failures, fuzzy fallback, and bookkeeping of invocations and journal entries.
- Add BDD scenarios and step definitions to exercise replay-backed command execution, strict mismatch behaviour, and fuzzy fallback in the controller.

<!-- Auto-generated content preserved -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated replay-backed fixture matching into command handling, prioritizing recorded fixtures before configured spy responses.
  * Replay mode now supports strict (raises error on mismatch) and fuzzy (falls back gracefully) strategies.

* **Tests**
  * Added comprehensive integration tests and behavior-driven scenarios for replay controller functionality.

* **Documentation**
  * Updated design, usage guides, and roadmap to reflect replay integration and behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->