### PR TITLE
Stop pinning the mutation-testing caller SHA in contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -143,3 +143,38 @@ When changing lint policy:
 
 Changes that add broad new rule families should explain whether failures are
 fixed immediately or recorded as a visible baseline.
+
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the _shape_ of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -3,14 +3,17 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; cmd-mox's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the pin
-at a branch, widening permissions, or losing the mutmut configuration)
-fails CI on the pull request rather than surfacing in a scheduled or
-manual run.
+PyYAML and assert the contract it must uphold: it must reference the
+correct reusable workflow, pinned to a commit SHA (not a mutable branch
+or tag), with the expected permissions and mutmut configuration.
+Dependabot owns the pinned SHA value, so drift in the workflow PATH,
+widened permissions, or a lost mutmut configuration fails CI on the
+pull request, while a routine Dependabot SHA bump does not.
 """
 
 from __future__ import annotations
 
+import re
 import typing as typ
 from pathlib import Path
 
@@ -32,13 +35,11 @@ pytestmark = pytest.mark.skipif(
     ),
 )
 
-#: The commit SHA of leynos/shared-actions carrying the validated
-#: mutation-mutmut reusable workflow. Bump the caller and this test
-#: together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA
+#: The caller must reference this reusable workflow path, pinned to a
+#: 40-hex commit SHA. Dependabot owns the SHA value; this test only
+#: checks its shape.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$"
 )
 
 #: The caller inputs this repository relies on; anything else must use
@@ -76,26 +77,14 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return typ.cast("dict[str, object]", jobs_map["mutation"])
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-mutmut.yml pinned to a 40-hex commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
     assert isinstance(uses, str), f"jobs.mutation.uses must be a string, got {uses!r}"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-mutmut.yml", (
-        f"jobs.mutation.uses must reference mutation-mutmut.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the workflow and this test together"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-mutmut.yml pinned to a "
+        f"40-hex commit SHA (not a branch or tag), got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Replace the exact-SHA assertion in the mutation-testing workflow contract
  test with a shape assertion: the caller must reference
  `mutation-mutmut.yml` on the correct path, pinned to a 40-hex commit SHA
  (not a mutable branch or tag), but the specific SHA value is no longer
  checked.
- Document the workflow-pins-and-Dependabot policy in
  `docs/developers-guide.md`.

## Review walkthrough

- `tests/test_workflow_contract.py`: dropped `PINNED_SHA` and
  `EXPECTED_USES`; replaced `test_uses_reference_is_pinned_to_the_documented_sha`
  with `test_uses_reference_is_pinned_to_a_commit_sha`, which matches
  `uses:` against a regex requiring the correct reusable-workflow path and a
  40-hex commit SHA suffix. Updated the module docstring accordingly. All
  other assertions (permissions, triggers, concurrency, `with:` inputs, and
  the mutmut sandbox `skipif` guard) are unchanged.
- `docs/developers-guide.md`: added a "Workflow pins and Dependabot"
  section using the estate's canonical wording, explaining why contract
  tests must assert shape rather than an exact SHA.
- `.github/dependabot.yml` already has a `github-actions` ecosystem entry
  with `directory: "/"`, so no change was needed there.
- No workflow file pins were touched; Dependabot continues to own the SHA
  in `.github/workflows/mutation-testing.yml`.

## Validation

- `uv run pytest tests/test_workflow_contract.py -v` — all six tests pass
  against the current pinned SHA.
- `uv run ruff check` / `uv run ruff format --check` on the changed test
  file — clean.
- `markdownlint-cli2 docs/developers-guide.md` — clean.
- Reasoned check: the new regex
  `^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$`
  matches any 40-character lowercase-hex SHA on the correct path, so a
  future Dependabot bump to a different SHA will still satisfy the test.
