### PR TITLE
Correct artifact spelling to artefact in docs

### DIFF
--- a/docs/execplans/12-1-1-recording-session-class.md
+++ b/docs/execplans/12-1-1-recording-session-class.md
@@ -332,7 +332,7 @@ If a quality gate fails:
 - Re-run the failing gate.
 - Then re-run all gates before marking complete.
 
-## Artifacts and Notes
+## Artefacts and Notes
 
 ### New files created
 

--- a/docs/execplans/12-1-2-fixture-file.md
+++ b/docs/execplans/12-1-2-fixture-file.md
@@ -420,7 +420,7 @@ no-op for v1.0 data, so existing save/load roundtrips are unchanged.
 If a step fails partway, rerunning `make test` after fixing the issue is safe.
 No state machines or filesystem mutations beyond JSON file I/O are involved.
 
-## Artifacts and notes
+## Artefacts and notes
 
 ### Files to create
 

--- a/docs/execplans/12-1-3-add-record-method-to-command-double.md
+++ b/docs/execplans/12-1-3-add-record-method-to-command-double.md
@@ -369,7 +369,7 @@ deleted.
 If a quality gate fails: fix only the reported issue, re-run the failing gate,
 then re-run all gates before marking complete.
 
-## Artifacts and Notes
+## Artefacts and Notes
 
 ### New files created
 

--- a/docs/execplans/8-1-3-comparison-migration-guide-for-shellmock-users.md
+++ b/docs/execplans/8-1-3-comparison-migration-guide-for-shellmock-users.md
@@ -177,7 +177,7 @@ The documentation edits are safe to re-run. If linting fails, fix the reported
 Markdown issues and re-run the commands. If the guide content needs adjustment,
 edit the single guide file and re-run linting.
 
-## Artifacts and Notes
+## Artefacts and Notes
 
 Expected linting transcripts (examples only):
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -433,7 +433,7 @@ sequenceDiagram
   raises a detailed `VerificationError`. The error messages will be designed
   for maximum debuggability, providing a clear "diff" between the expected and
   actual interactions, similar to the highly-regarded error reporting of PyMox.
-  Finally, it orchestrates the cleanup of all test artifacts, including
+  Finally, it orchestrates the cleanup of all test artefacts, including
   restoring the `PATH`.
 
 ## III. Architectural Blueprint: Inside `CmdMox`
@@ -463,18 +463,18 @@ steps:
 1. Create a temporary directory with a unique, process-safe name (e.g.,
    `/tmp/cmdmox-pytest-worker-1-pid-12345`).
 
-2. Resolve the active launcher artifact (`shim.py` or `cmdmox-mock[.exe]`) from
+2. Resolve the active launcher artefact (`shim.py` or `cmdmox-mock[.exe]`) from
    the selected backend.
 
 3. For each unique command name being mocked (e.g., `git`, `curl`), create a
    lightweight filesystem entry in the temporary directory that points to the
-   launcher artifact.
+   launcher artefact.
    - POSIX: symlink `git -> <launcher>`.
    - Windows Python backend: generate `git.cmd` wrapper targeting `shim.py`.
    - Windows Rust backend: create `git.exe` hardlink/copy to
      `cmdmox-mock.exe`.
 
-4. Ensure the launcher artifact is executable.
+4. Ensure the launcher artefact is executable.
 
 5. The launcher determines which command it impersonates from its invocation
    name (`argv[0]`).
@@ -811,7 +811,7 @@ approach avoids disrupting other threads that might rely on the environment
 remaining mostly stable.
 
 This rigorous management ensures that each test runs in a perfectly isolated
-environment and leaves no artifacts behind, a critical requirement for a
+environment and leaves no artefacts behind, a critical requirement for a
 reliable testing framework.
 
 `CmdMox` enforces this guarantee even when replay aborts unexpectedly. The

--- a/docs/wsl-testing.md
+++ b/docs/wsl-testing.md
@@ -22,5 +22,5 @@ make typecheck
 make test
 ```
 
-This keeps `uv` caches on the same filesystem as the build artifacts and avoids
+This keeps `uv` caches on the same filesystem as the build artefacts and avoids
 cross-device linking issues under WSL.


### PR DESCRIPTION
## Summary

Correct pre-existing `artifact` → `artefact` spelling in documentation
prose so the repository's own en-GB-oxendict typos gate passes.

## Review walkthrough

The shared en-GB-oxendict dictionary (fetched by
`scripts/generate_typos_config.py` at gate time) no longer whitelists
`artifact`/`artifacts`, so `make spelling` on `main` fails on
occurrences it previously tolerated. This corrects the flagged prose:

- `docs/wsl-testing.md` — "build artefacts".
- `docs/python-native-command-mocking-design.md` — five occurrences
  (launcher artefact, test artefacts).
- `docs/execplans/12-1-1`, `12-1-2`, `12-1-3`, and `8-1-3` — the
  "Artefacts and Notes" section headings.

No code, tests, or workflow files are touched. The generated `typos.toml`
is intentionally left untracked-modified locally; CI regenerates it, so
only the prose corrections are committed.

## Validation

- `make spelling` — exit 0 (was failing on `main`).
- `markdownlint-cli2` on the six changed files — clean.
