### PR TITLE
Align roadmap with the roadmap grammar

### DIFF
--- a/docs/cmd-mox-fake-capabilities-design.md
+++ b/docs/cmd-mox-fake-capabilities-design.md
@@ -4,7 +4,7 @@ Status: Draft
 Audience: CmdMox maintainers and contributors  
 Companion documents:
 [`python-native-command-mocking-design.md`](./python-native-command-mocking-design.md),
-[`cmd-mox-roadmap.md`](./cmd-mox-roadmap.md)
+[`roadmap.md`](./roadmap.md)
 
 This design extends CmdMox with reusable helpers for realistic command fakes.
 The immediate trigger is the `fake-uv.py` fixture used by

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -7,5 +7,5 @@
 - [Design Doc](./python-native-command-mocking-design.md): Design rationale.
 - [Fake Capabilities Design](./cmd-mox-fake-capabilities-design.md):
   Durable fixture writes and reusable helpers for stateful command fakes.
-- [Roadmap](./cmd-mox-roadmap.md): Planned features and progression.
+- [Roadmap](./roadmap.md): Planned features and progression.
 - [ADR 001](./adr-001-linting-architecture.md): Two-tier linting architecture.

--- a/docs/execplans/12-1-1-recording-session-class.md
+++ b/docs/execplans/12-1-1-recording-session-class.md
@@ -115,7 +115,7 @@ done.
 - [x] (2026-02-25) Record design decisions in design document. 3 decisions added
   (9.10.5, 9.10.6, 9.10.7).
 - [x] (2026-02-25) Mark XII-A roadmap items as done in
-  `docs/cmd-mox-roadmap.md`.
+  `docs/roadmap.md`.
 - [x] (2026-02-25) Run full quality gates. All pass (typecheck: 2 pre-existing
   diagnostics in `expectations.py`, not from this change).
 
@@ -184,7 +184,7 @@ All acceptance criteria met:
 - `make markdownlint`: 0 errors.
 - `docs/usage-guide.md`: Contains "Recording sessions (fixture capture)"
   section with lifecycle docs and code examples.
-- `docs/cmd-mox-roadmap.md`: XII-A sub-items marked `[x]`.
+- `docs/roadmap.md`: XII-A sub-items marked `[x]`.
 - Fixture JSON roundtrip verified by `test_from_dict_roundtrip` and
   `test_save_and_load` tests.
 - Environment filtering verified by 8 unit tests and 1 BDD scenario.
@@ -225,7 +225,7 @@ follows a record-replay-verify lifecycle.
 - `cmd_mox/__init__.py` -- Public API surface.
 - `docs/python-native-command-mocking-design.md` Section IX -- Normative spec
   for Record Mode.
-- `docs/cmd-mox-roadmap.md` -- Roadmap with XII-A checkboxes.
+- `docs/roadmap.md` -- Roadmap with XII-A checkboxes.
 - `docs/usage-guide.md` -- User-facing documentation.
 
 ### Existing test patterns
@@ -296,7 +296,7 @@ Run all quality gates and fix any issues.
 17. Run BDD tests -- confirm green.
 18. Update `docs/usage-guide.md` with recording session section.
 19. Update `docs/python-native-command-mocking-design.md` with decisions.
-20. Mark XII-A sub-items done in `docs/cmd-mox-roadmap.md`.
+20. Mark XII-A sub-items done in `docs/roadmap.md`.
 21. Run full quality gates: `make check-fmt`, `make typecheck`, `make lint`,
     `make test`, `make markdownlint`.
 22. Fix any issues, re-run gates.
@@ -314,7 +314,7 @@ The change is accepted when all of the following are true:
   baseline.
 - `docs/usage-guide.md` contains a "Recording sessions" section with example
   code.
-- `docs/cmd-mox-roadmap.md` XII-A "RecordingSession" sub-items are checked.
+- `docs/roadmap.md` XII-A "RecordingSession" sub-items are checked.
 - Fixture JSON roundtrip: `FixtureFile.from_dict(fixture.to_dict())` produces
   an equivalent object.
 - Fixture file written to disk is valid JSON matching the v1.0 schema.
@@ -352,7 +352,7 @@ If a quality gate fails:
 
 - `docs/usage-guide.md` -- new "Recording sessions" section
 - `docs/python-native-command-mocking-design.md` -- design decisions added
