### PR TITLE
Document Python docstring conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,25 @@
   related code (e.g., models + utilities + fixtures) close together.
 - **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers
   related to a domain concept rather than splitting by type.
+- **Document public APIs comprehensively.** Public functions, classes, and
+  methods must have comprehensive NumPy-style docstrings, including clear
+  examples that demonstrate usage and outcome where appropriate.
+- **Keep private helper docstrings concise.** Prefer single-line docstrings for
+  private helpers. When a private helper needs an explanatory paragraph,
+  inspect whether that need exposes conflated responsibilities, an unclear
+  command/query boundary, or another CQRS or cohesion failure:
+  - Split the helper when it performs distinct query and command
+    responsibilities or combines unrelated concerns.
+  - Extract a focused helper when doing so makes the invariant or boundary
+    local and simpler.
+  - Keep the helper intact when its responsibility is cohesive and the
+    explanation documents an unavoidable local constraint; retain the
+    paragraph in that case.
+- **Structure private helper docstrings selectively.** Use structured
+  NumPy-style sections for private helpers only when they describe non-obvious
+  behaviour.
+- **Keep test documentation meaningful.** Test documentation should omit
+  examples that only restate the test logic.
 
 ## Documentation Maintenance
 


### PR DESCRIPTION
## Summary

This change adds the canonical Python docstring conventions to [AGENTS.md](https://github.com/leynos/cmd-mox/blob/656b475fd24a436b4fb373972026390510f4d81f/AGENTS.md), explicitly covering public functions, classes, and methods and the CQRS/cohesion review expected when private-helper documentation grows beyond a concise explanation.

## Validation

- `make markdownlint` — 22 files, zero errors; spelling configuration current
- `make nixie` — all diagrams validated successfully
- `git diff --check origin/main...HEAD`
- Cumulative branch diff is only `AGENTS.md`
- Worktree clean; remote branch matches `656b475fd24a436b4fb373972026390510f4d81f`

## References

- https://lody.ai/leynos/sessions/43ef9705-4b33-4cfe-8799-0485a81cf5eb