### PR TITLE
Extend CmdMox.verify() to report unconsumed recordings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,15 @@ VENV_TOOLS = pytest
 UV_ENV = UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
 RUFF = $(UV_ENV) $(UV) run ruff
 TY = $(UV_ENV) $(UV) run ty
+WINDOWS_SMOKE_ARGS = tests/test_windows_environment.py \
+	tests/test_windows_support_bdd.py \
+	--log-file=windows-ipc.log \
+	--log-file-level=DEBUG \
+	--log-file-format="%(asctime)s %(levelname)s [%(name)s] %(message)s"
 
-.PHONY: help all clean build build-release lint fmt check-fmt \
-        markdownlint markdownlint-run nixie test typecheck $(TOOLS) $(VENV_TOOLS)
+.PHONY: help all clean build build-release lint fmt check-fmt
+.PHONY: markdownlint markdownlint-run nixie test typecheck
+.PHONY: $(TOOLS) $(VENV_TOOLS)
 
 .DEFAULT_GOAL := all
 
@@ -88,12 +94,7 @@ test: build $(UV) $(VENV_TOOLS) ## Run tests
 	$(UV_ENV) $(UV) run pytest -v -n auto
 
 windows-smoke: build $(UV) $(VENV_TOOLS) ## Run Windows smoke workflow and capture IPC logs
-	$(UV_ENV) $(UV) run pytest -v \
-	tests/test_windows_environment.py \
-	tests/test_windows_support_bdd.py \
-	--log-file=windows-ipc.log \
-	--log-file-level=DEBUG \
-	--log-file-format="%(asctime)s %(levelname)s [%(name)s] %(message)s"
+	$(UV_ENV) $(UV) run pytest -v $(WINDOWS_SMOKE_ARGS)
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ RUFF = $(UV_ENV) $(UV) run ruff
 TY = $(UV_ENV) $(UV) run ty
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
-        markdownlint nixie test typecheck $(TOOLS) $(VENV_TOOLS)
+        markdownlint markdownlint-run nixie test typecheck $(TOOLS) $(VENV_TOOLS)
 
 .DEFAULT_GOAL := all
 
@@ -58,18 +58,17 @@ endif
 fmt: build ## Format sources
 	$(RUFF) format
 	$(RUFF) check --select I --fix
-	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
-	  markdownlint-cli2 --fix '**/*.md'; \
-	else \
-	  npx --yes markdownlint-cli2@0.22.1 --fix '**/*.md'; \
-	fi
+	$(MAKE) markdownlint-run MDARGS="--fix"
 
 check-fmt: build ## Verify formatting
 	$(RUFF) format --check
+	$(MAKE) markdownlint-run
+
+markdownlint-run: ## Run markdownlint-cli2 with pinned fallback
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
-	  markdownlint-cli2 '**/*.md'; \
+	  markdownlint-cli2 $(MDARGS) '**/*.md'; \
 	else \
-	  npx --yes markdownlint-cli2@0.22.1 '**/*.md'; \
+	  npx --yes markdownlint-cli2@0.22.1 $(MDARGS) '**/*.md'; \
 	fi
 
 lint: build ## Run linters
@@ -80,11 +79,7 @@ typecheck: build ## Run typechecking
 	$(TY) check
 
 markdownlint: ## Lint Markdown files
-	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
-	  markdownlint-cli2 '**/*.md'; \
-	else \
-	  npx --yes markdownlint-cli2@0.22.1 '**/*.md'; \
-	fi
+	$(MAKE) markdownlint-run
 
 nixie: $(NIXIE) ## Validate Mermaid diagrams
 	$(NIXIE) --no-sandbox

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TOOLS = $(MDFORMAT_ALL) $(NIXIE) $(UV)
 VENV_TOOLS = pytest
 UV_ENV = UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
 RUFF = $(UV_ENV) $(UV) run ruff
-TY = $(UV_ENV) $(UV) tool run ty
+TY = $(UV_ENV) $(UV) run ty
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
         markdownlint nixie test typecheck $(TOOLS) $(VENV_TOOLS)
@@ -55,10 +55,14 @@ $(VENV_TOOLS): ## Verify required CLI tools in venv
 	$(call ensure_tool_venv,$@)
 endif
 
-fmt: build $(MDFORMAT_ALL) ## Format sources
+fmt: build ## Format sources
 	$(RUFF) format
 	$(RUFF) check --select I --fix
-	$(MDFORMAT_ALL)
+	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
+	  markdownlint-cli2 --fix '**/*.md'; \
+	else \
+	  npx --yes markdownlint-cli2@0.22.1 --fix '**/*.md'; \
+	fi
 
 check-fmt: build ## Verify formatting
 	$(RUFF) format --check
@@ -75,7 +79,7 @@ markdownlint: ## Lint Markdown files
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
 	  markdownlint-cli2 '**/*.md'; \
 	else \
-	  npx --yes markdownlint-cli2 '**/*.md'; \
+	  npx --yes markdownlint-cli2@0.22.1 '**/*.md'; \
 	fi
 
 nixie: $(NIXIE) ## Validate Mermaid diagrams

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 NIXIE ?= nixie
 MDFORMAT_ALL ?= mdformat-all
-TOOLS = $(MDFORMAT_ALL) $(NIXIE) uv
+UV ?= $(shell command -v uv 2>/dev/null || printf '%s' "$$HOME/.local/bin/uv")
+TOOLS = $(MDFORMAT_ALL) $(NIXIE) $(UV)
 VENV_TOOLS = pytest
 UV_ENV = UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
-RUFF = $(UV_ENV) uv run ruff
-TY = $(UV_ENV) uv tool run ty
+RUFF = $(UV_ENV) $(UV) run ruff
+TY = $(UV_ENV) $(UV) tool run ty
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
         markdownlint nixie test typecheck $(TOOLS) $(VENV_TOOLS)
@@ -14,10 +15,10 @@ TY = $(UV_ENV) uv tool run ty
 all: build check-fmt test typecheck
 
 .venv: pyproject.toml
-	$(UV_ENV) uv venv --clear
+	$(UV_ENV) $(UV) venv --clear
 
-build: uv .venv ## Build virtual-env and install deps
-	$(UV_ENV) uv sync --group dev
+build: $(UV) .venv ## Build virtual-env and install deps
+	$(UV_ENV) $(UV) sync --group dev
 
 build-release: ## Build artefacts (sdist & wheel)
 	python -m build --sdist --wheel
@@ -36,7 +37,7 @@ define ensure_tool
 endef
 
 define ensure_tool_venv
-	$(UV_ENV) uv run which $(1) >/dev/null 2>&1 || { \
+	$(UV_ENV) $(UV) run which $(1) >/dev/null 2>&1 || { \
 	  printf "Error: '%s' is required in the virtualenv, but is not installed\n" "$(1)" >&2; \
 	  exit 1; \
 	}
@@ -80,11 +81,11 @@ markdownlint: ## Lint Markdown files
 nixie: $(NIXIE) ## Validate Mermaid diagrams
 	$(NIXIE) --no-sandbox
 
-test: build uv $(VENV_TOOLS) ## Run tests
-	$(UV_ENV) uv run pytest -v -n auto
+test: build $(UV) $(VENV_TOOLS) ## Run tests
+	$(UV_ENV) $(UV) run pytest -v -n auto
 
-windows-smoke: build uv $(VENV_TOOLS) ## Run Windows smoke workflow and capture IPC logs
-	$(UV_ENV) uv run pytest -v \
+windows-smoke: build $(UV) $(VENV_TOOLS) ## Run Windows smoke workflow and capture IPC logs
+	$(UV_ENV) $(UV) run pytest -v \
 	tests/test_windows_environment.py \
 	tests/test_windows_support_bdd.py \
 	--log-file=windows-ipc.log \

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,11 @@ fmt: build ## Format sources
 
 check-fmt: build ## Verify formatting
 	$(RUFF) format --check
-	# mdformat-all doesn't currently do checking
+	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
+	  markdownlint-cli2 '**/*.md'; \
+	else \
+	  npx --yes markdownlint-cli2@0.22.1 '**/*.md'; \
+	fi
 
 lint: build ## Run linters
 	$(RUFF) check

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 MDFORMAT_ALL ?= mdformat-all
-TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) $(NIXIE) uv
+TOOLS = $(MDFORMAT_ALL) $(NIXIE) uv
 VENV_TOOLS = pytest
 UV_ENV = UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
+RUFF = $(UV_ENV) uv run ruff
+TY = $(UV_ENV) uv tool run ty
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
         markdownlint nixie test typecheck $(TOOLS) $(VENV_TOOLS)
@@ -53,24 +54,28 @@ $(VENV_TOOLS): ## Verify required CLI tools in venv
 	$(call ensure_tool_venv,$@)
 endif
 
-fmt: ruff $(MDFORMAT_ALL) ## Format sources
-	ruff format
-	ruff check --select I --fix
+fmt: build $(MDFORMAT_ALL) ## Format sources
+	$(RUFF) format
+	$(RUFF) check --select I --fix
 	$(MDFORMAT_ALL)
 
-check-fmt: ruff ## Verify formatting
-	ruff format --check
+check-fmt: build ## Verify formatting
+	$(RUFF) format --check
 	# mdformat-all doesn't currently do checking
 
-lint: ruff ## Run linters
-	ruff check
+lint: build ## Run linters
+	$(RUFF) check
 
-typecheck: build ty ## Run typechecking
-	ty --version
-	ty check
+typecheck: build ## Run typechecking
+	$(TY) --version
+	$(TY) check
 
-markdownlint: $(MDLINT) ## Lint Markdown files
-	$(MDLINT) '**/*.md'
+markdownlint: ## Lint Markdown files
+	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
+	  markdownlint-cli2 '**/*.md'; \
+	else \
+	  npx --yes markdownlint-cli2 '**/*.md'; \
+	fi
 
 nixie: $(NIXIE) ## Validate Mermaid diagrams
 	$(NIXIE) --no-sandbox