-- `docs/cmd-mox-roadmap.md` -- XII-A checkboxes marked done
+- `docs/roadmap.md` -- XII-A checkboxes marked done
 - `docs/execplans/7-1-1-recording-session-class.md` -- this plan (created)
 
 ## Interfaces and Dependencies

--- a/docs/execplans/12-1-2-fixture-file.md
+++ b/docs/execplans/12-1-2-fixture-file.md
@@ -29,7 +29,7 @@ After this change a developer can observe the following behaviour:
   functions that chain together (e.g. v0 -> v1 -> v2).
 
 This completes the final unchecked roadmap item under XII-A in
-`docs/cmd-mox-roadmap.md`:
+`docs/roadmap.md`:
 
 ```plaintext
 - [ ] Schema migration support for forward compatibility
@@ -165,7 +165,7 @@ All acceptance criteria met:
 - `make check-fmt`: All checks passed.
 - `make typecheck`: 0 diagnostics (ty 0.0.19).
 - `make markdownlint`: 0 errors.
-- `docs/cmd-mox-roadmap.md`: "Schema migration support" checkbox marked `[x]`.
+- `docs/roadmap.md`: "Schema migration support" checkbox marked `[x]`.
 - `docs/usage-guide.md`: Contains "Schema versioning and migration" subsection.
 - `docs/python-native-command-mocking-design.md`: Decision 9.10.8 added.
 - Existing roundtrip tests (`test_save_and_load`, `test_from_dict_roundtrip`)
@@ -207,7 +207,7 @@ supporting models. This plan adds the final XII-A item: schema migration.
 - `tests/test_recording_session_bdd.py` (36 lines) -- Scenario wiring.
 - `docs/usage-guide.md` -- User-facing docs; "Recording sessions" section at
   lines 339-434.
-- `docs/cmd-mox-roadmap.md` -- Roadmap; unchecked item at line 242.
+- `docs/roadmap.md` -- Roadmap; unchecked item at line 242.
 - `docs/python-native-command-mocking-design.md` -- Design spec; Section 9.11
   covers versioning and forward compatibility.
 
@@ -335,7 +335,7 @@ Fix any issues found. Re-run all gates after fixes.
 
 ### Stage E: Documentation updates
 
-1. `docs/cmd-mox-roadmap.md` line 242: change `[ ]` to `[x]` for "Schema
+1. `docs/roadmap.md` line 242: change `[ ]` to `[x]` for "Schema
    migration support for forward compatibility".
 
 2. `docs/usage-guide.md`: add a "Schema versioning and migration" subsection
@@ -371,7 +371,7 @@ All commands run from `/home/user/project`.
    `from_dict()`.
 8. Run `make test` -- all tests pass.
 9. Run `make check-fmt && make typecheck && make lint` -- all pass.
-10. Edit `docs/cmd-mox-roadmap.md`: mark checkbox done.
+10. Edit `docs/roadmap.md`: mark checkbox done.
 11. Edit `docs/usage-guide.md`: add migration subsection.
 12. Edit `docs/python-native-command-mocking-design.md`: add decision entry.
 13. Run `make markdownlint`.
@@ -395,7 +395,7 @@ The change is accepted when all of the following hold:
 - `make check-fmt` passes.
 - `make typecheck` produces 0 diagnostics (matching current baseline).
 - `make markdownlint` passes for edited markdown files.
-- `docs/cmd-mox-roadmap.md` line 242 shows `[x]`.
+- `docs/roadmap.md` line 242 shows `[x]`.
 - `docs/usage-guide.md` contains "Schema versioning and migration" subsection.
 - Existing fixture roundtrip tests (`test_save_and_load`,
   `test_from_dict_roundtrip`) still pass unchanged.
@@ -435,7 +435,7 @@ No state machines or filesystem mutations beyond JSON file I/O are involved.
 - `features/recording_session.feature` -- add migration BDD scenario.
 - `tests/steps/recording_session.py` -- add step definitions.
 - `tests/test_recording_session_bdd.py` -- wire new scenario.
-- `docs/cmd-mox-roadmap.md` -- mark checkbox done.
+- `docs/roadmap.md` -- mark checkbox done.
 - `docs/usage-guide.md` -- add migration subsection.
 - `docs/python-native-command-mocking-design.md` -- add design decision.
 

--- a/docs/execplans/12-1-3-add-record-method-to-command-double.md
+++ b/docs/execplans/12-1-3-add-record-method-to-command-double.md
@@ -99,7 +99,7 @@ disk. New unit tests in `cmd_mox/unittests/test_command_double_record.py` and
   skipped.
 - [x] (2026-03-01) Update `docs/usage-guide.md` with `.record()` fluent API
   documentation.
-- [x] (2026-03-01) Update `docs/cmd-mox-roadmap.md` — mark XII-A items done.
+- [x] (2026-03-01) Update `docs/roadmap.md` — mark XII-A items done.
 - [x] (2026-03-01) Update `docs/python-native-command-mocking-design.md` — add
   decision 9.10.9.
 - [x] (2026-03-01) Run full quality gates and fix any issues.
@@ -166,7 +166,7 @@ All acceptance criteria met:
 - `make nixie`: All diagrams validated.
 - `docs/usage-guide.md`: Contains "Automatic recording with `.record()`"
   section with fluent API docs and examples.
-- `docs/cmd-mox-roadmap.md`: XII-A items all marked `[x]`.
+- `docs/roadmap.md`: XII-A items all marked `[x]`.
 - `docs/python-native-command-mocking-design.md`: Decision 9.10.9 added.
 - Fluent API validated: `spy("git").passthrough().record(path)` creates a
   started session; `spy("git").record(path)` raises `ValueError`.
@@ -232,7 +232,7 @@ lifecycle.
 - `docs/python-native-command-mocking-design.md` Section 9.8.2 — Normative
   spec for `CommandDouble.record()` method signature.
 
-- `docs/cmd-mox-roadmap.md` lines 244-259 — XII-A checklist items to mark
+- `docs/roadmap.md` lines 244-259 — XII-A checklist items to mark
   done.
 
 - `docs/usage-guide.md` lines 339-443 — Existing "Recording sessions" section
@@ -312,7 +312,7 @@ Go/no-go: all tests pass (both existing and new).
 Update `docs/usage-guide.md` with new subsection documenting the `.record()`
 fluent API.
 
-Update `docs/cmd-mox-roadmap.md` to mark remaining XII-A items as done.
+Update `docs/roadmap.md` to mark remaining XII-A items as done.
 
 Update `docs/python-native-command-mocking-design.md` with decision 9.10.9.
 
@@ -337,7 +337,7 @@ Run `make check-fmt`, `make typecheck`, `make lint`, `make test`,
     call from `verify()`.
 11. Run `make test` — confirm all tests pass.
 12. Update `docs/usage-guide.md`.
-13. Update `docs/cmd-mox-roadmap.md`.
+13. Update `docs/roadmap.md`.
 14. Update `docs/python-native-command-mocking-design.md`.
 15. Run `make check-fmt && make typecheck && make lint && make test`.
 16. Fix any issues, re-run gates.
@@ -355,7 +355,7 @@ The change is accepted when all of the following are true:
   baseline (currently 0).
 - `docs/usage-guide.md` contains a section documenting the `.record()` fluent
   API with example code.
-- `docs/cmd-mox-roadmap.md` XII-A items are all checked.
+- `docs/roadmap.md` XII-A items are all checked.
 - `docs/python-native-command-mocking-design.md` contains decision 9.10.9.
 - `spy("git").passthrough().record(path)` creates a started
   `RecordingSession`; `spy("git").record(path)` raises `ValueError`.
@@ -387,7 +387,7 @@ then re-run all gates before marking complete.
 - `cmd_mox/controller.py` — add `_finalize_recording_sessions()` and call from
   `verify()`
 - `docs/usage-guide.md` — new subsection for `.record()` API
-- `docs/cmd-mox-roadmap.md` — mark XII-A items done
+- `docs/roadmap.md` — mark XII-A items done
 - `docs/python-native-command-mocking-design.md` — add decision 9.10.9
 
 ## Interfaces and Dependencies

--- a/docs/execplans/12-2-1-implement-replay-session.md
+++ b/docs/execplans/12-2-1-implement-replay-session.md
@@ -30,7 +30,7 @@ Observable success: new unit tests in
 `make check-fmt`, `make typecheck`, `make markdownlint`, and `make nixie` all
 succeed. `docs/usage-guide.md` documents the replay session API.
 `docs/python-native-command-mocking-design.md` records design decisions. The
-12.2.1 roadmap checkbox in `docs/cmd-mox-roadmap.md` is marked done.
+12.2.1 roadmap checkbox in `docs/roadmap.md` is marked done.
 
 ## Constraints
 
@@ -98,7 +98,7 @@ succeed. `docs/usage-guide.md` documents the replay session API.
 - [x] Update `docs/usage-guide.md` with replay session documentation.
 - [x] Record design decisions in
   `docs/python-native-command-mocking-design.md`.
-- [x] Mark 12.2.1 as done in `docs/cmd-mox-roadmap.md`.
+- [x] Mark 12.2.1 as done in `docs/roadmap.md`.
 - [x] Run full quality gates. Fix any issues.
 - [x] Update ExecPlan to COMPLETE.
 
@@ -198,7 +198,7 @@ The change is accepted when:
   diagnostics).
 - `make markdownlint`, `make nixie` pass.
 - `docs/usage-guide.md` contains a "Replay sessions" section with examples.
-- `docs/cmd-mox-roadmap.md` item 12.2.1 is marked `[x]`.
+- `docs/roadmap.md` item 12.2.1 is marked `[x]`.
 - `docs/python-native-command-mocking-design.md` contains new design
   decisions.
 - Fixture loading correctly handles v1.0 and migrated older versions.

--- a/docs/execplans/12-2-2-invocation-matcher-with-strict-matching.md
+++ b/docs/execplans/12-2-2-invocation-matcher-with-strict-matching.md
@@ -37,7 +37,7 @@ Observable success after implementation:
    changes which recording is consumed.
 6. `docs/python-native-command-mocking-design.md` records the final scoring and
    tie-break decisions, `docs/usage-guide.md` explains the replay-selection
-   semantics for consumers, and `docs/cmd-mox-roadmap.md` marks `12.2.2` done.
+   semantics for consumers, and `docs/roadmap.md` marks `12.2.2` done.
 7. The full quality gates pass:
 
 ```bash
