### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -178,3 +178,65 @@ def test_uses_pinned_full_sha(caller_step):
 If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
+
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow,
+[`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-mutmut.yml`. The heavy
+lifting — running `mutmut` and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check. The mutation targets and
+test selection themselves are configured in `[tool.mutmut]` in
+`pyproject.toml` (`source_paths`, `pytest_add_cli_args_test_selection`,
+`runner`).
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped run
+that mutates only the source files touched within the detection window, so
+quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run workflow"
+control) mutates the whole package; select a branch in that control to
+exercise a feature branch.
+
+The caller passes two configuration inputs:
+
+- `paths` — set to `cmd_mox/`, the change-detection glob that decides whether
+  a scheduled run has anything to mutate. CmdMox uses a flat layout, so the
+  mutable source lives directly under `cmd_mox/` rather than under `src/`.
+- `module-prefix-strip` — set to an empty string, because the flat layout has
+  no package prefix to strip when mapping mutated files back to import paths.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit.
+
+Because the caller is configuration rather than code, a contract test in
+`tests/test_workflow_contract.py` pins the shape it must uphold, failing the
+pull request when the caller drifts — repointing the pin at a branch,
+widening the token scope, or dropping a configuration input — rather than
+letting the breakage surface only in a scheduled run. The test module
+self-skips when the workflow file is absent (mutmut copies the sources into a
+sandbox that omits `.github/`, so the contract test does not run there). Run
+it locally with:
+
+```bash
+uv run pytest tests/test_workflow_contract.py -v
+```
+
+The test validates:
+
+- the `uses:` reference targets `mutation-mutmut.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly `paths: cmd_mox/` and
+  `module-prefix-strip: ""`, nothing more and nothing less;
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no inputs.


### PR DESCRIPTION
## Summary

Adds a "Mutation-testing workflow contract tests" section to
[`docs/developers-guide.md`](docs/developers-guide.md), documenting the
`.github/workflows/mutation-testing.yml` caller and the contract test that
pins its shape.

- Explains that the caller delegates to
  `leynos/shared-actions/.github/workflows/mutation-mutmut.yml` and only
  carries declarative configuration (the mutation run itself is
  informational, never gating).
- Documents the two `with:` inputs the caller actually sets: `paths:
  cmd_mox/` and `module-prefix-strip: ""` (CmdMox uses a flat package
  layout, not `src/`).
- Describes `tests/test_workflow_contract.py`: a shape-only `USES_RE` pin
  (asserts a 40-hex commit SHA, not a specific value, so Dependabot bumps
  need no test edit) and its `pytestmark = pytest.mark.skipif(...)` guard,
  which self-skips inside mutmut's sandbox where `.github/` is absent.
- Documents the local run command, verified to pass:
  `uv run pytest tests/test_workflow_contract.py -v` (there is no
  `make test-workflow-contracts` target in this repository's `Makefile`).

No existing mutation-testing section was present in the developer guide, so
this lands as a new top-level `##` section, placed after the existing
"Workflow pins and Dependabot" section (which documents the general
shape-only-pin convention this contract test follows).

The developer guide has no table of contents / index list of its own
sections, so no cross-link was added there. `docs/contents.md` links to the
whole developer guide file already and did not need a new entry.

No roadmap or execplan tracking applies to this change; `docs/roadmap.md`
and `docs/execplans/` contain no mutation-testing-related tracked task.

## Docs lint

- `make markdownlint`: 0 errors.
- `make spelling` (via `make markdownlint`): passes; the new section uses
  en-GB Oxford `-ize` spelling (`summarizing`, `serializes`).

## Test plan

- [x] `make markdownlint` passes.
- [x] `uv run pytest tests/test_workflow_contract.py -v` passes locally (6
      tests), confirming the documented command is correct.
