### PR TITLE
Enable the CodeScene mode: check coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Full history so a future `cs-coverage check` can reach the
-          # pull request's merge base (see the deferred gate note below).
+          # Full history so `cs-coverage check` can reach the pull
+          # request's merge base.
           fetch-depth: 0
 
       - name: Set up Python
@@ -85,16 +85,18 @@ jobs:
           # pytest-xdist once the suite is confirmed xdist-clean.
           pytest-workers: ''
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 69277 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint and chutoro's projects hit the byte-identical
-      # error). Add the check step in a fast-follow PR once
-      # coverage-main.yml has uploaded to main at least once and the gate
-      # is confirmed to resolve, or once CodeScene confirms the project's
-      # coverage gate is enabled.
+
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: matrix.run-windows-smoke == false && env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/69277
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 
       - name: Run Windows smoke tests
         if: matrix.run-windows-smoke


### PR DESCRIPTION
## Summary

- CodeScene project 69277's coverage-gates configuration has been
  enabled on the CodeScene side, so the `cs-coverage check` step —
  previously deferred with a comment because it errored with "Lacks
  the gates configuration" — can now be wired in for real.
- Replace the deferred-gate comment in
  [`.github/workflows/ci.yml`](../blob/codescene-mode-check/.github/workflows/ci.yml)
  with the guarded `mode: check` step, using the same shared-actions
  pin (`927edd4`) as the existing `generate-coverage` step, `format:
  cobertura`, and `project-url:
  https://api.codescene.io/v2/projects/69277`.
- The step runs only on the Linux QA leg (`matrix.run-windows-smoke ==
  false`, where coverage is generated), only for pull requests, and
  only when `CS_ACCESS_TOKEN` is set — matching the estate's guard
  convention so forks and secret-less runs skip rather than fail.

## Review walkthrough

The change is confined to `.github/workflows/ci.yml`: the deferred
comment block is removed and replaced by a `Check coverage against
CodeScene gates` step placed after `Generate coverage` and before the
Windows smoke step. `coverage-main.yml` is untouched — it continues to
use `mode: upload` on pushes to `main`.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- `uv run pytest tests/test_workflow_contract.py -q` (6 passed — the
  contract test does not assert on this step's shape)
- CI on this PR's own head: confirm the `Check coverage against
  CodeScene gates` step on the Linux QA leg executes (not skipped) and
  succeeds, and that the `CodeScene Code Coverage` check completes.