@@ -157,7 +157,7 @@ make test 2>&1 | tee /tmp/12-2-2-test.log
   extraction and scoring decisions.
 - [x] Update `docs/usage-guide.md` to explain replay best-fit semantics for
   consumers.
-- [x] Mark roadmap item `12.2.2` done in `docs/cmd-mox-roadmap.md`.
+- [x] Mark roadmap item `12.2.2` done in `docs/roadmap.md`.
 - [x] Run all quality gates and attach the resulting evidence to this document
   if the plan later moves into execution.
 
@@ -281,7 +281,7 @@ replay behaviour and the documentation that must change:
   design-decision log.
 - `docs/usage-guide.md`: replay-session consumer documentation that still
   describes first-match selection.
-- `docs/cmd-mox-roadmap.md`: checkbox for `12.2.2`.
+- `docs/roadmap.md`: checkbox for `12.2.2`.
 
 The current `ReplaySession.match()` implementation is small: it loads the
 fixture, chooses either `_matches_strict` or `_matches_fuzzy`, iterates the
@@ -433,7 +433,7 @@ The wording must explain:
 
 Only after code, tests, and docs are complete:
 
-1. Mark `12.2.2` as done in `docs/cmd-mox-roadmap.md`.
+1. Mark `12.2.2` as done in `docs/roadmap.md`.
 2. Run the full repository gates with `tee` and `set -o pipefail` exactly as
    required by `AGENTS.md`.
 3. Review the captured logs rather than trusting truncated terminal output.
