### PR TITLE
Bump shared-actions pins to 18bed1ca

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       # the work and the CodeScene upload for the same commit.
       - name: Generate coverage
         if: matrix.run-windows-smoke == false && github.event_name == 'pull_request'
-        uses: leynos/shared-actions/.github/actions/generate-coverage@9f788dad94c848e3bbddfb90f9e80b6742b7390c
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: coverage.xml
           format: cobertura
@@ -90,7 +90,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: matrix.run-windows-smoke == false && env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: cobertura
           mode: check

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -33,7 +33,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
 
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@9f788dad94c848e3bbddfb90f9e80b6742b7390c
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: coverage.xml
           format: cobertura
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@8c8e8a38f1f9a783ba7e25ba2c0f9bfda5bf2cb3
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: cobertura
           path: coverage.xml

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@8c8e8a38f1f9a783ba7e25ba2c0f9bfda5bf2cb3
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@9f788dad94c848e3bbddfb90f9e80b6742b7390c
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       # Flat layout: mutable source lives under cmd_mox/, not src/.
       paths: "cmd_mox/"


### PR DESCRIPTION
## Summary

- Bump every `leynos/shared-actions` ref in `.github/workflows/` to `18bed1ca49a6de3d8882bd72635a32ae3f023d57` (shared-actions main HEAD).
- Picks up the coverage-ratchet baseline-advance fix and symmetric ±1pp dead-band (shared-actions#353), plus routine follow-ups (#354, #356 whitaker-installer 0.2.6, #344).

## Review walkthrough

- `ci.yml`, `coverage-main.yml`, `dependabot-automerge.yml`, `mutation-testing.yml`: all `@<sha>` refs moved to the new pin; no other content changed.

## Validation

- `uv run pytest tests/test_workflow_contract.py` — 6 passed locally.
- [ ] CI green on this PR