--- a/cmd_mox/_shim_bootstrap.py
+++ b/cmd_mox/_shim_bootstrap.py
@@ -33,8 +33,8 @@ def _temporary_sys_path(entries: tuple[str, ...]) -> t.Iterator[None]:
     """Temporarily replace ``sys.path`` while keeping import caches coherent."""
     original_sys_path = sys.path
     sys.path = list(entries)
-    importlib.invalidate_caches()
     try:
+        importlib.invalidate_caches()
         yield
     finally:
         sys.path = original_sys_path

--- a/cmd_mox/_shim_bootstrap.py
+++ b/cmd_mox/_shim_bootstrap.py
@@ -14,14 +14,32 @@ if t.TYPE_CHECKING:
     from types import ModuleType
 
 _BOOTSTRAP_DONE = False
+_INITIAL_SYS_PATH = tuple(sys.path)
+_INITIAL_STDLIB_PATH = sysconfig.get_path("stdlib")
 
 
 def _get_stdlib_path() -> str | None:
     """Return the stdlib path, guarding against missing or invalid configs."""
     try:
         return sysconfig.get_path("stdlib")
-    except (KeyError, OSError, ValueError, TypeError):
-        return None
+    except (AttributeError, ImportError, KeyError, OSError, ValueError, TypeError):
+        original_sys_path = sys.path
+        try:
+            sys.path = list(_INITIAL_SYS_PATH)
+            importlib.invalidate_caches()
+            return sysconfig.get_path("stdlib")
+        except (
+            AttributeError,
+            ImportError,
+            KeyError,
+            OSError,
+            ValueError,
+            TypeError,
+        ):
+            return _INITIAL_STDLIB_PATH
+        finally:
+            sys.path = original_sys_path
+            importlib.invalidate_caches()
 
 
 def _create_module_from_file(module_name: str, file_path: Path) -> ModuleType | None:

--- a/cmd_mox/_shim_bootstrap.py
+++ b/cmd_mox/_shim_bootstrap.py
@@ -101,12 +101,12 @@ def bootstrap_shim_path() -> None:
 
     package_dir = Path(__file__).resolve().parent
     removed: list[str] = []
-    for entry in list(sys.path):
-        if _should_remove_path_entry(entry, package_dir):
-            sys.path.remove(entry)
-            removed.append(entry)
-    sys.path_importer_cache.clear()
     try:
+        for entry in list(sys.path):
+            if _should_remove_path_entry(entry, package_dir):
+                sys.path.remove(entry)
+                removed.append(entry)
+        sys.path_importer_cache.clear()
         std_platform = _load_stdlib_platform()
         sys.modules["platform"] = std_platform
     finally:

--- a/cmd_mox/_shim_bootstrap.py
+++ b/cmd_mox/_shim_bootstrap.py
@@ -15,31 +15,33 @@ if t.TYPE_CHECKING:
 
 _BOOTSTRAP_DONE = False
 _INITIAL_SYS_PATH = tuple(sys.path)
-_INITIAL_STDLIB_PATH = sysconfig.get_path("stdlib")
+
+
+def _try_get_stdlib_path() -> str | None:
+    """Return the configured stdlib path, or ``None`` if config lookup fails."""
+    try:
+        return sysconfig.get_path("stdlib")
+    except (AttributeError, ImportError, KeyError, OSError, ValueError, TypeError):
+        return None
+
+
+_INITIAL_STDLIB_PATH = _try_get_stdlib_path()
 
 
 def _get_stdlib_path() -> str | None:
     """Return the stdlib path, guarding against missing or invalid configs."""
+    stdlib_path = _try_get_stdlib_path()
+    if stdlib_path is not None:
+        return stdlib_path
+
+    original_sys_path = sys.path
     try:
-        return sysconfig.get_path("stdlib")
-    except (AttributeError, ImportError, KeyError, OSError, ValueError, TypeError):
-        original_sys_path = sys.path
-        try:
-            sys.path = list(_INITIAL_SYS_PATH)
-            importlib.invalidate_caches()
-            return sysconfig.get_path("stdlib")
-        except (
-            AttributeError,
-            ImportError,
-            KeyError,
-            OSError,
-            ValueError,
-            TypeError,
-        ):
-            return _INITIAL_STDLIB_PATH
-        finally:
-            sys.path = original_sys_path
-            importlib.invalidate_caches()
+        sys.path = list(_INITIAL_SYS_PATH)
+        importlib.invalidate_caches()
+        return _try_get_stdlib_path() or _INITIAL_STDLIB_PATH
+    finally:
+        sys.path = original_sys_path
+        importlib.invalidate_caches()
 
 
 def _create_module_from_file(module_name: str, file_path: Path) -> ModuleType | None:

--- a/cmd_mox/_shim_bootstrap.py
+++ b/cmd_mox/_shim_bootstrap.py
@@ -106,8 +106,10 @@ def bootstrap_shim_path() -> None:
             sys.path.remove(entry)
             removed.append(entry)
     sys.path_importer_cache.clear()
-    std_platform = _load_stdlib_platform()
-    sys.modules["platform"] = std_platform
-    for entry in reversed(removed):
-        sys.path.insert(0, entry)
+    try:
+        std_platform = _load_stdlib_platform()
+        sys.modules["platform"] = std_platform
+    finally:
+        for entry in reversed(removed):
+            sys.path.insert(0, entry)
     _BOOTSTRAP_DONE = True

--- a/cmd_mox/_shim_bootstrap.py
+++ b/cmd_mox/_shim_bootstrap.py
@@ -28,20 +28,27 @@ def _try_get_stdlib_path() -> str | None:
 _INITIAL_STDLIB_PATH = _try_get_stdlib_path()
 
 
+@contextlib.contextmanager
+def _temporary_sys_path(entries: tuple[str, ...]) -> t.Iterator[None]:
+    """Temporarily replace ``sys.path`` while keeping import caches coherent."""
+    original_sys_path = sys.path
+    sys.path = list(entries)
+    importlib.invalidate_caches()
+    try:
+        yield
+    finally:
+        sys.path = original_sys_path
+        importlib.invalidate_caches()
+
+
 def _get_stdlib_path() -> str | None:
     """Return the stdlib path, guarding against missing or invalid configs."""
     stdlib_path = _try_get_stdlib_path()
     if stdlib_path is not None:
         return stdlib_path
 
-    original_sys_path = sys.path
-    try:
-        sys.path = list(_INITIAL_SYS_PATH)
-        importlib.invalidate_caches()
+    with _temporary_sys_path(_INITIAL_SYS_PATH):
         return _try_get_stdlib_path() or _INITIAL_STDLIB_PATH
-    finally:
-        sys.path = original_sys_path
-        importlib.invalidate_caches()
 
 
 def _create_module_from_file(module_name: str, file_path: Path) -> ModuleType | None:

--- a/cmd_mox/controller.py
+++ b/cmd_mox/controller.py
@@ -665,6 +665,14 @@ class CmdMox:
         UnexpectedCommandVerifier().verify(self.journal, self._doubles)
         OrderVerifier(self._ordered).verify(self.journal)
         CountVerifier().verify(expectations, inv_map)
+        self._verify_replay_sessions_consumed()
+
+    def _verify_replay_sessions_consumed(self) -> None:
+        """Verify attached replay sessions did not leave fixture entries unused."""
+        for double in self._doubles.values():
+            replay_session = double.replay_session
+            if replay_session is not None:
+                replay_session.verify_all_consumed()
 
     def _finalize_recording_sessions(self) -> None:
         """Finalize all active recording sessions and persist fixtures."""

--- a/cmd_mox/ipc/server.py
+++ b/cmd_mox/ipc/server.py
@@ -481,6 +481,8 @@ class _InnerServer(_BaseUnixServer):
 class NamedPipeServer(_BaseIPCServer["_NamedPipeState"]):
     """Windows named pipe variant of :class:`IPCServer`."""
 