@@ -457,7 +457,7 @@ The implementation is complete only when all of the following are true:
    decisions and matches the shipped behaviour.
 6. `docs/usage-guide.md` accurately describes replay selection semantics for
    consumers.
-7. `docs/cmd-mox-roadmap.md` marks `12.2.2` as complete.
+7. `docs/roadmap.md` marks `12.2.2` as complete.
 8. The following commands all succeed, with logs captured for review:
 
 ```bash

--- a/docs/execplans/12-2-3-add-replay-to-command-double.md
+++ b/docs/execplans/12-2-3-add-replay-to-command-double.md
@@ -40,7 +40,7 @@ Observable success after implementation:
    fluent API contract for replay-enabled doubles.
 6. `docs/python-native-command-mocking-design.md` records the final API
    decisions, `docs/usage-guide.md` explains the consumer-facing behaviour, and
-   `docs/cmd-mox-roadmap.md` marks `12.2.3` done.
+   `docs/roadmap.md` marks `12.2.3` done.
 7. The full quality gates pass:
 
 ```bash
@@ -336,7 +336,7 @@ Update `docs/usage-guide.md` to describe the consumer-facing behaviour:
 
 ### Stage E: Mark the roadmap item complete
 
-Once the code, tests, and docs are done, update `docs/cmd-mox-roadmap.md` to
+Once the code, tests, and docs are done, update `docs/roadmap.md` to
 change:
 
 ```plaintext
@@ -404,7 +404,7 @@ The feature is complete when all of the following are true:
 8. `docs/python-native-command-mocking-design.md` captures the final design
    decisions.
 9. `docs/usage-guide.md` describes the user-visible replay behaviour.
-10. `docs/cmd-mox-roadmap.md` marks `12.2.3` done.
+10. `docs/roadmap.md` marks `12.2.3` done.
 11. `make markdownlint`, `make nixie`, `make check-fmt`, `make typecheck`,
     `make lint`, and `make test` all pass.
 

--- a/docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md
+++ b/docs/execplans/12-2-4-integrate-replay-into-cmd-mox-make-response.md
@@ -36,7 +36,7 @@ The user-visible behaviour after implementation is:
    replay flow.
 7. `docs/python-native-command-mocking-design.md` records the final controller
    integration decision, `docs/usage-guide.md` explains the new runtime
-   behaviour, and `docs/cmd-mox-roadmap.md` marks `12.2.4` done.
+   behaviour, and `docs/roadmap.md` marks `12.2.4` done.
 8. The full quality gates pass:
 
 ```bash
