### PR TITLE
Wire CodeScene coverage upload and ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          # Full history so a future `cs-coverage check` can reach the
+          # pull request's merge base (see the deferred gate note below).
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
@@ -65,43 +69,32 @@ jobs:
         if: matrix.run-windows-smoke == false
         run: make typecheck
 
-      - name: Run tests with coverage
-        if: matrix.run-windows-smoke == false
-        run: |
-          uv pip install slipcover pytest-forked
-          uv run python -m slipcover \
-            --source=./cmd_mox \
-            --omit="*/unittests/*,*/.venv/*" \
-            --branch \
-            --out coverage.xml \
-            -m pytest --forked -v cmd_mox/unittests
-
-      - name: Upload coverage artifact
-        if: matrix.run-windows-smoke == false
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.0.0
+      # Coverage runs on pull requests only. Pushes to main upload their
+      # own coverage (and advance the ratchet baseline) via
+      # coverage-main.yml, so generating it here as well would duplicate
+      # the work and the CodeScene upload for the same commit.
+      - name: Generate coverage
+        if: matrix.run-windows-smoke == false && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          name: coverage
-          path: coverage.xml
-
-      - name: Install CodeScene Coverage CLI
-        if: matrix.run-windows-smoke == false && env.CS_ACCESS_TOKEN != ''
-        run: |
-          curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
-          if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
-          fi
-
-      - name: Upload coverage to CodeScene
-        if: matrix.run-windows-smoke == false && env.CS_ACCESS_TOKEN != ''
-        run: |
-          if [ ! -f coverage.xml ]; then
-            echo "coverage.xml not found!"
-            exit 1
-          fi
-          cs-coverage upload \
-            --format "cobertura" \
-            --metric "line-coverage" \
-            coverage.xml
+          output-path: coverage.xml
+          format: cobertura
+          # The suite currently runs serially (the previous slipcover step
+          # used pytest-forked without xdist); keep it serial to stay
+          # behaviour-preserving. Follow-up 4 removes this pin to adopt
+          # pytest-xdist once the suite is confirmed xdist-clean.
+          pytest-workers: ''
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 69277 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint and chutoro's projects hit the byte-identical
+      # error). Add the check step in a fast-follow PR once
+      # coverage-main.yml has uploaded to main at least once and the gate
+      # is confirmed to resolve, or once CodeScene confirms the project's
+      # coverage gate is enabled.
 
       - name: Run Windows smoke tests
         if: matrix.run-windows-smoke

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,52 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# coverage generation (and, in a future fast-follow, the changed-line
+# `cs-coverage check` gate) in ci.yml instead. This workflow also
+# advances the coverage ratchet baseline: caches saved on main are
+# readable by every pull-request run, so the baseline written here is
+# the one PR ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: coverage.xml
+          format: cobertura
+          # Keep the run serial to match the pull-request coverage job;
+          # see the note in ci.yml.
+          pytest-workers: ''
+          with-ratchet: 'true'
+
+      - name: Upload coverage data to CodeScene
+        if: env.CS_ACCESS_TOKEN
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          path: coverage.xml
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1b2711ce239338df192ed58809be6a145736b878
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # Flat layout: mutable source lives under cmd_mox/, not src/.
       paths: "cmd_mox/"

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.skipif(
 #: The commit SHA of leynos/shared-actions carrying the validated
 #: mutation-mutmut reusable workflow. Bump the caller and this test
 #: together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

Onboards cmd-mox to the estate CodeScene coverage flow, the first
Python repository in the rollout.

- Replaces the bespoke slipcover coverage and `cs-coverage upload`
  steps in [`ci.yml`](https://github.com/leynos/cmd-mox/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  with the shared
  [`generate-coverage`](https://github.com/leynos/shared-actions/tree/927edd45ae77be4251a8a18ca9eb5613a2e32cbd/.github/actions/generate-coverage)
  action on the Linux QA leg. Coverage now runs on pull requests only —
  pushes to `main` are handled by the new main workflow, so generating
  it in both places would upload duplicate coverage for the same commit.
- Checks out with `fetch-depth: 0` so a future changed-line gate can
  reach the pull request's merge base.
- Adds [`coverage-main.yml`](https://github.com/leynos/cmd-mox/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml):
  on push to `main` it regenerates coverage and uploads it to CodeScene
  (the only branch CodeScene accepts uploads for), and advances the
  ratchet baseline that pull-request runs compare against.
- Enables the coverage ratchet (`with-ratchet: 'true'`) on both the
  pull-request job and the main job.
- Bumps every `leynos/shared-actions` reference to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` as a single repo-wide pin —
  the coverage actions require it — including the mutation-testing and
  dependabot-automerge callers, and updates the workflow-contract test.

The `CodeScene Code Coverage` check is **not** a required check and does
not appear in the branch ruleset (which requires only `Linux QA` and
`Windows smoke`). CodeScene posts it on every pull-request head and it
influences the status rollup, which is what the Dependabot automerge
gate reads. Wiring the upload lets that check resolve instead of hanging.

### Deferred gate

The `mode: check` changed-line gate is deliberately **not** wired in
yet. CodeScene project 69277 has no coverage-gates configuration, so
`cs-coverage check` would fail every run with "the received
project-config isn't valid. Lacks the gates configuration." — a
CodeScene-side per-project setting, not a CI defect (ddlint and chutoro
hit the byte-identical error). It joins a fast-follow PR once the gate
is enabled and `coverage-main.yml` has uploaded from `main` at least
once.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/cmd-mox/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  — `fetch-depth: 0`; bespoke slipcover/upload steps replaced by
  `generate-coverage` (cobertura, `pytest-workers: ''`, ratchet on),
  pull-request-only; deferred-gate note in place of the check step.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/cmd-mox/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  — new push-to-main upload + ratchet baseline writer.
- [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/cmd-mox/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml)
  and [`.github/workflows/dependabot-automerge.yml`](https://github.com/leynos/cmd-mox/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml)
  — pin bumped to the single repo-wide SHA.
- [`tests/test_workflow_contract.py`](https://github.com/leynos/cmd-mox/blob/codescene-coverage-gate/tests/test_workflow_contract.py)
  — `PINNED_SHA` updated to match the mutation caller.

### Behaviour-preserving choices

- **Serial run.** The previous slipcover step used `pytest-forked`
  without xdist, i.e. serial. `pytest-workers: ''` keeps it serial.
  Follow-up 4 removes this pin to adopt pytest-xdist once the suite is
  confirmed xdist-clean (`make test` already runs `-n auto`, so this
  should be a small follow-up).
- **Cobertura.** The pipeline was already cobertura throughout
  (`coverage.xml`, `--format cobertura`); kept rather than switching to
  lcov.

## Validation

- `python3 -c "import yaml; ..."` parses all workflow files.
- `pytest tests/test_workflow_contract.py` — 6 passed.
- Repository CI (`Linux QA`, `Windows smoke`) on this PR head.