+    _pipe_name: str
+
     def __init__(
         self,
         socket_path: Path,

--- a/cmd_mox/unittests/test_controller_environment_manager.py
+++ b/cmd_mox/unittests/test_controller_environment_manager.py
@@ -112,7 +112,7 @@ def test_replay_detects_environment_loss(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_require_env_attrs_rejects_missing_environment() -> None:
     """_require_env_attrs surfaces the default missing environment message."""
     mox = CmdMox()
-    mox.environment = None
+    mox.environment = t.cast("EnvironmentManager", None)
     with pytest.raises(
         MissingEnvironmentError, match="Replay environment is not ready"
     ):

--- a/cmd_mox/unittests/test_controller_lifecycle.py
+++ b/cmd_mox/unittests/test_controller_lifecycle.py
@@ -8,16 +8,18 @@ import pytest
 
 from cmd_mox.controller import CmdMox, Phase
 from cmd_mox.environment import EnvironmentManager
-from cmd_mox.errors import LifecycleError
+from cmd_mox.errors import LifecycleError, VerificationError
 from cmd_mox.unittests._env_helpers import (
     require_shim_dir,
     require_socket_path,
 )
+from tests.helpers.fixtures import write_minimal_replay_fixture
 
 pytestmark = pytest.mark.requires_unix_sockets
 
 if t.TYPE_CHECKING:  # pragma: no cover - typing only
     import subprocess
+    from pathlib import Path
 
 
 def test_cmdmox_replay_verify_out_of_order(
@@ -157,6 +159,27 @@ def test_verify_cleans_up_when_recording_finalize_raises(
         mox.verify()
 
     # Mandatory cleanup must have happened despite the OSError.
+    assert EnvironmentManager.get_active_manager() is None
+    assert not mox._entered
+    assert mox.phase is Phase.VERIFY
+
+
+def test_verify_cleans_up_when_replay_consumption_verification_raises(
+    tmp_path: Path,
+) -> None:
+    """Replay verification failures must not skip controller teardown."""
+    mox = CmdMox()
+    fixture_path = write_minimal_replay_fixture(tmp_path)
+    mox.spy("git").replay(fixture_path)
+    mox.__enter__()
+    mox.replay()
+
+    with pytest.raises(
+        VerificationError,
+        match="Not all fixture recordings were consumed during replay",
+    ):
+        mox.verify()
+
     assert EnvironmentManager.get_active_manager() is None
     assert not mox._entered
     assert mox.phase is Phase.VERIFY

--- a/cmd_mox/unittests/test_controller_replay.py
+++ b/cmd_mox/unittests/test_controller_replay.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import typing as t
 
 import pytest
 
 from cmd_mox.controller import CmdMox
-from cmd_mox.errors import UnexpectedCommandError
+from cmd_mox.errors import UnexpectedCommandError, VerificationError
 from cmd_mox.ipc import Invocation, Response
-from tests.helpers.fixtures import write_minimal_replay_fixture
+from cmd_mox.record.fixture import RecordedInvocation
+from cmd_mox.record.replay import ReplaySession
+from tests.helpers.fixtures import write_minimal_replay_fixture, write_replay_fixture
 
 if t.TYPE_CHECKING:
     from pathlib import Path
@@ -157,3 +160,84 @@ class TestControllerReplayIntegration:
         assert response.stdout == "handler-fallback"
         assert spy.invocations == [invocation]
         assert list(mox.journal) == [invocation]
+
+
+class TestControllerReplayVerification:
+    """Replay-backed controller verification should enforce fixture consumption."""
+
+    def test_verify_raises_when_replay_fixture_has_unconsumed_recordings(
+        self, tmp_path: Path
+    ) -> None:
+        """Controller verification should fail when replay entries remain unused."""
+        mox = CmdMox()
+        fixture_path = write_replay_fixture(
+            tmp_path,
+            [
+                RecordedInvocation(
+                    sequence=0,
+                    command="git",
+                    args=["status"],
+                    stdin="",
+                    env_subset={},
+                    stdout="ok\n",
+                    stderr="",
+                    exit_code=0,
+                    timestamp=dt.datetime.now(dt.UTC).isoformat(),
+                    duration_ms=0,
+                ),
+                RecordedInvocation(
+                    sequence=1,
+                    command="git",
+                    args=["commit"],
+                    stdin="",
+                    env_subset={},
+                    stdout="committed\n",
+                    stderr="",
+                    exit_code=0,
+                    timestamp=dt.datetime.now(dt.UTC).isoformat(),
+                    duration_ms=1,
+                ),
+            ],
+        )
+        mox.spy("git").replay(fixture_path)
+        invocation = Invocation(command="git", args=["status"], stdin="", env={})
+
+        with mox:
+            mox.replay()
+            mox._handle_invocation(invocation)
+            with pytest.raises(
+                VerificationError,
+                match="Not all fixture recordings were consumed during replay",
+            ):
+                mox.verify()
+
+    def test_verify_passes_when_replay_fixture_is_fully_consumed(
+        self, tmp_path: Path
+    ) -> None:
+        """Controller verification should succeed once all replay entries are used."""
+        mox = CmdMox()
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        mox.spy("git").replay(fixture_path)
+        invocation = Invocation(command="git", args=["status"], stdin="", env={})
+
+        with mox:
+            mox.replay()
+            mox._handle_invocation(invocation)
+            mox.verify()
+
+    def test_verify_skips_unconsumed_check_when_replay_allows_unmatched(
+        self, tmp_path: Path
+    ) -> None:
+        """Controllers should respect direct ReplaySession allow_unmatched opt-out."""
+        mox = CmdMox()
+        spy = mox.spy("git")
+        fixture_path = write_minimal_replay_fixture(tmp_path)
+        replay_session = ReplaySession(fixture_path, allow_unmatched=True)
+        replay_session.load()
+        # The fluent API does not expose allow_unmatched; inject the direct
+        # session to assert controller verification honours the lower-level opt-out.
+        spy._replay_session = replay_session
+
+        with mox:
+            mox.replay()
+            mox.verify()

--- a/cmd_mox/unittests/test_shim.py
+++ b/cmd_mox/unittests/test_shim.py
@@ -420,6 +420,29 @@ def test_bootstrap_shim_path_prefers_stdlib_platform(
         sys.modules.pop("platform", None)
 
 
+def test_bootstrap_shim_path_restores_sys_path_when_platform_load_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bootstrapping should restore removed entries when platform loading fails."""
+    from cmd_mox import _shim_bootstrap
+
+    original_path = ["__editable__dummy", "/usr/lib/python3.12"]
+    monkeypatch.setattr(_shim_bootstrap, "_BOOTSTRAP_DONE", False)
+    monkeypatch.setattr(sys, "path", list(original_path))
+
+    def raise_runtime_error() -> t.NoReturn:
+        msg = "platform load failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(_shim_bootstrap, "_load_stdlib_platform", raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="platform load failed"):
+        _shim_bootstrap.bootstrap_shim_path()
+
+    assert sys.path == original_path
+    assert not _shim_bootstrap._BOOTSTRAP_DONE
+
+
 @pytest.mark.parametrize(
     ("factory", "expected_exit", "expected_message"),
     [

--- a/docs/cmd-mox-roadmap.md
+++ b/docs/cmd-mox-roadmap.md
@@ -254,7 +254,7 @@ supports deterministic replay without external dependencies. See
   incompatibility validation and strict-mode option.
 - [x] 12.2.4. Integrate replay into `CmdMox._make_response()` and raise
   `UnexpectedCommandError` for unmatched strict replay invocations.
-- [ ] 12.2.5. Extend `CmdMox.verify()` to report unconsumed recordings.
+- [x] 12.2.5. Extend `CmdMox.verify()` to report unconsumed recordings.
 - [ ] 12.2.6. Add unit tests for fixture loading, matcher behaviour, and
   consumption tracking.
 

--- a/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
+++ b/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
@@ -139,30 +139,22 @@ The implementer should keep these references open while executing the plan:
 
 ## Constraints
 
-- This file is a draft only. Do not implement the feature until the user gives
-  explicit approval for this ExecPlan.
-- Follow the repository test-driven development workflow from `AGENTS.md`:
-  update tests first, confirm they fail, then implement the production change,
-  then rerun focused tests and the full quality gates.
-- Keep the roadmap boundary intact. `12.2.5` only extends controller
-  verification to report unconsumed replay recordings. Do not change fixture
-  schema, matching rules, replay attachment API, or strict-versus-fuzzy runtime
-  matching behaviour.
-- Reuse `ReplaySession.verify_all_consumed()` as the single source of truth for
-  consumption checks. Do not reimplement unconsumed-recording detection inside
-  `CmdMox`.
+- The completed implementation kept the roadmap boundary intact. `12.2.5`
+  only extends controller verification to report unconsumed replay recordings;
+  fixture schema, matching rules, replay attachment API, and
+  strict-versus-fuzzy runtime matching behaviour remain unchanged.
+- `ReplaySession.verify_all_consumed()` remains the single source of truth for
+  consumption checks, and `CmdMox` delegates unconsumed-recording detection to
+  that API.
 - Preserve existing cleanup guarantees in `CmdMox.verify()`: IPC teardown and
   recording-session finalisation must still run even if replay-consumption
   verification fails.
-- Do not add new dependencies.
-- Keep unit tests under `cmd_mox/unittests/` and behavioural tests under
-  `features/`, `tests/steps/`, and `tests/test_*_bdd.py`.
-- Update consumer-facing docs in `docs/usage-guide.md` and record any final
-  design decisions in `docs/python-native-command-mocking-design.md`.
-- Mark roadmap item `12.2.5` done only after implementation is complete and
-  all required quality gates succeed. Do not mark it done during this planning
-  turn.
-- Required gates for feature completion are `make markdownlint`, `make nixie`,
+- The test and documentation updates stayed within the existing project
+  layout: unit tests under `cmd_mox/unittests/`, behavioural tests under
+  `features/`, `tests/steps/`, and `tests/test_*_bdd.py`, consumer-facing docs
+  in `docs/usage-guide.md`, and design notes in
+  `docs/python-native-command-mocking-design.md`.
+- The completed feature passed `make markdownlint`, `make nixie`,
   `make check-fmt`, `make typecheck`, `make lint`, and `make test`.
 
 ## Tolerances
@@ -297,10 +289,10 @@ The implementer should keep these references open while executing the plan:
   the unconsumed-path failure. Rationale: the feature needs behavioural
   coverage, but the happy path is already exercised end-to-end.
 
-- Decision: do not mark `docs/cmd-mox-roadmap.md` item `12.2.5` done until the
-  implementation is approved, merged into the working tree, and all required
-  quality gates pass. Rationale: drafting the plan alone is not feature
-  completion.
+- Decision: mark `docs/cmd-mox-roadmap.md` item `12.2.5` done after the
+  implementation landed in the working tree and all required quality gates
+  passed. Rationale: the roadmap status now reflects completed, verified
+  feature work rather than the earlier planning draft.
 
 ## Plan of work
 
@@ -414,11 +406,11 @@ Update the documentation immediately after the code and tests settle:
     replay-backed spies and point readers to `allow_unmatched=True` in the
     direct `ReplaySession` section when tolerant verification is desired.
 - `docs/cmd-mox-roadmap.md`
-  - change `12.2.5` from unchecked to checked only after code, tests, and
-    quality gates are complete.
+  - mark `12.2.5` checked to reflect the completed implementation and passing
+    quality gates.
 
-If implementation reveals a stronger or narrower design rule than this draft
-states, record it in `Decision Log` before closing the work.
+The final design rules discovered during implementation are recorded in
+`Decision Log`.
 
 ### Stage E: Run the full quality gates
 
@@ -455,9 +447,9 @@ set -o pipefail
 make test 2>&1 | tee /tmp/12-2-5-test.log
 ```
 
-Once all six commands succeed, update `Progress`, add the final verification
-summary to `Outcomes & Retrospective`, and only then mark roadmap item
-`12.2.5` done.
+All six commands succeeded, `Progress` records completion, `Outcomes &
+Retrospective` captures the final verification summary, and roadmap item
+`12.2.5` is marked done.
 
 ## Outcomes & Retrospective
 

--- a/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
+++ b/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
@@ -1,0 +1,442 @@
+# Extend `CmdMox.verify()` to report unconsumed recordings
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap item `12.2.5` closes the main correctness gap that remains after
+`12.2.4`. Replay-backed spies already serve fixture responses during command
+execution, but `cmd_mox.controller.CmdMox.verify()` still succeeds even when a
+fixture contains recordings that were never consumed. That leaves a silent
+failure mode: a test can claim to be replaying a real interaction while only
+using part of the captured fixture.
+
+After this change, a developer who attaches a replay fixture to a spy and never
+uses all of its recorded entries will see `CmdMox.verify()` fail with a clear
+`VerificationError`. A fully consumed fixture will continue to verify cleanly.
+Direct `ReplaySession` users keep their existing opt-out via
+`allow_unmatched=True`, and replay-related cleanup must still run even when
+verification fails.
+
+Observable success after implementation:
+
+1. A replay-backed spy that leaves fixture entries unused causes
+   `CmdMox.verify()` to raise `VerificationError` with the existing
+   replay-session diagnostic text.
+2. A replay-backed spy that consumes all fixture entries continues to verify
+   successfully.
+3. The implementation reuses `ReplaySession.verify_all_consumed()` rather than
+   duplicating consumption logic inside the controller.
+4. `CmdMox.verify()` still tears down the IPC server and finalises recording
+   sessions even when replay-consumption verification fails.
+5. Unit tests written with `pytest` fail before the code change and pass after
+   it.
+6. Behavioural tests written with `pytest-bdd` demonstrate the consumer-facing
+   verify-time failure.
+7. `docs/python-native-command-mocking-design.md` records the final ordering
+   and error-surface decision, `docs/usage-guide.md` explains the new
+   verify-time behaviour for replay fixtures, and `docs/cmd-mox-roadmap.md`
+   marks `12.2.5` done after the feature lands.
+8. The full quality gates pass:
+
+```bash
+set -o pipefail
+make markdownlint 2>&1 | tee /tmp/12-2-5-markdownlint.log
+```
+
+```bash
+set -o pipefail
+make nixie 2>&1 | tee /tmp/12-2-5-nixie.log
+```
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/12-2-5-check-fmt.log
+```
+
+```bash
+set -o pipefail
+make typecheck 2>&1 | tee /tmp/12-2-5-typecheck.log
+```
+
+```bash
+set -o pipefail
+make lint 2>&1 | tee /tmp/12-2-5-lint.log
+```
+
+```bash
+set -o pipefail
+make test 2>&1 | tee /tmp/12-2-5-test.log
+```
+
+## Repository orientation
+
+The implementation seam is now very narrow because the replay machinery already
+exists:
+
+- `cmd_mox/controller.py`
+  - `CmdMox.verify()` currently runs `_run_verifiers()` and then always calls
+    `_finalize_verification()` and `_finalize_recording_sessions()` in a
+    `finally` block.
+  - `CmdMox._run_verifiers()` currently verifies unexpected commands, ordering,
+    and mock call counts only.
+  - `CmdMox._response_for_replay()` already consumes recordings through
+    `ReplaySession.match()` and raises `UnexpectedCommandError` for strict
+    replay misses.
+- `cmd_mox/record/replay.py`
+  - `ReplaySession.verify_all_consumed()` already implements the exact
+    consumption check needed by this roadmap item, including the
+    `allow_unmatched` escape hatch and the diagnostic message format.
+- `cmd_mox/test_doubles.py`
+  - `CommandDouble` already exposes `has_replay_session` and `replay_session`,
+    which is enough for controller-side iteration without adding new public API.
+- `cmd_mox/unittests/test_controller_replay.py`
+  - already covers replay dispatch in `_make_response()` and is the natural
+    home for controller-level replay-verification tests.
+- `cmd_mox/unittests/test_controller_lifecycle.py`
+  - already covers the rule that `verify()` must still clean up when later
+    finalisation steps raise.
+- `features/controller.feature`, `tests/test_controller_bdd.py`,
+  `tests/steps/controller_setup.py`, and `tests/steps/controller_replay.py`
+  already provide controller-level behavioural coverage and reusable
+  step definitions for verify-time errors.
+- `docs/python-native-command-mocking-design.md`
+  - already says that `verify()` should call
+    `ReplaySession.verify_all_consumed()`, but it does not yet pin down the
+    final controller ordering relative to existing verifiers and teardown.
+- `docs/usage-guide.md`
+  - already documents replay fixtures, strict versus fuzzy replay, and direct
+    `ReplaySession(..., allow_unmatched=True)` usage, but it does not yet state
+    that `CmdMox.verify()` enforces replay-consumption completeness.
+
+The neighbouring roadmap items matter here:
+
+- `12.2.4` is complete and already handles runtime replay matching.
+- `12.2.6` remains a follow-on item for broader replay infrastructure coverage.
+  This plan should only add tests needed to validate `12.2.5` itself.
+
+## Relevant docs and skills
+
+The implementer should keep these references open while executing the plan:
+
+- Docs:
+  - `docs/cmd-mox-roadmap.md`
+  - `docs/python-native-command-mocking-design.md`, especially Section IX,
+    `9.5.2`, and `9.8.3`
+  - `docs/usage-guide.md`, especially the replay-session and `.replay()`
+    sections
+  - `docs/execplans/12-2-3-add-replay-to-command-double.md`
+  - `docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md`
+- Skills:
+  - `execplans` for keeping this document current during implementation
+  - `leta` for symbol-aware navigation of `CmdMox.verify()`,
+    `_run_verifiers()`, and the replay-session tests
+
+## Constraints
+
+- This file is a draft only. Do not implement the feature until the user gives
+  explicit approval for this ExecPlan.
+- Follow the repository test-driven development workflow from `AGENTS.md`:
+  update tests first, confirm they fail, then implement the production change,
+  then rerun focused tests and the full quality gates.
+- Keep the roadmap boundary intact. `12.2.5` only extends controller
+  verification to report unconsumed replay recordings. Do not change fixture
+  schema, matching rules, replay attachment API, or strict-versus-fuzzy runtime
+  matching behaviour.
+- Reuse `ReplaySession.verify_all_consumed()` as the single source of truth for
+  consumption checks. Do not reimplement unconsumed-recording detection inside
+  `CmdMox`.
+- Preserve existing cleanup guarantees in `CmdMox.verify()`: IPC teardown and
+  recording-session finalisation must still run even if replay-consumption
+  verification fails.
+- Do not add new dependencies.
+- Keep unit tests under `cmd_mox/unittests/` and behavioural tests under
+  `features/`, `tests/steps/`, and `tests/test_*_bdd.py`.
+- Update consumer-facing docs in `docs/usage-guide.md` and record any final
+  design decisions in `docs/python-native-command-mocking-design.md`.
+- Mark roadmap item `12.2.5` done only after implementation is complete and
+  all required quality gates succeed. Do not mark it done during this planning
+  turn.
+- Required gates for feature completion are `make markdownlint`, `make nixie`,
+  `make check-fmt`, `make typecheck`, `make lint`, and `make test`.
+
+## Tolerances
+
+- Scope tolerance: stop and escalate if the work appears to require new replay
+  public API, fixture-format changes, or `CmdMox._make_response()` behaviour
+  changes. Those belong to other roadmap items.
+- Ordering tolerance: stop and escalate if replay-consumption verification
+  cannot be added with a focused controller helper or a small extension to
+  `_run_verifiers()`. This item should not require a wide controller
+  refactor.
+- Error-precedence tolerance: preserve the current broad `verify()` error
+  contract unless tests prove a regression. Do not opportunistically redesign
+  how earlier verification errors interact with later cleanup errors without
+  explicit approval.
+- Test-surface tolerance: prefer extending
+  `cmd_mox/unittests/test_controller_replay.py`,
+  `cmd_mox/unittests/test_controller_lifecycle.py`, and
+  `features/controller.feature` over creating new controller-specific test
+  files. Stop and reassess if coverage seems to need a large new scaffold.
+- Quality-gate tolerance: if any required gate still fails after 3 focused fix
+  attempts, capture the failing command and log path in
+  `Surprises & Discoveries` and pause for guidance.
+
+## Risks
+
+- Risk: it is easy to place replay-consumption verification in the wrong part
+  of `CmdMox.verify()`, either skipping cleanup on failure or letting teardown
+  happen before the verification check. Mitigation: write an ordering-focused
+  unit test before changing controller code.
+- Risk: the controller already has one cleanup regression test for recording
+  finalisation errors, but not for replay-verification failures. Mitigation:
+  add a red-phase test that proves environment cleanup still happens when
+  replay verification raises.
+- Risk: `.replay()` does not expose `allow_unmatched`, so there is no fluent
+  library-level opt-out for consumers using the common spy API. Mitigation:
+  keep scope limited; document the current behaviour clearly and only mention
+  `allow_unmatched=True` in the direct `ReplaySession` section where it already
+  exists.
+- Risk: existing replay-backed controller scenarios may start failing once
+  verification tightens. Mitigation: treat the existing successful replay BDD
+  scenario as an implicit regression test for the fully consumed path, then add
+  one new scenario for the unconsumed path.
+- Risk: replay-consumption verification may be tempted to inspect private state
+  directly. Mitigation: iterate doubles via the public `replay_session`
+  property and delegate the actual check to `verify_all_consumed()`.
+
+## Progress
+
+- [x] Reviewed `AGENTS.md`, project notes, the `execplans` skill, and the
+  `leta` skill instructions relevant to this task.
+- [x] Inspected the roadmap, design doc, usage guide, existing replay ExecPlans,
+  and the current controller and replay-session seams.
+- [x] Drafted this ExecPlan in
+  `docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md`.
+- [ ] Obtain explicit user approval for this plan before implementation.
+- [ ] Add or update unit tests for replay-consumption verification before
+  touching production code.
+- [ ] Add or update `pytest-bdd` scenarios covering the verify-time failure
+  before touching production code.
+- [ ] Implement controller-side replay-consumption verification in
+  `cmd_mox/controller.py`.
+- [ ] Update the design doc, usage guide, and roadmap.
+- [ ] Run all required quality gates and record the results in this document if
+  the plan moves into execution.
+
+## Surprises & Discoveries
+
+- `ReplaySession.verify_all_consumed()` already exists and already formats the
+  exact `VerificationError` message this roadmap item needs. The missing work
+  is controller integration, not replay-engine design.
+- `CmdMox.verify()` currently runs replay teardown before recording-session
+  finalisation, but replay-consumption verification is absent entirely. The
+  implementation must add the check without regressing cleanup.
+- Existing BDD infrastructure already supports
+  `When I verify the controller expecting an VerificationError` and
+  `Then the verification error message should contain "..."`, so this feature
+  should need only a small scenario addition rather than new plumbing.
+- The current usage guide already documents `allow_unmatched=True` for direct
+  `ReplaySession` use. The plan should preserve that documentation path rather
+  than inventing a new `.replay(..., allow_unmatched=...)` API.
+- Focused red/green test runs need
+  `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run pytest ...` rather than
+  plain `pytest`, because the repo does not put the test runner directly on
+  `PATH`.
+
+## Decision Log
+
+- Decision: verify replay consumption in the controller by calling
+  `ReplaySession.verify_all_consumed()` for each attached replay session after
+  the existing mock/order/unexpected-command verifiers and before teardown
+  finalisers. Rationale: this keeps replay consumption as part of verification
+  rather than cleanup, while still letting the existing `finally` block run.
+
+- Decision: keep `ReplaySession.verify_all_consumed()` as the single source of
+  truth for unconsumed-recording semantics, including the
+  `allow_unmatched=True` branch and the diagnostic message shape. Rationale:
+  this avoids semantic drift between direct `ReplaySession` usage and
+  controller-driven replay.
+
+- Decision: preserve the current public API. `12.2.5` should not add new
+  fluent options to `.replay()` or new replay configuration objects. Rationale:
+  the roadmap item is controller verification, not API expansion.
+
+- Decision: treat the existing controller replay success scenarios as the
+  consumed-path regression tests, and add one explicit controller scenario for
+  the unconsumed-path failure. Rationale: the feature needs behavioural
+  coverage, but the happy path is already exercised end-to-end.
+
+- Decision: do not mark `docs/cmd-mox-roadmap.md` item `12.2.5` done until the
+  implementation is approved, merged into the working tree, and all required
+  quality gates pass. Rationale: drafting the plan alone is not feature
+  completion.
+
+## Plan of work
+
+### Stage A: Add failing unit tests first
+
+Extend `cmd_mox/unittests/test_controller_replay.py` with controller-level
+verification tests that demonstrate the missing behaviour before production code
+changes. Keep these tests focused on user-visible controller outcomes, not on
+private replay-session internals.
+
+Add at least these unit tests:
+
+1. A test where a spy attaches a replay fixture, no invocation consumes the
+   fixture, and `mox.verify()` raises `VerificationError` containing
+   `Not all fixture recordings were consumed during replay`.
+2. A test where a replay-backed spy consumes the fixture and `mox.verify()`
+   succeeds, proving the new verification does not break the happy path.
+3. A test where a replay session is attached with `allow_unmatched=True` and
+   `mox.verify()` does not raise for unused fixture entries. If the cleanest
+   setup requires constructing `ReplaySession` directly and assigning it to the
+   double in the test, document that in the test comment rather than expanding
+   production API.
+4. A cleanup regression test, likely in
+   `cmd_mox/unittests/test_controller_lifecycle.py`, proving that a
+   `VerificationError` from replay-consumption verification still leaves
+   `EnvironmentManager.get_active_manager()` as `None`, sets `mox._entered` to
+   `False`, and leaves the controller in `Phase.VERIFY` after `verify()`
+   returns or raises.
+
+Run a focused red-phase command and confirm the new or modified tests fail for
+the expected reason:
+
+```bash
+set -o pipefail
+UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run pytest \
+  cmd_mox/unittests/test_controller_replay.py \
+  cmd_mox/unittests/test_controller_lifecycle.py \
+  2>&1 | tee /tmp/12-2-5-unit-red.log
+```
+
+Record the observed failing assertion briefly in `Surprises & Discoveries` once
+implementation begins.
+
+### Stage B: Add one behavioural scenario for the verify-time failure
+
+Extend `features/controller.feature` with a new scenario that proves the
+consumer-visible failure mode. Keep it minimal:
+
+1. Create a `CmdMox` controller.
+2. Create a replay fixture.
+3. Attach the fixture to a spy.
+4. Enter replay mode but do not run the command.
+5. Verify the controller expecting `VerificationError`.
+6. Assert that the verification message contains the unconsumed-recordings
+   text.
+
+Prefer reusing existing steps in `tests/steps/controller_setup.py` and
+`tests/steps/assertions.py`. Only add a new step in
+`tests/steps/controller_replay.py` if the scenario needs replay-specific setup
+that is not already expressed clearly.
+
+Run a focused behavioural red-phase command:
+
+```bash
+set -o pipefail
+UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run pytest \
+  tests/test_controller_bdd.py -k "replay or verify" \
+  2>&1 | tee /tmp/12-2-5-bdd-red.log
+```
+
+### Stage C: Implement controller verification with minimal surface area
+
+Modify `cmd_mox/controller.py` with the smallest possible change set.
+
+Preferred shape:
+
+1. Add a private helper such as `_verify_replay_sessions_consumed()` that
+   iterates `self._doubles.values()`.
+2. For each double whose `replay_session` property is not `None`, call
+   `replay_session.verify_all_consumed()`.
+3. Call that helper from `CmdMox.verify()` after `_run_verifiers()` succeeds
+   and before entering the `finally` block's teardown finalisers, or fold it
+   into `_run_verifiers()` if that is measurably cleaner. Either placement is
+   acceptable so long as cleanup still runs on failure and the plan’s tests
+   pass.
+4. Do not inspect `ReplaySession._consumed` or any other private replay state
+   from the controller.
+5. Do not alter `_response_for_replay()` or replay matching rules unless a test
+   demonstrates a direct regression in `12.2.5`.
+
+Run the focused unit and behavioural suites again until they pass:
+
+```bash
+set -o pipefail
+UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run pytest \
+  cmd_mox/unittests/test_controller_replay.py \
+  cmd_mox/unittests/test_controller_lifecycle.py \
+  tests/test_controller_bdd.py \
+  2>&1 | tee /tmp/12-2-5-focused-green.log
+```
+
+### Stage D: Update documentation and roadmap
+
+Update the documentation immediately after the code and tests settle:
+
+- `docs/python-native-command-mocking-design.md`
+  - record the final placement of replay-consumption verification inside the
+    controller lifecycle and any deliberate decision about error precedence.
+- `docs/usage-guide.md`
+  - explain that `CmdMox.verify()` now enforces full fixture consumption for
+    replay-backed spies and point readers to `allow_unmatched=True` in the
+    direct `ReplaySession` section when tolerant verification is desired.
+- `docs/cmd-mox-roadmap.md`
+  - change `12.2.5` from unchecked to checked only after code, tests, and
+    quality gates are complete.
+
+If implementation reveals a stronger or narrower design rule than this draft
+states, record it in `Decision Log` before closing the work.
+
+### Stage E: Run the full quality gates
+
+Run the full repository gates with `tee` and `pipefail`, then inspect the logs
+if anything fails:
+
+```bash
+set -o pipefail
+make markdownlint 2>&1 | tee /tmp/12-2-5-markdownlint.log
+```
+
+```bash
+set -o pipefail
+make nixie 2>&1 | tee /tmp/12-2-5-nixie.log
+```
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/12-2-5-check-fmt.log
+```
+
+```bash
+set -o pipefail
+make typecheck 2>&1 | tee /tmp/12-2-5-typecheck.log
+```
+
+```bash
+set -o pipefail
+make lint 2>&1 | tee /tmp/12-2-5-lint.log
+```
+
+```bash
+set -o pipefail
+make test 2>&1 | tee /tmp/12-2-5-test.log
+```
+
+Once all six commands succeed, update `Progress`, add the final verification
+summary to `Outcomes & Retrospective`, and only then mark roadmap item
+`12.2.5` done.
+
+## Outcomes & Retrospective
+
+This section is intentionally blank during draft phase. When implementation is
+complete, replace this note with a concise summary of what shipped, what tests
+proved it, which documentation changed, and any lessons that should shape later
+replay work such as roadmap item `12.2.6`.

--- a/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
+++ b/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -218,25 +218,31 @@ The implementer should keep these references open while executing the plan:
   and the current controller and replay-session seams.
 - [x] Drafted this ExecPlan in
   `docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md`.
-- [ ] Obtain explicit user approval for this plan before implementation.
-- [ ] Add or update unit tests for replay-consumption verification before
+- [x] User approved implementation by requesting execution of this plan.
+- [x] Add or update unit tests for replay-consumption verification before
   touching production code.
-- [ ] Add or update `pytest-bdd` scenarios covering the verify-time failure
+- [x] Add or update `pytest-bdd` scenarios covering the verify-time failure
   before touching production code.
-- [ ] Implement controller-side replay-consumption verification in
+- [x] Implement controller-side replay-consumption verification in
   `cmd_mox/controller.py`.
-- [ ] Update the design doc, usage guide, and roadmap.
-- [ ] Run all required quality gates and record the results in this document if
-  the plan moves into execution.
+- [x] Update the design doc, usage guide, and roadmap.
+- [x] Run all required quality gates and record the results in this document.
 
 ## Surprises & Discoveries
 
 - `ReplaySession.verify_all_consumed()` already exists and already formats the
   exact `VerificationError` message this roadmap item needs. The missing work
   is controller integration, not replay-engine design.
+- `CmdMox._run_verifiers()` is the narrowest safe insertion point. Extending it
+  preserves the existing `verify()` cleanup structure, which already guarantees
+  both finalisers run and that the first failure wins.
 - `CmdMox.verify()` currently runs replay teardown before recording-session
   finalisation, but replay-consumption verification is absent entirely. The
   implementation must add the check without regressing cleanup.
+- Existing fuzzy replay fallback behaviour remains unchanged at invocation time,
+  but `verify()` now fails afterwards if the fallback path left the fixture
+  recording unused. The affected BDD scenario had to move from verify-success
+  to verify-failure expectations.
 - Existing BDD infrastructure already supports
   `When I verify the controller expecting an VerificationError` and
   `Then the verification error message should contain "..."`, so this feature
@@ -248,6 +254,14 @@ The implementer should keep these references open while executing the plan:
   `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run pytest ...` rather than
   plain `pytest`, because the repo does not put the test runner directly on
   `PATH`.
+- Red-phase confirmation:
+  - `cmd_mox/unittests/test_controller_replay.py::TestControllerReplayVerification.test_verify_raises_when_replay_fixture_has_unconsumed_recordings`
+    failed with `Failed: DID NOT RAISE <class 'cmd_mox.errors.VerificationError'>`.
+  - `cmd_mox/unittests/test_controller_lifecycle.py::test_verify_cleans_up_when_replay_consumption_verification_raises`
+    failed with the same missing-error assertion.
+  - `tests/test_controller_bdd.py::test_replay_backed_spy_fails_verification_when_fixture_recordings_remain_unused`
+    failed in `verify_controller_expect_error()` with the same missing-error
+    assertion.
 
 ## Decision Log
 
@@ -262,6 +276,17 @@ The implementer should keep these references open while executing the plan:
   `allow_unmatched=True` branch and the diagnostic message shape. Rationale:
   this avoids semantic drift between direct `ReplaySession` usage and
   controller-driven replay.
+
+- Decision: integrate replay-consumption verification into
+  `CmdMox._run_verifiers()` rather than adding a separate top-level verification
+  phase in `CmdMox.verify()`. Rationale: the check is semantically part of
+  verification, and this placement preserves the existing teardown and
+  error-precedence behaviour with the smallest controller change.
+
+- Decision: keep fuzzy replay fallback behaviour at invocation time and surface
+  incomplete fixture consumption only during `verify()`. Rationale: runtime
+  fallback remains useful for additive replay scenarios, while verify-time
+  enforcement still prevents silent partial-fixture tests.
 
 - Decision: preserve the current public API. `12.2.5` should not add new
   fluent options to `.replay()` or new replay configuration objects. Rationale:
@@ -436,7 +461,40 @@ summary to `Outcomes & Retrospective`, and only then mark roadmap item
 
 ## Outcomes & Retrospective
 
-This section is intentionally blank during draft phase. When implementation is
-complete, replace this note with a concise summary of what shipped, what tests
-proved it, which documentation changed, and any lessons that should shape later
-replay work such as roadmap item `12.2.6`.
+`CmdMox.verify()` now enforces full replay-fixture consumption by calling a new
+controller helper, `_verify_replay_sessions_consumed()`, from
+`CmdMox._run_verifiers()`. That helper iterates attached replay sessions via
+the existing `CommandDouble.replay_session` property and delegates the actual
+check to `ReplaySession.verify_all_consumed()`, preserving the existing
+cleanup-first `finally` behaviour in `verify()`.
+
+The shipped test coverage proves both behaviour and cleanup:
+
+- Focused red/green coverage was added in
+  `cmd_mox/unittests/test_controller_replay.py`,
+  `cmd_mox/unittests/test_controller_lifecycle.py`,
+  `features/controller.feature`, and `tests/test_controller_bdd.py`.
+- The new tests cover verify-time failure for unused recordings, successful
+  verification after full consumption, the direct `allow_unmatched=True`
+  opt-out path, and cleanup after replay-consumption verification raises.
+- An existing fuzzy replay BDD scenario was updated to reflect the final
+  contract: fuzzy mismatch still falls back at invocation time, then
+  `verify()` raises if the fixture recording remained unused.
+
+Documentation was updated in `docs/usage-guide.md` and
+`docs/python-native-command-mocking-design.md`, and roadmap item `12.2.5` is
+now marked complete in `docs/cmd-mox-roadmap.md`.
+
+Final gate results:
+
+- `make markdownlint`: passed
+- `make nixie`: passed
+- `make check-fmt`: passed
+- `make typecheck`: passed
+- `make lint`: passed
+- `make test`: passed (`738 passed, 12 skipped`)
+
+Lesson for follow-on replay work: fuzzy replay is now explicitly a two-stage
+contract. Invocation-time matching may be permissive, but verify-time fixture
+consumption remains strict unless a caller opts into `allow_unmatched=True`
+through direct `ReplaySession` construction.

--- a/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
+++ b/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
@@ -32,7 +32,7 @@ Observable success after implementation:
    successfully.
 3. The implementation reuses `ReplaySession.verify_all_consumed()` rather than
    duplicating consumption logic inside the controller.
-4. `CmdMox.verify()` still tears down the IPC server and finalises recording
+4. `CmdMox.verify()` still tears down the IPC server and finalizes recording
    sessions even when replay-consumption verification fails.
 5. Unit tests written with `pytest` fail before the code change and pass after
    it.
@@ -100,11 +100,11 @@ exists:
     home for controller-level replay-verification tests.
 - `cmd_mox/unittests/test_controller_lifecycle.py`
   - already covers the rule that `verify()` must still clean up when later
-    finalisation steps raise.
+    finalization steps raise.
 - `features/controller.feature`, `tests/test_controller_bdd.py`,
   `tests/steps/controller_setup.py`, and `tests/steps/controller_replay.py`
-  already provide controller-level behavioural coverage and reusable
-  step definitions for verify-time errors.
+  already provide controller-level behavioural coverage and reusable step
+  definitions for verify-time errors.
 - `docs/python-native-command-mocking-design.md`
   - already says that `verify()` should call
     `ReplaySession.verify_all_consumed()`, but it does not yet pin down the
@@ -147,7 +147,7 @@ The implementer should keep these references open while executing the plan:
   consumption checks, and `CmdMox` delegates unconsumed-recording detection to
   that API.
 - Preserve existing cleanup guarantees in `CmdMox.verify()`: IPC teardown and
-  recording-session finalisation must still run even if replay-consumption
+  recording-session finalization must still run even if replay-consumption
   verification fails.
 - The test and documentation updates stayed within the existing project
   layout: unit tests under `cmd_mox/unittests/`, behavioural tests under
@@ -164,8 +164,7 @@ The implementer should keep these references open while executing the plan:
   changes. Those belong to other roadmap items.
 - Ordering tolerance: stop and escalate if replay-consumption verification
   cannot be added with a focused controller helper or a small extension to
-  `_run_verifiers()`. This item should not require a wide controller
-  refactor.
+  `_run_verifiers()`. This item should not require a wide controller refactor.
 - Error-precedence tolerance: preserve the current broad `verify()` error
   contract unless tests prove a regression. Do not opportunistically redesign
   how earlier verification errors interact with later cleanup errors without
@@ -186,7 +185,7 @@ The implementer should keep these references open while executing the plan:
   happen before the verification check. Mitigation: write an ordering-focused
   unit test before changing controller code.
 - Risk: the controller already has one cleanup regression test for recording
-  finalisation errors, but not for replay-verification failures. Mitigation:
+  finalization errors, but not for replay-verification failures. Mitigation:
   add a red-phase test that proves environment cleanup still happens when
   replay verification raises.
 - Risk: `.replay()` does not expose `allow_unmatched`, so there is no fluent
@@ -227,12 +226,12 @@ The implementer should keep these references open while executing the plan:
   is controller integration, not replay-engine design.
 - `CmdMox._run_verifiers()` is the narrowest safe insertion point. Extending it
   preserves the existing `verify()` cleanup structure, which already guarantees
-  both finalisers run and that the first failure wins.
+  both finalizers run and that the first failure wins.
 - `CmdMox.verify()` currently runs replay teardown before recording-session
-  finalisation, but replay-consumption verification is absent entirely. The
+  finalization, but replay-consumption verification is absent entirely. The
   implementation must add the check without regressing cleanup.
 - Existing fuzzy replay fallback behaviour remains unchanged at invocation time,
-  but `verify()` now fails afterwards if the fallback path left the fixture
+  but `verify()` now fails afterward if the fallback path left the fixture
   recording unused. The affected BDD scenario had to move from verify-success
   to verify-failure expectations.
 - Existing BDD infrastructure already supports
@@ -260,7 +259,7 @@ The implementer should keep these references open while executing the plan:
 - Decision: verify replay consumption in the controller by calling
   `ReplaySession.verify_all_consumed()` for each attached replay session after
   the existing mock/order/unexpected-command verifiers and before teardown
-  finalisers. Rationale: this keeps replay consumption as part of verification
+  finalizers. Rationale: this keeps replay consumption as part of verification
   rather than cleanup, while still letting the existing `finally` block run.
 
 - Decision: keep `ReplaySession.verify_all_consumed()` as the single source of
@@ -270,9 +269,9 @@ The implementer should keep these references open while executing the plan:
   controller-driven replay.
 
 - Decision: integrate replay-consumption verification into
-  `CmdMox._run_verifiers()` rather than adding a separate top-level verification
-  phase in `CmdMox.verify()`. Rationale: the check is semantically part of
-  verification, and this placement preserves the existing teardown and
+  `CmdMox._run_verifiers()` rather than adding a separate top-level
+  verification phase in `CmdMox.verify()`. Rationale: the check is semantically
+  part of verification, and this placement preserves the existing teardown and
   error-precedence behaviour with the smallest controller change.
 
 - Decision: keep fuzzy replay fallback behaviour at invocation time and surface
@@ -299,9 +298,9 @@ The implementer should keep these references open while executing the plan:
 ### Stage A: Add failing unit tests first
 
 Extend `cmd_mox/unittests/test_controller_replay.py` with controller-level
-verification tests that demonstrate the missing behaviour before production code
-changes. Keep these tests focused on user-visible controller outcomes, not on
-private replay-session internals.
+verification tests that demonstrate the missing behaviour before production
+code changes. Keep these tests focused on user-visible controller outcomes, not
+on private replay-session internals.
 
 Add at least these unit tests:
 
@@ -374,7 +373,7 @@ Preferred shape:
 2. For each double whose `replay_session` property is not `None`, call
    `replay_session.verify_all_consumed()`.
 3. Call that helper from `CmdMox.verify()` after `_run_verifiers()` succeeds
-   and before entering the `finally` block's teardown finalisers, or fold it
+   and before entering the `finally` block's teardown finalizers, or fold it
    into `_run_verifiers()` if that is measurably cleaner. Either placement is
    acceptable so long as cleanup still runs on failure and the plan’s tests
    pass.
@@ -447,9 +446,9 @@ set -o pipefail
 make test 2>&1 | tee /tmp/12-2-5-test.log
 ```
 
-All six commands succeeded, `Progress` records completion, `Outcomes &
-Retrospective` captures the final verification summary, and roadmap item
-`12.2.5` is marked done.
+All six commands succeeded, `Progress` records completion,
+`Outcomes & Retrospective` captures the final verification summary, and roadmap
+item `12.2.5` is marked done.
 
 ## Outcomes & Retrospective
 
@@ -470,8 +469,8 @@ The shipped test coverage proves both behaviour and cleanup:
   verification after full consumption, the direct `allow_unmatched=True`
   opt-out path, and cleanup after replay-consumption verification raises.
 - An existing fuzzy replay BDD scenario was updated to reflect the final
-  contract: fuzzy mismatch still falls back at invocation time, then
-  `verify()` raises if the fixture recording remained unused.
+  contract: fuzzy mismatch still falls back at invocation time, then `verify()`
+  raises if the fixture recording remained unused.
 
 Documentation was updated in `docs/usage-guide.md` and
 `docs/python-native-command-mocking-design.md`, and roadmap item `12.2.5` is

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -2541,7 +2541,40 @@ class CmdMox:
 
 Replay integration in `_make_response()` is intentionally separate from replay
 consumption verification in `verify()`. The former is roadmap item `12.2.4`;
-the latter remains `12.2.5`.
+the latter is implemented by extending the existing verifier pass rather than
+the teardown path:
+
+```python
+class CmdMox:
+    def _run_verifiers(self) -> None:
+        """Execute mock, order, and replay-consumption verification."""
+        expectations = {n: d.expectation for n, d in self.mocks.items()}
+        inv_map = {n: d.invocations for n, d in self.mocks.items()}
+
+        UnexpectedCommandVerifier().verify(self.journal, self._doubles)
+        OrderVerifier(self._ordered).verify(self.journal)
+        CountVerifier().verify(expectations, inv_map)
+        self._verify_replay_sessions_consumed()
+
+    def _verify_replay_sessions_consumed(self) -> None:
+        """Fail verify() when any attached replay fixture is left unused."""
+        for double in self._doubles.values():
+            replay_session = double.replay_session
+            if replay_session is not None:
+                replay_session.verify_all_consumed()
+```
+
+This ordering keeps replay completeness as part of verification rather than
+cleanup. `verify()` still enters its existing `finally` block afterwards, so
+IPC teardown and recording-session finalization run even when
+`verify_all_consumed()` raises `VerificationError`.
+
+One subtle consequence is that fuzzy replay remains additive at invocation
+time but not at verification time. A fuzzy mismatch can fall back to the spy's
+configured handler or canned response, yet `verify()` still fails later if the
+fixture recording was never consumed. Tests that intentionally use only part of
+a fixture must construct `ReplaySession(..., allow_unmatched=True)` directly
+rather than relying on `.replay()`.
 
 ### 9.9 Security Considerations
 
@@ -2870,7 +2903,9 @@ misses fall back to the spy's configured behaviour.
 - Raising immediately on strict mismatches surfaces the failure at the exact
   invocation that violated the fixture contract
 - Allowing fuzzy mismatches to fall back keeps fuzzy replay additive and useful
-  for partial-fixture scenarios
+  for invocation-time partial-fixture scenarios, while verify-time consumption
+  checks still catch unused recordings unless `allow_unmatched=True` is used
+  with a direct `ReplaySession`
 
 **Alternatives considered:**
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -559,6 +559,10 @@ If strict replay is enabled and no fixture recording matches the live
 invocation, CmdMox raises `UnexpectedCommandError` immediately during command
 handling. If fuzzy replay is enabled and no fixture recording matches, CmdMox
 falls back to the spy's configured response or handler instead of raising.
+Either way, `CmdMox.verify()` later calls `verify_all_consumed()` for every
+attached replay session. Any fixture entries left unused at verify time raise
+`VerificationError` unless the session was created directly with
+`allow_unmatched=True`.
 
 ### Creating and loading a replay session
 
@@ -665,10 +669,15 @@ session.verify_all_consumed()
 
 `verify_all_consumed()` raises `VerificationError` if any recording was not
 consumed, listing the unconsumed recordings by index, command, and arguments.
+`CmdMox.verify()` applies the same check automatically to replay-backed spies,
+so attaching a fixture through `.replay()` means tests must consume every
+recording before verification completes.
 
 When `allow_unmatched=True`, `verify_all_consumed()` always succeeds regardless
 of how many recordings remain unconsumed. This is useful for fixtures that
-contain more recordings than a specific test exercises.
+contain more recordings than a specific test exercises. The fluent
+`.replay()` helper does not expose this opt-out; use `ReplaySession`
+directly when partial-consumption verification is the intended behaviour.
 
 ## Pipelines and shell syntax
 

--- a/features/controller.feature
+++ b/features/controller.feature
@@ -94,6 +94,14 @@ Feature: CmdMox basic functionality
     When I verify the controller
     Then the journal entry for "git" should record arguments "status" stdin "<empty>" env var "EXPECT_ENV"="VALUE"
 
+  Scenario: replay-backed spy fails verification when fixture recordings remain unused
+    Given a CmdMox controller
+    And a git replay fixture exists
+    And the command "git" is spied with that replay fixture
+    When I replay the controller
+    And I verify the controller expecting an VerificationError
+    Then the verification error message should contain "Not all fixture recordings were consumed during replay"
+
   Scenario: strict replay mismatch fails during invocation handling
     Given a CmdMox controller
     And a git replay fixture exists
@@ -103,15 +111,16 @@ Feature: CmdMox basic functionality
     And the spy "git" should record 0 invocation
     And the journal should contain 0 invocation of "git"
 
-  Scenario: fuzzy replay mismatch falls back to spy response
+  Scenario: fuzzy replay mismatch falls back to spy response before verify-time failure
     Given a CmdMox controller
     And a git replay fixture exists
     And the command "git" is spied with fuzzy replay and fallback "fallback"
     When I replay the controller
     And I run the command "git" with arguments "commit"
     Then the output should be "fallback"
-    When I verify the controller
-    Then the spy "git" should record 1 invocation
+    When I verify the controller expecting an VerificationError
+    Then the verification error message should contain "Not all fixture recordings were consumed during replay"
+    And the spy "git" should record 1 invocation
     And the journal should contain 1 invocation of "git"
 
   Scenario: spy assertion helpers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
     "pytest",
 	"pytest-xdist",
     "ruff",
+    "ty",
     "pytest-timeout",
     "pytest-bdd",
     "parse_type",

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -1,4 +1,4 @@
-"""Shared test fixture utilities for creating minimal valid replay fixtures."""
+"""Shared test fixture utilities for creating replay fixtures."""
 
 from __future__ import annotations
 
@@ -49,6 +49,38 @@ def write_minimal_replay_fixture(
                 duration_ms=0,
             )
         ],
+        scrubbing_rules=[],
+    )
+    path = tmp_path / filename
+    fixture.save(path)
+    return path
+
+
+def write_replay_fixture(
+    tmp_path: Path,
+    recordings: list[RecordedInvocation],
+    filename: str = "fixture.json",
+) -> Path:
+    """Write a replay fixture containing the provided recordings.
+
+    Parameters
+    ----------
+    tmp_path:
+        Temporary directory path (typically from pytest's tmp_path fixture).
+    recordings:
+        Recorded invocations to persist in the fixture.
+    filename:
+        Name for the fixture file. Defaults to ``"fixture.json"``.
+
+    Returns
+    -------
+    Path
+        The full path to the created fixture file.
+    """
+    fixture = FixtureFile(
+        version=FixtureFile.SCHEMA_VERSION,
+        metadata=FixtureMetadata.create(),
+        recordings=recordings,
         scrubbing_rules=[],
     )
     path = tmp_path / filename

--- a/tests/test_controller_bdd.py
+++ b/tests/test_controller_bdd.py
@@ -105,6 +105,15 @@ def test_replay_backed_spy_applies_expectation_environment() -> None:
 
 @scenario(
     str(FEATURES_DIR / "controller.feature"),
+    "replay-backed spy fails verification when fixture recordings remain unused",
+)
+def test_replay_backed_spy_fails_verification_with_unused_fixture() -> None:
+    """Replay-backed spies should fail verification if fixture entries are unused."""
+    pass
+
+
+@scenario(
+    str(FEATURES_DIR / "controller.feature"),
     "strict replay mismatch fails during invocation handling",
 )
 def test_strict_replay_mismatch_fails_during_invocation_handling() -> None:
@@ -114,10 +123,10 @@ def test_strict_replay_mismatch_fails_during_invocation_handling() -> None:
 
 @scenario(
     str(FEATURES_DIR / "controller.feature"),
-    "fuzzy replay mismatch falls back to spy response",
+    "fuzzy replay mismatch falls back to spy response before verify-time failure",
 )
-def test_fuzzy_replay_mismatch_falls_back_to_spy_response() -> None:
-    """Fuzzy replay should fall back to the spy's configured response."""
+def test_fuzzy_replay_mismatch_falls_back_before_verify_failure() -> None:
+    """Fuzzy replay falls back at runtime, then fails verification if unused."""
     pass
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -31,6 +32,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [[package]]
@@ -275,6 +277,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.33"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ca/ba1eed819895bd239fba8ee35dfcd5fcb266c203b0914a17a59579096bb5/ty-0.0.33-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4a2b5ba078f90de342f56b5f7979bb77c9b9b1d8625a041352ffc6ee93c4073", size = 10777272, upload-time = "2026-04-28T10:45:32.905Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a8/c3131d37b44b3fea1d6654a1c929a0cd0873822f77a90482b8ec28f6fbbd/ty-0.0.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:84ff5707825e9af9668d2bcf66975f93e520a63b524ab494e3a8265735be2563", size = 10201078, upload-time = "2026-04-28T10:45:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/db/d8e37ff0045810cc65e1ff36aa0da0a2253c05659787ac987df8a16c7897/ty-0.0.33-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e375285736f57886868e7af0b11c7b0ec5b6543fa15e7ad2a714fed9f077d4e0", size = 10732347, upload-time = "2026-04-28T10:45:21.444Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1a/20e83a412506a918e4684fc67b567cf7cc13b105470b3428cb23c3d5aa13/ty-0.0.33-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5680f6350c3b4e46b8bff6d7bb132366ea239463d6cad4892725d06046e65464", size = 10808238, upload-time = "2026-04-28T10:45:38.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/4b/d0a39f4464dc6cb4cc2c159473ce216bd1846bfb684c0323a3cb36dce5c6/ty-0.0.33-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5535538bad8d0f7e62bcdff02197cdb30e41451d80b35d27e17d128f2e1dc5d", size = 11288348, upload-time = "2026-04-28T10:45:08.419Z" },
+    { url = "https://files.pythonhosted.org/packages/35/7e/f1745e0f9583363d7a83d9a4990fc244f76ecc30840ddad83dc16a33c52d/ty-0.0.33-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da196c42bbbc069e1e21e3e52107c061aa9660352dae57a41930690b56e2c02d", size = 11789907, upload-time = "2026-04-28T10:45:19.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/71/25f39f46a12d662859d45bc648555d0661044eb43db6b5648c9947487da9/ty-0.0.33-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9281672921ef6d4460e03146b5e6c18cb1a3e3a3b8a1a88f6f33226d05a469b7", size = 11500774, upload-time = "2026-04-28T10:45:48.012Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ec/136959ecbb7c71cb90537f5aea441c73f4ab24612868a6ecdc9d7444d32d/ty-0.0.33-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c1b8f303f82da64e878108e764be3ecbcd7c9903ac0a7f7031614ed00b97ab", size = 11360314, upload-time = "2026-04-28T10:45:05.402Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/95/32809575c222f00beed498cb728e9290a0f5009f930025381bb7253b2206/ty-0.0.33-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:efe3af412c9ff67bce5fa37d0a2b0d8555c24072b145a5bac6c79637f1c83abe", size = 10707785, upload-time = "2026-04-28T10:45:10.836Z" },
+    { url = "https://files.pythonhosted.org/packages/13/89/c8e9531f7aa4a093359e15fa32c8e1277fbbe90d16894d7c6032d29f4b34/ty-0.0.33-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aeec29c91ea768601747da546c3efc20b72c2fb1bd52bcc786a5c6eeff51d27b", size = 10834987, upload-time = "2026-04-28T10:45:40.738Z" },
+    { url = "https://files.pythonhosted.org/packages/31/16/9835fbcf5338af1a1917bd28fdb8a7193c210b83f243aa286fa9f79cb3ad/ty-0.0.33-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a535977c52bbb5f7e96b8b70a6ad375ad077f4a9ff2492508ea3816a2b403819", size = 10968968, upload-time = "2026-04-28T10:45:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/36/69/64c76aabc1bc70c7f24b686cd93c3407f8ea430905e395f59bf9603ef571/ty-0.0.33-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d732facf39fcb221ba279d469c5040d37883e964f123b1563888efd34818180", size = 11458077, upload-time = "2026-04-28T10:45:45.971Z" },
+    { url = "https://files.pythonhosted.org/packages/91/84/fae27b0c4718776a298690d31ca4cc1995f2e3e1c63a7b59e84c41498e9a/ty-0.0.33-py3-none-win32.whl", hash = "sha256:d90960b574428dc252f85e8598ec5fcb7f619794196b2fc95a90da075ed4681c", size = 10345364, upload-time = "2026-04-28T10:45:16.836Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a0/a2938b23ae3e1a09a2d7c189e2ac5f7113676bae4e0e23948b568e18e5f8/ty-0.0.33-py3-none-win_amd64.whl", hash = "sha256:c1c3aec62c44de610c6e95f0a4e97ac3dbc07934bfdbf1fd90d758c9ff72f48e", size = 11342470, upload-time = "2026-04-28T10:45:26.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/62/7fb948aace38d2f6329261bb33c035a8484549c74f1db28649c7a4c6fed9/ty-0.0.33-py3-none-win_arm64.whl", hash = "sha256:0d44f99ba1b441e55e2aa301b2ac0a21112784931b46a5f66f4ea9efe5620d97", size = 10742673, upload-time = "2026-04-28T10:45:35.555Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Implements runtime verification in CmdMox.verify() to fail when a replay fixture attached to a spy has unconsumed recordings (12.2.5). Adds an ExecPlan document, tests, and small typing/test adjustments. The change moves beyond planning and enacts the verification behavior while preserving existing teardown guarantees.

## Changes
- cmd_mox/controller.py
  - Add private helper `_verify_replay_sessions_consumed()` and invoke it from the verification flow to call `replay_session.verify_all_consumed()` for each attached replay session.
- cmd_mox/ipc/server.py
  - NamedPipeServer: add `_pipe_name: str` to satisfy typing for Windows named pipe variant.
- cmd_mox/unittests/test_controller_environment_manager.py
  - Adjust test to cast `None` to `EnvironmentManager` for typing compatibility.
- cmd_mox/unittests/test_controller_lifecycle.py
  - Update tests to align with typing and new verification flow.
- cmd_mox/unittests/test_controller_replay.py
  - Introduce tests that exercise replay-consumption verification behavior and assertions around unconsumed recordings.
- docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
  - Added a new ExecPlan outlining goals, constraints, progress, and staged plan for enforcing unconsumed-recordings reporting in CmdMox.verify().
- docs/cmd-mox-roadmap.md
  - Mark roadmap item 12.2.5 as complete to reflect implementation and testing now in place.
- docs/usage-guide.md
  - Update to explain that verify() enforces full fixture consumption for replay-backed spies, with an opt-out path via direct ReplaySession usage (e.g., `allow_unmatched=True`).
- features/controller.feature
  - Added a scenario to verify that replay-backed spies fail verification when fixture recordings remain unused.
- tests/helpers/fixtures.py
  - Added `write_replay_fixture(...)` helper to construct fixtures with explicit recordings.
- tests/test_controller_bdd.py
  - Wire in a new scenario to cover the new verification behavior in BDD tests.
- docs/python-native-command-mocking-design.md
  - Update example snippets to reflect controller-side verification consuming fixtures during verify().

## Rationale
- Ensures that replay fixtures are fully consumed during verification, preventing silent failures where tests pass even though only part of a fixture is used. The change aligns the controller’s behavior with the intended 12.2.5 roadmap item, providing a clear error when unused fixture entries remain. The approach reuses existing ReplaySession verification logic and keeps cleanup semantics intact.

## Testing plan
- Run existing unit tests to ensure typing-related changes remain compatible.
- Add unit tests covering: (a) unconsumed fixture entries cause `VerificationError`, (b) fully consumed fixtures verify successfully, (c) direct `ReplaySession` opt-out via `allow_unmatched=True` remains functional, (d) cleanup still occurs when verification raises.
- Update behavioural tests and BDD scenarios to reflect the new verify-time failure mode.
- Focused commands for red/green validation were prepared in the ExecPlan and wired into tests accordingly.

## Documentation
- Added ExecPlan documenting the staged approach for implementing unconsumed-recordings reporting in CmdMox.verify().
- Updated usage guidance to describe new verify-time behavior and opt-out considerations.
- Updated the roadmap to reflect completion of 12.2.5.

## Notes
- This PR changes runtime behavior by introducing verification for unconsumed replay recordings. It still preserves the existing cleanup guarantees in `CmdMox.verify()`.
- Do not mark roadmap item 12.2.5 as done until the implementation, tests, and gates complete in CI.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---
Task: https://www.devboxer.com/task/4e589d87-0dc8-45ec-9254-ed04dcd3edc0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification now enforces that replay fixture recordings are fully consumed; verify() raises a VerificationError for unused recordings by default.

* **Documentation**
  * Updated design, roadmap, usage, and exec-plan docs describing fixture-consumption verification and the explicit opt-out path.

* **Tests**
  * Added unit, integration, BDD tests and helpers covering replay fixture consumption and verify-time behavior.

* **Refactor**
  * Improved runtime bootstrap and path-handling robustness.

* **Chores**
  * Build/test tooling and dev dependency configuration updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->