@@ -373,7 +373,7 @@ In `docs/usage-guide.md`:
 3. Document the fuzzy fallback behaviour explicitly so consumers know replay is
    best-effort in fuzzy mode.
 
-In `docs/cmd-mox-roadmap.md`:
+In `docs/roadmap.md`:
 
 1. Change `12.2.4` from `[ ]` to `[x]` only after the implementation and all
    gates succeed.
@@ -431,7 +431,7 @@ The implementation is complete when all of the following are true:
    consumers.
 7. `docs/python-native-command-mocking-design.md` records the final controller
    integration decision.
-8. `docs/cmd-mox-roadmap.md` marks `12.2.4` done.
+8. `docs/roadmap.md` marks `12.2.4` done.
 9. `make markdownlint`, `make nixie`, `make check-fmt`, `make typecheck`,
    `make lint`, and `make test` all pass.
 

--- a/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
+++ b/docs/execplans/12-2-5-extend-cmd-mox-verify-to-report-unconsumed-recordings.md
@@ -40,7 +40,7 @@ Observable success after implementation:
    verify-time failure.
 7. `docs/python-native-command-mocking-design.md` records the final ordering
    and error-surface decision, `docs/usage-guide.md` explains the new
-   verify-time behaviour for replay fixtures, and `docs/cmd-mox-roadmap.md`
+   verify-time behaviour for replay fixtures, and `docs/roadmap.md`
    marks `12.2.5` done after the feature lands.
 8. The full quality gates pass:
 
@@ -125,7 +125,7 @@ The neighbouring roadmap items matter here:
 The implementer should keep these references open while executing the plan:
 
 - Docs:
-  - `docs/cmd-mox-roadmap.md`
+  - `docs/roadmap.md`
   - `docs/python-native-command-mocking-design.md`, especially Section IX,
     `9.5.2`, and `9.8.3`
   - `docs/usage-guide.md`, especially the replay-session and `.replay()`
@@ -288,7 +288,7 @@ The implementer should keep these references open while executing the plan:
   the unconsumed-path failure. Rationale: the feature needs behavioural
   coverage, but the happy path is already exercised end-to-end.
 
-- Decision: mark `docs/cmd-mox-roadmap.md` item `12.2.5` done after the
+- Decision: mark `docs/roadmap.md` item `12.2.5` done after the
   implementation landed in the working tree and all required quality gates
   passed. Rationale: the roadmap status now reflects completed, verified
   feature work rather than the earlier planning draft.
@@ -404,7 +404,7 @@ Update the documentation immediately after the code and tests settle:
   - explain that `CmdMox.verify()` now enforces full fixture consumption for
     replay-backed spies and point readers to `allow_unmatched=True` in the
     direct `ReplaySession` section when tolerant verification is desired.
-- `docs/cmd-mox-roadmap.md`
+- `docs/roadmap.md`
   - mark `12.2.5` checked to reflect the completed implementation and passing
     quality gates.
 
@@ -474,7 +474,7 @@ The shipped test coverage proves both behaviour and cleanup:
 
 Documentation was updated in `docs/usage-guide.md` and
 `docs/python-native-command-mocking-design.md`, and roadmap item `12.2.5` is
-now marked complete in `docs/cmd-mox-roadmap.md`.
+now marked complete in `docs/roadmap.md`.
 
 Final gate results:
 

--- a/docs/execplans/8-1-3-comparison-migration-guide-for-shellmock-users.md
+++ b/docs/execplans/8-1-3-comparison-migration-guide-for-shellmock-users.md
@@ -98,7 +98,7 @@ CmdMox documentation lives in `docs/usage-guide.md` (user-facing API guidance)
 and `docs/python-native-command-mocking-design.md` (design rationale and
 feature mappings, including a shellmock-to-CmdMox table). The documentation
 index is `docs/contents.md`. The roadmap entry for this work is under "VIII.
-Documentation, Examples & Usability" in `docs/cmd-mox-roadmap.md`.
+Documentation, Examples & Usability" in `docs/roadmap.md`.
 
 Shellmock is a shell-script-based command mocking tool. CmdMox provides similar
 behaviour with Python shims and a record-replay-verify workflow.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -503,7 +503,8 @@ should graduate from internal utility to documented public API.
     router dispatch, and executable side effects without leaking files between
     tests.
 
-## Legend
+<!-- markdownlint-disable-next-line MD036 -->
+**Legend**
 
 - Each unchecked box represents an implementable, trackable unit suitable for
   project management tools.


### PR DESCRIPTION
## Summary

This branch aligns the cmd-mox roadmap with the mapsplice roadmap grammar. It renames `docs/cmd-mox-roadmap.md` to [docs/roadmap.md](https://github.com/leynos/cmd-mox/blob/docs/roadmap-syntax/docs/roadmap.md) so the roadmap lives at the conventional path, updates every reference to the old filename across the documentation, and demotes the trailing unnumbered `## Legend` heading to a bold paragraph, which the grammar requires: unnumbered level-2 headings are not permitted after the first numbered phase. No roadmap items were reordered, renumbered, reworded, or re-checked.

## Review walkthrough

- Start with [docs/roadmap.md](https://github.com/leynos/cmd-mox/blob/docs/roadmap-syntax/docs/roadmap.md) to see the rename and the sole content change: `## Legend` becomes `**Legend**` at the foot of the document, preceded by an inline markdownlint disable comment for MD036.
- [docs/contents.md](https://github.com/leynos/cmd-mox/blob/docs/roadmap-syntax/docs/contents.md) and [docs/cmd-mox-fake-capabilities-design.md](https://github.com/leynos/cmd-mox/blob/docs/roadmap-syntax/docs/cmd-mox-fake-capabilities-design.md) update their links to the renamed file.
- The files under [docs/execplans](https://github.com/leynos/cmd-mox/tree/docs/roadmap-syntax/docs/execplans) contain mechanical `cmd-mox-roadmap.md` → `roadmap.md` reference rewrites only.

## Validation

- `mapsplice append docs/roadmap.md <dummy-phase>`: exit 0 (grammar-clean)
- `bunx markdownlint-cli2` on all twelve changed files: 0 errors

## Notes

- The `Legend` section was demoted in place rather than moved into the preamble because its second bullet reads "All MVP checkboxes above this point", which would become misleading at the top of the document. Demotion keeps the wording accurate without rephrasing.
- The unnumbered checkbox bullet inside the legend was left untouched; the checker accepts it as body content once the heading is demoted.
